### PR TITLE
Hooked FE up to the API, with endpoint dummy responses

### DIFF
--- a/client/src/components/employee-form/index.js
+++ b/client/src/components/employee-form/index.js
@@ -31,7 +31,7 @@ export const Form = ({ initialValues, isDisabled }) => {
   const handleSubmit = async (values) => {
     setSubmitLoading(true);
 
-    const response = await fetch('/api/v1/form', {
+    const response = await fetch('/api/v1/employee-form', {
       method: 'POST',
       headers: { 'Accept': 'application/json', 'Content-type': 'application/json' },
       body: JSON.stringify(values),

--- a/client/src/components/employer-form/index.js
+++ b/client/src/components/employer-form/index.js
@@ -33,27 +33,27 @@ export const Form = ({ initialValues, isDisabled }) => {
   };
 
   const handleSubmit = async (values) => {
-    // setSubmitLoading(true);
+    setSubmitLoading(true);
 
-    // const response = await fetch('/api/v1/form', {
-    //   method: 'POST',
-    //   headers: { 'Accept': 'application/json', 'Content-type': 'application/json' },
-    //   body: JSON.stringify(values),
-    // });
+    const response = await fetch('/api/v1/employer-form', {
+      method: 'POST',
+      headers: { 'Accept': 'application/json', 'Content-type': 'application/json' },
+      body: JSON.stringify(values),
+    });
 
-    // if (response.ok) {
-    //   const { id, error } = await response.json();
-    //   if (error) {
-    //     openToast({ status: ToastStatus.Error, message: error.message || 'Failed to submit this form' });
-    //   } else {
-    history.push(Routes.EmployerConfirmation, { formValues: values });
-    //     return;
-    //   }
-    // } else {
-    //   openToast({ status: ToastStatus.Error, message: response.error || response.statusText || 'Server error' });
-    // }
+    if (response.ok) {
+      const { error } = await response.json();
+      if (error) {
+        openToast({ status: ToastStatus.Error, message: error.message || 'Failed to submit this form' });
+      } else {
+        history.push(Routes.EmployerConfirmation, { formValues: values });
+        return;
+      }
+    } else {
+      openToast({ status: ToastStatus.Error, message: response.error || response.statusText || 'Server error' });
+    }
 
-    // setSubmitLoading(false);
+    setSubmitLoading(false);
   };
 
   const handleSubmitButton = (submitForm) => {

--- a/client/src/pages/public/Login.js
+++ b/client/src/pages/public/Login.js
@@ -18,26 +18,24 @@ export default () => {
   };
 
   const handleSubmit = async (values) => {
-    history.push(Routes.EmployerForm); //Remove once we have an endpoint
+    setSubmitLoading(true);
 
-    //Uncomment once we have an endpoint
+    const response = await fetch('/api/v1/login', {
+      headers: { 'Accept': 'application/json', 'Content-type': 'application/json' },
+      method: 'POST',
+      body: JSON.stringify({ ...values })
+    });
 
-    // setSubmitLoading(true);
-    // const response = await fetch('/api/v1/login', {
-    //   headers: { 'Accept': 'application/json', 'Content-type': 'application/json' },
-    //   method: 'POST',
-    //   body: JSON.stringify({ ...values })
-    // });
-
-    // if (response.ok) {
-    //   const { token } = await response.json();
-    //   window.localStorage.setItem('jwt', token);
-    //   history.push(Routes.EmployerForm);
-    //   return;
-    // } else {
-    //   setSubmitError(response.error || response.statusText || response);
-    // }
-    // setSubmitLoading(false);
+    if (response.ok) {
+      // TODO Uncomment once we have auth implemented
+      // const { token } = await response.json();
+      // window.localStorage.setItem('jwt', token);
+      history.push(Routes.EmployerForm);
+      return;
+    } else {
+      setSubmitError(response.error || response.statusText || response);
+    }
+    setSubmitLoading(false);
   };
 
   return (

--- a/server/scripts/parse-xml.js
+++ b/server/scripts/parse-xml.js
@@ -14,7 +14,7 @@ const endpoints = [
 
 const postHcapSubmission = async (endpoint, data) => {
   const apiUrl = `${endpoint}/api/v1`;
-  const response = await axios.post(`${apiUrl}/form`, data);
+  const response = await axios.post(`${apiUrl}/employee-form`, data);
   return response.data;
 };
 

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,9 @@ const helmet = require('helmet');
 const bodyParser = require('body-parser');
 const path = require('path');
 const { randomBytes } = require('crypto');
-const { validate, EmployeeFormSchema } = require('./validation.js');
+const {
+  validate, LoginSchema, EmployerFormSchema, EmployeeFormSchema,
+} = require('./validation.js');
 const { dbClient, collections } = require('./db');
 const { errorHandler, asyncMiddleware } = require('./error-handler.js');
 
@@ -31,8 +33,31 @@ app.use(helmet({
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, '../client/build')));
 
-// Create new form, not secured
-app.post(`${apiBaseUrl}/form`,
+// Login endpoint
+// TODO not implemented
+app.post(`${apiBaseUrl}/login`,
+  asyncMiddleware(async (req, res) => {
+    await validate(LoginSchema, req.body);
+
+    // TODO implement login, success mocked
+    const result = 'success';
+    return res.json({ result });
+  }));
+
+// Create new employer form
+// TODO needs to be secured if/when login implemented
+// TODO not implemented
+app.post(`${apiBaseUrl}/employer-form`,
+  asyncMiddleware(async (req, res) => {
+    await validate(EmployerFormSchema, req.body); // Validate submitted form against schema
+
+    // TODO implement DB communication, success mocked
+    const result = 'success';
+    return res.json({ result });
+  }));
+
+// Create new employee form, not secured
+app.post(`${apiBaseUrl}/employee-form`,
   asyncMiddleware(async (req, res) => {
     await validate(EmployeeFormSchema, req.body); // Validate submitted form against schema
     const formsCollection = dbClient.db.collection(collections.FORMS);

--- a/server/tests/form.test.js
+++ b/server/tests/form.test.js
@@ -14,7 +14,7 @@ describe('Server V1 Form Endpoints', () => {
     await closeDB();
   });
 
-  const formEndpoint = '/api/v1/form';
+  const formEndpoint = '/api/v1/employee-form';
 
   const form = {
     eligibility: true,


### PR DESCRIPTION
There are a couple of things I didn't update yet, because the FE design isn't even close to final:
- tests
- openAPI spec

Everything should be hooked up FE > BE with validation, although the actual responses are just dummy success messages since the API > DB communication isn't in place yet.