### PR TITLE
Hcap 187 approve access request

### DIFF
--- a/client/src/components/generic/Dialog.js
+++ b/client/src/components/generic/Dialog.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Box, Typography, Dialog as MuiDialog} from '@material-ui/core';
+
+export const Dialog = ({
+  open,
+  onClose,
+  children,
+  title,
+  initialValues,
+  validationSchema,
+}) => {
+  return (
+    <MuiDialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="simple-modal-title"
+      aria-describedby="simple-modal-description"
+    >
+      <Box pt={4} pb={2} pl={4} pr={4}>
+        <Typography variant="subtitle1">
+          { title }
+        </Typography>
+      </Box>
+      <Box pt={4} pb={4} pl={4} pr={4}>
+        { children }
+      </Box>
+    </MuiDialog>
+  )
+};

--- a/client/src/components/generic/Dialog.js
+++ b/client/src/components/generic/Dialog.js
@@ -6,15 +6,11 @@ export const Dialog = ({
   onClose,
   children,
   title,
-  initialValues,
-  validationSchema,
 }) => {
   return (
     <MuiDialog
       open={open}
       onClose={onClose}
-      aria-labelledby="simple-modal-title"
-      aria-describedby="simple-modal-description"
     >
       <Box pt={4} pb={2} pl={4} pr={4}>
         <Typography variant="subtitle1">

--- a/client/src/components/generic/Table.js
+++ b/client/src/components/generic/Table.js
@@ -73,12 +73,12 @@ export const Table = ({ order, orderBy, onRequestSort, columns, rows, isLoading,
           <TableRow>
             {columns.map((column, index) => (
               <StyledHeaderTableCell key={index}>
-                <TableSortLabel
+                {column.name && <TableSortLabel // Disable sorting if column has no header
                   active={orderBy === column.id}
                   direction={orderBy === column.id ? order : 'asc'}
                   onClick={createSortHandler(column.id)}>
                   {column.name}
-                </TableSortLabel>
+                </TableSortLabel>}
               </StyledHeaderTableCell>
             ))}
           </TableRow>
@@ -92,8 +92,8 @@ export const Table = ({ order, orderBy, onRequestSort, columns, rows, isLoading,
             </StyledTableRow>
           )) : pageRows.map((row, index) => (
             <StyledTableRow hover key={index}>
-              {Object.keys(row).map((key) => (
-                <StyledTableCell key={key}>{row[key]}</StyledTableCell>
+              {columns.map((column) => (
+                <StyledTableCell key={column.id}>{row[column.id] || ''}</StyledTableCell>
               ))}
             </StyledTableRow>
           ))}

--- a/client/src/components/generic/index.js
+++ b/client/src/components/generic/index.js
@@ -8,3 +8,4 @@ export * from './InputFieldError';
 export * from './Toast';
 export * from './PDFButton';
 export * from './CheckPermissions';
+export * from './Dialog';

--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -17,7 +17,7 @@ const siteTypes = [
 ];
 
 const userRoles = [
-  'ministry_of_health',
+  'health_authority',
 ];
 
 const validateUniqueArray = (a) => (

--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -7,7 +7,6 @@ const healthRegions = [
   'Vancouver Coastal',
   'Vancouver Island',
   'Northern',
-  '',
 ];
 
 const siteTypes = [
@@ -15,8 +14,11 @@ const siteTypes = [
   'Assisted living',
   'Both',
   'Other',
-  '',
-]
+];
+
+const userRoles = [
+  'ministry_of_health',
+];
 
 const validateUniqueArray = (a) => (
   Array.isArray(a) && new Set(a).size === a.length
@@ -84,6 +86,11 @@ export const LoginSchema = yup.object().noUnknown().shape({
   password: yup.string().required('Password is required'),
 });
 
+export const ApproveAccessRequestSchema = yup.object().noUnknown().shape({
+  region: yup.string().required('Region is required').oneOf(healthRegions, 'Invalid region'),
+  role: yup.string().required('Role is required').oneOf(userRoles, 'Invalid role'),
+});
+
 export const EmployerFormSchema = yup.object().noUnknown('Unknown field for form').shape({
   // Operator Contact Information
   registeredBusinessName: yup.string().nullable(errorMessage),
@@ -98,14 +105,14 @@ export const EmployerFormSchema = yup.object().noUnknown('Unknown field for form
   // Site contact info
   siteName: yup.string().nullable(errorMessage),
   address: yup.string().nullable(errorMessage),
-  healthAuthority: yup.string().nullable(errorMessage).oneOf(healthRegions, 'Invalid location'),
+  healthAuthority: yup.string().nullable(errorMessage).oneOf([...healthRegions, ''], 'Invalid location'),
   siteContactFirstName: yup.string().nullable(errorMessage),
   siteContactLastName: yup.string().nullable(errorMessage),
   phoneNumber: yup.string().nullable(errorMessage).matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
   emailAddress: yup.string().nullable(errorMessage).matches(/^(.+@.+\..+)?$/, 'Invalid email address'),
 
   // Site type and size info
-  siteType: yup.string().nullable(errorMessage).oneOf(siteTypes, 'Invalid site type'),
+  siteType: yup.string().nullable(errorMessage).oneOf([...siteTypes, ''], 'Invalid site type'),
   otherSite: yup.string().when('siteType', {
     is: 'Other',
     then: yup.string().nullable('Must specify other site type'),

--- a/client/src/pages/private/EOIView.js
+++ b/client/src/pages/private/EOIView.js
@@ -24,7 +24,7 @@ export default () => {
     { id: 'address', name: 'Address' },
     { id: 'healthAuthority', name: 'Health Authority' },
     { id: 'operatorName', name: 'Operator Name' },
-    {}, //Details
+    { id: 'details' },
   ]);
   const [healthAuthorities] = useState([
     'Interior',

--- a/client/src/pages/private/ParticipantView.js
+++ b/client/src/pages/private/ParticipantView.js
@@ -18,11 +18,11 @@ const defaultColumns = [
 
 const sortOrder = [
   'id',
-  'lastName', 
-  'firstName', 
-  'postalCode', 
-  'phoneNumber', 
-  'emailAddress', 
+  'lastName',
+  'firstName',
+  'postalCode',
+  'phoneNumber',
+  'emailAddress',
   'preferredLocation',
   'interested',
   'nonHCAP',

--- a/client/src/pages/private/UserView.js
+++ b/client/src/pages/private/UserView.js
@@ -4,8 +4,11 @@ import { useHistory } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import { Box, Typography } from '@material-ui/core';
 import store from 'store';
-import { Button, Page, Table, CheckPermissions } from '../../components/generic';
-import { Routes } from '../../constants';
+import { useToast } from '../../hooks';
+import { Button, Page, Table, CheckPermissions, Dialog } from '../../components/generic';
+import { ApproveAccessRequestSchema, ToastStatus } from '../../constants';
+import { FastField, Formik, Form as FormikForm } from 'formik';
+import { RenderSelectField } from '../../components/fields';
 
 const columns = [
   { id: 'firstName', name: 'First Name' },
@@ -20,19 +23,36 @@ export default () => {
 
   const [roles, setRoles] = useState([]);
   const [order, setOrder] = useState('asc');
+  const [modalOpen, setModalOpen] = useState(false);
   const [isLoadingData, setLoadingData] = useState(false);
   const [isLoadingUser, setLoadingUser] = useState(false);
   const [isPendingRequests, setIsPendingRequests] = useState(true);
+  const [selectedUserId, setSelectedUserId] = useState(null);
   const [rows, setRows] = useState([]);
 
   const [orderBy, setOrderBy] = useState(columns[4].id);
 
   const history = useHistory();
+  const { openToast } = useToast();
 
   const handleRequestSort = (event, property) => {
     const isAsc = orderBy === property && order === 'asc';
     setOrder(isAsc ? 'desc' : 'asc');
     setOrderBy(property);
+  };
+
+  const handleSubmit = async (values) => {
+    const response = await fetch('/api/v1/approve-user', {
+      headers: { 'Content-type': 'application/json', 'Authorization': `Bearer ${store.get('TOKEN')}` },
+      method: 'POST',
+      body: JSON.stringify({ ...values, userId: selectedUserId }),
+    });
+    if (response.ok) {
+      setModalOpen(false);
+      openToast({ status: ToastStatus.Success, message: 'Access request approved' });
+    } else {
+      openToast({ status: ToastStatus.Error, message: 'Access request approval failed' });
+    }
   };
 
   const sort = (array) => _orderBy(array, [orderBy, 'operatorName'], [order]);
@@ -67,7 +87,10 @@ export default () => {
             [i.id]: row[i.id],
             details: (
               <Button
-                onClick={() => history.push(Routes.Admin)}
+                onClick={() => {
+                  setSelectedUserId(row['id']);
+                  setModalOpen(true);
+                }}
                 variant="outlined"
                 size="small"
                 text="Options"
@@ -88,8 +111,68 @@ export default () => {
     fetchPendingUsers();
   }, [history]);
 
+  const initialValues = {
+    region: '',
+    role: '',
+  };
+
   return (
     <Page>
+      <Dialog
+        title="Approve Access Request"
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+      >
+        <Formik
+          initialValues={initialValues}
+          validationSchema={ApproveAccessRequestSchema}
+          onSubmit={handleSubmit}
+        >
+          {({ submitForm }) => (
+            <FormikForm>
+              <FastField
+                name="region"
+                component={RenderSelectField}
+                label="* Health Region"
+                options={[
+                  { value: 'Interior', label: 'Interior Health' },
+                  { value: 'Fraser', label: 'Fraser Health' },
+                  { value: 'Vancouver Coastal', label: 'Vancouver Coastal Health' },
+                  { value: 'Vancouver Island', label: 'Vancouver Island Health' },
+                  { value: 'Northern', label: 'Northern Health' },
+                ]}
+              />
+              <FastField
+                name="role"
+                component={RenderSelectField}
+                label="* User Role"
+                options={[
+                  { value: 'ministry_of_health', label: 'Ministry of Health' },
+                ]}
+              />
+              <Box mt={3}>
+                <Grid container spacing={2} justify="flex-end">
+                  <Grid item>
+                    <Button
+                      onClick={() => setModalOpen(false)}
+                      color="default"
+                      text="Cancel"
+                    />
+                  </Grid>
+                  <Grid item>
+                    <Button
+                      onClick={submitForm}
+                      variant="contained"
+                      color="primary"
+                      text={'Submit'}
+                    />
+                  </Grid>
+                </Grid>
+              </Box>
+            </FormikForm>
+          )}
+        </Formik>
+      </Dialog>
       <CheckPermissions isLoading={isLoadingUser} roles={roles} permittedRoles={['ministry_of_health']} renderErrorMessage={true}>
         <Grid container alignContent="center" justify="center" alignItems="center" direction="column">
           <Box pt={4} pb={4} pl={2} pr={2}>

--- a/client/src/pages/private/UserView.js
+++ b/client/src/pages/private/UserView.js
@@ -4,7 +4,8 @@ import { useHistory } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import { Box, Typography } from '@material-ui/core';
 import store from 'store';
-import { Page, Table, CheckPermissions } from '../../components/generic';
+import { Button, Page, Table, CheckPermissions } from '../../components/generic';
+import { Routes } from '../../constants';
 
 const columns = [
   { id: 'firstName', name: 'First Name' },
@@ -12,6 +13,7 @@ const columns = [
   { id: 'username', name: 'Username' },
   { id: 'emailAddress', name: 'Email Address' },
   { id: 'createdAt', name: 'Created' },
+  { id: 'details' },
 ];
 
 export default () => {
@@ -36,36 +38,24 @@ export default () => {
   const sort = (array) => _orderBy(array, [orderBy, 'operatorName'], [order]);
 
   useEffect(() => {
-
     const fetchUserInfo = async () => {
       setLoadingUser(true);
       const response = await fetch('/api/v1/user', {
-        headers: {
-          'Authorization': `Bearer ${store.get('TOKEN')}`,
-        },
+        headers: { 'Authorization': `Bearer ${store.get('TOKEN')}` },
         method: 'GET',
       });
 
       if (response.ok) {
         const { roles } = await response.json();
-        setLoadingUser(false);
         setRoles(roles);
       }
+      setLoadingUser(false);
     };
 
-    const prettyTableCell = (v) => {
-      if (typeof v === 'undefined' || v === null) return '';
-      return String(v);
-    }
-
-    const getPendingUsers = async () => {
+    const fetchPendingUsers = async () => {
       setLoadingData(true);
       const response = await fetch('/api/v1/pending-users', {
-        headers: {
-          'Accept': 'application/json',
-          'Content-type': 'application/json',
-          'Authorization': `Bearer ${store.get('TOKEN')}`,
-        },
+        headers: { 'Authorization': `Bearer ${store.get('TOKEN')}` },
         method: 'GET',
       });
 
@@ -74,7 +64,15 @@ export default () => {
         const rows = data.map((row) => {
           return columns.reduce((a, i) => ({
             ...a,
-            [i.id]: prettyTableCell(row[i.id]),
+            [i.id]: row[i.id],
+            details: (
+              <Button
+                onClick={() => history.push(Routes.Admin)}
+                variant="outlined"
+                size="small"
+                text="Options"
+              />
+            ),
           }), {})
         });
         setRows(rows);
@@ -83,15 +81,11 @@ export default () => {
         setRows([]);
         setIsPendingRequests(false);
       }
-
       setLoadingData(false);
     };
 
-    const init = async () => {
-      await fetchUserInfo();
-      await getPendingUsers();
-    };
-    init();
+    fetchUserInfo();
+    fetchPendingUsers();
   }, [history]);
 
   return (

--- a/client/src/pages/private/UserView.js
+++ b/client/src/pages/private/UserView.js
@@ -147,7 +147,7 @@ export default () => {
                 component={RenderSelectField}
                 label="* User Role"
                 options={[
-                  { value: 'ministry_of_health', label: 'Ministry of Health' },
+                  { value: 'health_authority', label: 'Health Authority' },
                 ]}
               />
               <Box mt={3}>

--- a/client/src/pages/private/UserView.js
+++ b/client/src/pages/private/UserView.js
@@ -49,10 +49,46 @@ export default () => {
     });
     if (response.ok) {
       setModalOpen(false);
+      fetchPendingUsers();
       openToast({ status: ToastStatus.Success, message: 'Access request approved' });
     } else {
       openToast({ status: ToastStatus.Error, message: 'Access request approval failed' });
     }
+  };
+
+  const fetchPendingUsers = async () => {
+    setLoadingData(true);
+    const response = await fetch('/api/v1/pending-users', {
+      headers: { 'Authorization': `Bearer ${store.get('TOKEN')}` },
+      method: 'GET',
+    });
+
+    if (response.ok) {
+      const { data } = await response.json();
+      const rows = data.map((row) => {
+        return columns.reduce((a, i) => ({
+          ...a,
+          [i.id]: row[i.id],
+          details: (
+            <Button
+              onClick={() => {
+                setSelectedUserId(row['id']);
+                setModalOpen(true);
+              }}
+              variant="outlined"
+              size="small"
+              text="Options"
+            />
+          ),
+        }), {})
+      });
+      setRows(rows);
+      setIsPendingRequests(rows.length > 0);
+    } else {
+      setRows([]);
+      setIsPendingRequests(false);
+    }
+    setLoadingData(false);
   };
 
   const sort = (array) => _orderBy(array, [orderBy, 'operatorName'], [order]);
@@ -70,41 +106,6 @@ export default () => {
         setRoles(roles);
       }
       setLoadingUser(false);
-    };
-
-    const fetchPendingUsers = async () => {
-      setLoadingData(true);
-      const response = await fetch('/api/v1/pending-users', {
-        headers: { 'Authorization': `Bearer ${store.get('TOKEN')}` },
-        method: 'GET',
-      });
-
-      if (response.ok) {
-        const { data } = await response.json();
-        const rows = data.map((row) => {
-          return columns.reduce((a, i) => ({
-            ...a,
-            [i.id]: row[i.id],
-            details: (
-              <Button
-                onClick={() => {
-                  setSelectedUserId(row['id']);
-                  setModalOpen(true);
-                }}
-                variant="outlined"
-                size="small"
-                text="Options"
-              />
-            ),
-          }), {})
-        });
-        setRows(rows);
-        setIsPendingRequests(rows.length > 0);
-      } else {
-        setRows([]);
-        setIsPendingRequests(false);
-      }
-      setLoadingData(false);
     };
 
     fetchUserInfo();

--- a/server/keycloak.js
+++ b/server/keycloak.js
@@ -127,14 +127,17 @@ class Keycloak { // Wrapper class around keycloak-connect
     };
     await this.authenticateIfNeeded();
     const config = { headers: { Authorization: `Bearer ${this.access_token}` } };
+    const url = `${this.authUrl}/admin/realms/${this.realm}/users/${userId}/role-mappings/clients/${this.clientIdMap[this.clientNameBackend]}`;
     {
-      const url = `${this.authUrl}/admin/realms/${this.realm}/users/${userId}/role-mappings/clients/${this.clientIdMap[this.clientNameBackend]}`;
       const data = [
         ...regions.map(regionToRole).filter((x) => x),
         { name: role, id: this.roleIdMap[role] },
       ];
-      const response = await axios.post(url, data, config);
-      console.log(response);
+      await axios.post(url, data, config);
+    }
+    {
+      const data = [{ name: 'pending', id: this.roleIdMap.pending }];
+      await axios.delete(url, { ...config, data });
     }
   }
 

--- a/server/keycloak.js
+++ b/server/keycloak.js
@@ -122,7 +122,7 @@ class Keycloak { // Wrapper class around keycloak-connect
     if (!Object.keys(this.roleIdMap).includes(role)) throw Error(`Invalid role: ${role}`);
     const regionToRole = (region) => {
       const roleName = Object.keys(regionMap).find((k) => regionMap[k] === region);
-      if (!roleName) return null;
+      if (!roleName || !this.roleIdMap[roleName]) return null;
       return { name: roleName, id: this.roleIdMap[roleName] };
     };
     await this.authenticateIfNeeded();

--- a/server/main.js
+++ b/server/main.js
@@ -37,7 +37,7 @@ process.on('SIGTERM', () => {
 (async () => {
   try {
     await dbClient.connect();
-    await keycloak.getClientIdentifier();
+    await keycloak.buildInternalIdMap();
     const results = await dbClient.runMigration();
     results.forEach((result) => {
       logger.info(`Migration success: ${result.name}`);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "0.20.0",
+        "axios": "^0.21.0",
         "body-parser": "1.19.0",
         "dayjs": "1.9.3",
         "dotenv": "8.2.0",
@@ -1669,9 +1669,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
       "dependencies": {
         "follow-redirects": "^1.10.0"
       }
@@ -12052,9 +12052,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
       "requires": {
         "follow-redirects": "^1.10.0"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "test": "NODE_ENV=test jest --runInBand --forceExit"
   },
   "dependencies": {
-    "axios": "0.20.0",
+    "axios": "0.21.0",
     "body-parser": "1.19.0",
     "dayjs": "1.9.3",
     "dotenv": "8.2.0",

--- a/server/server.js
+++ b/server/server.js
@@ -106,6 +106,7 @@ app.get(`${apiBaseUrl}/pending-users`,
   asyncMiddleware(async (req, res) => {
     const users = await keycloak.getPendingUsers();
     const scrubbed = users.map((user) => ({
+      id: user.id,
       emailAddress: user.email,
       username: user.username,
       firstName: user.firstName,

--- a/server/server.js
+++ b/server/server.js
@@ -120,7 +120,7 @@ app.post(`${apiBaseUrl}/approve-user`,
   keycloak.allowRolesMiddleware('ministry_of_health'),
   asyncMiddleware(async (req, res) => {
     await validate(AccessRequestApproval, req.body);
-    await keycloak.approvePendingRequest(req.body.userId, req.body.role, req.body.regions);
+    await keycloak.approvePendingRequest(req.body.userId, req.body.role, [req.body.region]);
     res.json({});
   }));
 

--- a/server/validation.js
+++ b/server/validation.js
@@ -94,11 +94,6 @@ const errorMessage = ({ path }) => {
     eligibility: 'We\'re sorry, but current eligibility to work in Canada is a requirement to submit this form.',
     preferredLocation: 'Please select at least one location you\'d like to work in.',
     consent: 'We\'re sorry, but we cannot process your request without permission.',
-
-    // Access request approval
-    userId: 'User ID is required',
-    role: 'User role is required',
-    regions: 'User health regions are required',
   };
   return errorMessages[path] || `Failed validation on ${path}`;
 };

--- a/server/validation.js
+++ b/server/validation.js
@@ -27,6 +27,10 @@ const siteTypes = [
   '',
 ];
 
+const userRoles = [
+  'ministry_of_health',
+];
+
 const isBooleanValue = (val) => typeof val === 'string' && ['yes', 'no'].includes(val.toLowerCase());
 
 const evaluateBooleanAnswer = (val) => (isBooleanValue(val) && val.toLowerCase() === 'yes');
@@ -184,11 +188,9 @@ const ParticipantBatchSchema = yup.array().of(
 );
 
 const AccessRequestApproval = yup.object().noUnknown('Unknown field in form').shape({
-  userId: yup.string().required(errorMessage),
-  regions: yup.array().required(errorMessage).of(
-    yup.string().nullable(errorMessage).oneOf(healthRegions, 'Invalid location'),
-  ),
-  role: yup.string().required(errorMessage),
+  userId: yup.string().required('User ID is required'),
+  region: yup.string().required('Region is required').oneOf(healthRegions, 'Invalid region'),
+  role: yup.string().required('Role is required').oneOf(userRoles, 'Invalid role'),
 });
 
 const validate = async (schema, data) => schema.validate(data, { strict: true });

--- a/server/validation.js
+++ b/server/validation.js
@@ -28,7 +28,7 @@ const siteTypes = [
 ];
 
 const userRoles = [
-  'ministry_of_health',
+  'health_authority',
 ];
 
 const isBooleanValue = (val) => typeof val === 'string' && ['yes', 'no'].includes(val.toLowerCase());

--- a/server/validation.js
+++ b/server/validation.js
@@ -7,7 +7,6 @@ const healthRegions = [
   'Vancouver Coastal',
   'Vancouver Island',
   'Northern',
-  '',
 ];
 
 const roles = [
@@ -91,6 +90,11 @@ const errorMessage = ({ path }) => {
     eligibility: 'We\'re sorry, but current eligibility to work in Canada is a requirement to submit this form.',
     preferredLocation: 'Please select at least one location you\'d like to work in.',
     consent: 'We\'re sorry, but we cannot process your request without permission.',
+
+    // Access request approval
+    userId: 'User ID is required',
+    role: 'User role is required',
+    regions: 'User health regions are required',
   };
   return errorMessages[path] || `Failed validation on ${path}`;
 };
@@ -111,7 +115,7 @@ const EmployerFormSchema = yup.object().noUnknown('Unknown field in form').shape
   // Site contact info
   siteName: yup.string().nullable(errorMessage),
   address: yup.string().nullable(errorMessage),
-  healthAuthority: yup.string().nullable(errorMessage).oneOf(healthRegions, 'Invalid location'),
+  healthAuthority: yup.string().nullable(errorMessage).oneOf([...healthRegions, ''], 'Invalid location'),
   siteContactFirstName: yup.string().nullable(errorMessage),
   siteContactLastName: yup.string().nullable(errorMessage),
   phoneNumber: yup.string().matches(/(^[0-9]{10})?$/, 'Phone number must be provided as 10 digits').nullable(true),
@@ -179,8 +183,16 @@ const ParticipantBatchSchema = yup.array().of(
   }),
 );
 
+const AccessRequestApproval = yup.object().noUnknown('Unknown field in form').shape({
+  userId: yup.string().required(errorMessage),
+  regions: yup.array().required(errorMessage).of(
+    yup.string().nullable(errorMessage).oneOf(healthRegions, 'Invalid location'),
+  ),
+  role: yup.string().required(errorMessage),
+});
+
 const validate = async (schema, data) => schema.validate(data, { strict: true });
 
 module.exports = {
-  EmployerFormSchema, ParticipantBatchSchema, validate, isBooleanValue, evaluateBooleanAnswer,
+  EmployerFormSchema, ParticipantBatchSchema, validate, isBooleanValue, evaluateBooleanAnswer, AccessRequestApproval,
 };


### PR DESCRIPTION
BE route for pending access request approval. Takes user ID (set by Keycloak), region, role (only MoH for now).

Keycloak class takes user ID, array of regions, and a role.

FE has a dialog form that allows choosing a single region and single role for a pending user and approving said user. I'm sure the Dialog component can be improved. Specifically, I think that either the Dialog component or a new component should take some of the responsibility from the UserView component which is getting pretty heavy.

The Table component was updated to improve the way it lays out its cells. Previously, it iterated through the keys of a row item, adding each as a contiguous cell. Now, it iterated through the ID of each header cell and accesses properties of each row item using this key. This allows for row items with an arbitrary order and properties that are not displayed in the table. Additionally, columns can no longer be used to order the table if they do not include a label (see Employers table Details column in previous builds). Finally, Table now handles missing cell values and places `''` (empty string) when cell value is missing.

Validation updated. Now `ParticipantFormSchema.preferredLocation` does not accept `''` (empty string).