### PR TITLE
Switched default login to present both options, renamed Applicant on FE

### DIFF
--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -3,7 +3,7 @@ export default Object.freeze({
   Login: '/login',
   Keycloak: '/keycloak',
   EmployerForm: '/',
-  EmployeeUpload: '/employee-upload',
+  ApplicantUpload: '/applicant-upload',
   EmployeeForm: '/employee-form',
   EmployeeConfirmation: '/employee-confirmation',
   EmployerConfirmation: '/employer-confirmation',

--- a/client/src/pages/private/Admin.js
+++ b/client/src/pages/private/Admin.js
@@ -51,12 +51,12 @@ export default () => {
               </Typography>
               :
               roles.includes('admin') ?
-                [renderAdminButton(0, Routes.EmployeeUpload, 'Upload Employees')]
+                [renderAdminButton(0, Routes.ApplicantUpload, 'Upload Applicants')]
                 :
                 roles.map((item, index) => {
                   switch (item) {
                     case 'maximus':
-                      return renderAdminButton(index, Routes.EmployeeUpload, 'Upload Employees');
+                      return renderAdminButton(index, Routes.ApplicantUpload, 'Upload Applicants');
                     default:
                       return null
                   }

--- a/client/src/pages/private/ApplicantUpload.js
+++ b/client/src/pages/private/ApplicantUpload.js
@@ -47,7 +47,7 @@ export default () => {
         setErrors(error);
       } else {
         setFile(null);
-        setSuccess('Employees successfully uploaded.');
+        setSuccess('Applicants successfully uploaded.');
       }
       return;
     }
@@ -78,7 +78,7 @@ export default () => {
             filesLimit={1}
             dropzoneClass={classes.dropzone}
             dropzoneParagraphClass={classes.dropzoneText}
-            dropzoneText="Drop your employee sheet here or click"
+            dropzoneText="Drop your applicant sheet here or click the box"
           />
         </Box>
         <Box pl={4} pr={4} pt={2}>

--- a/client/src/pages/public/Login.js
+++ b/client/src/pages/public/Login.js
@@ -17,11 +17,10 @@ export default () => {
     const redirect = state ? state.redirectOnLogin : Routes.Admin;
 
     switch (redirect) {
-      case Routes.EmployeeUpload:
+      case Routes.ApplicantUpload:
         idpHint = 'bceid';
         break;
       default:
-        idpHint = 'idir';
         break;
     }
     store.set('REDIRECT', redirect);

--- a/client/src/routes/index.js
+++ b/client/src/routes/index.js
@@ -8,7 +8,7 @@ import Keycloak from 'keycloak-js';
 import { Routes } from '../constants';
 
 const Admin = lazy(() => import('../pages/private/Admin'));
-const EmployeeUpload = lazy(() => import('../pages/private/EmployeeUpload'));
+const ApplicantUpload = lazy(() => import('../pages/private/ApplicantUpload'));
 const EmployeeForm = lazy(() => import('../pages/public/EmployeeForm'));
 const EmployerForm = lazy(() => import('../pages/public/EmployerForm'));
 const Login = lazy(() => import('../pages/public/Login'));
@@ -87,7 +87,7 @@ export default () => {
             <Route exact path={Routes.EmployeeForm} component={EmployeeForm} />
             <Route exact path={Routes.EmployeeConfirmation} component={EmployeeConfirmation} />
             <Route exact path={Routes.EmployerConfirmation} component={EmployerConfirmation} />
-            <PrivateRoute exact path={Routes.EmployeeUpload} component={EmployeeUpload} />
+            <PrivateRoute exact path={Routes.ApplicantUpload} component={ApplicantUpload} />
             <PrivateRoute exact path={Routes.Admin} component={Admin} />
             <Route exact path={Routes.Keycloak} component={KeycloackRedirect} />
             <Route component={EmployerForm} />


### PR DESCRIPTION
In this PR:
- /login now offers both options, IDIR and BCeID, for login
- FE references have been changed from employee to applicant, including employee-upload to applicant-upload
- Going to /applicant-upload without logging in first will redirect to BCeID login as the default IDP