### PR TITLE
Hcap 372 last updated bug

### DIFF
--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -766,7 +766,7 @@ export default () => {
                     />
                   }
                   if (columnId === 'userUpdatedAt') {
-                    return fuzzyDateOffset(row.engage.userUpdatedAt);
+                    return fuzzyDateOffset(row.userUpdatedAt);
                   }
                   return row[columnId];
                 }

--- a/client/src/utils/date.js
+++ b/client/src/utils/date.js
@@ -4,6 +4,8 @@ export const dateToString = (dateObj) => moment(dateObj).format('YYYY/MM/DD');
 
 export const stringToDate = (dateStr) => moment(dateStr, 'YYYY/MM/DD');
 
+export const stringToDateTime = (dateStr) => moment(dateStr, 'YYYY/MM/DD hh:mm:ss.SSSZ');
+
 export const getTodayDate = () => {
     const today = new Date();
     const dd = String(today.getDate()).padStart(2, '0');

--- a/client/src/utils/fuzzyDateOffset.js
+++ b/client/src/utils/fuzzyDateOffset.js
@@ -1,13 +1,16 @@
+import { stringToDateTime } from './date';
+
 export const fuzzyDateOffset = (datestring) => {
     if (!datestring) return "Never Updated";
 
     // Some browsers (firefox, safari) cannot parse datestrings of the following form:
     // 2021-02-11 16:02:12.877406+00
-    if (datestring.includes(" ")) {
-        datestring = datestring.replace(' ','T').replace('+00', 'Z')
+    let offsetTime = null;
+    if (datestring.includes(' ')) {
+        offsetTime = stringToDateTime(datestring).format('x');
+    } else {
+        offsetTime = new Date(datestring).getTime();
     }
-
-    const offsetTime = new Date(datestring).getTime();
     const currentTime = new Date().getTime();
     const weekInMilliseconds = 7*24*60*60*1000; 
     const dayInMilliseconds = 24*60*60*1000; 

--- a/client/src/utils/fuzzyDateOffset.js
+++ b/client/src/utils/fuzzyDateOffset.js
@@ -1,7 +1,7 @@
 export const fuzzyDateOffset = (datestring) => {
     if (!datestring) return "Never Updated";
 
-    // Some browsers cannot parse datestrings of the following form:
+    // Some browsers (firefox, safari) cannot parse datestrings of the following form:
     // 2021-02-11 16:02:12.877406+00
     if (datestring.includes(" ")) {
         datestring = datestring.replace(' ','T').replace('+00', 'Z')
@@ -9,8 +9,6 @@ export const fuzzyDateOffset = (datestring) => {
 
     const offsetTime = new Date(datestring).getTime();
     const currentTime = new Date().getTime();
-    console.log("fuzzyDateOffset_Debug");
-    console.log(`offsetTime is ${offsetTime}, built from datestring ${datestring}, currentTime is ${currentTime}`);
     const weekInMilliseconds = 7*24*60*60*1000; 
     const dayInMilliseconds = 24*60*60*1000; 
     const hourInMilliseconds = 60*60*1000; 

--- a/client/src/utils/fuzzyDateOffset.js
+++ b/client/src/utils/fuzzyDateOffset.js
@@ -1,6 +1,8 @@
 export const fuzzyDateOffset = (datestring) => {
     const offsetTime = new Date(datestring).getTime();
     const currentTime = new Date().getTime();
+    console.log("fuzzyDateOffset_Debug");
+    console.log(`offsetTime is ${offsetTime}, built from datestring ${datestring}, currentTime is ${currentTime}`);
     const weekInMilliseconds = 7*24*60*60*1000; 
     const dayInMilliseconds = 24*60*60*1000; 
     const hourInMilliseconds = 60*60*1000; 

--- a/client/src/utils/fuzzyDateOffset.js
+++ b/client/src/utils/fuzzyDateOffset.js
@@ -1,4 +1,12 @@
 export const fuzzyDateOffset = (datestring) => {
+    if (!datestring) return "Never Updated";
+
+    // Some browsers cannot parse datestrings of the following form:
+    // 2021-02-11 16:02:12.877406+00
+    if (datestring.includes(" ")) {
+        datestring = datestring.replace(' ','T').replace('+00', 'Z')
+    }
+
     const offsetTime = new Date(datestring).getTime();
     const currentTime = new Date().getTime();
     console.log("fuzzyDateOffset_Debug");


### PR DESCRIPTION
The issue was the format of datestring that was being passed to the Date() constructor, Chrome was able to interpret properly but other browsers were not.