### PR TITLE
Hostname-based routing, participant form updates

### DIFF
--- a/client/src/components/generic/Header.js
+++ b/client/src/components/generic/Header.js
@@ -70,7 +70,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const Header = () => {
+export const Header = ({hideEmployers=false}) => {
   const history = useHistory();
   const location = useLocation();
   const classes = useStyles();
@@ -83,6 +83,12 @@ export const Header = () => {
   const handleLogoutClick = async () => {
     store.remove('TOKEN');
     await keycloak.logout({ redirectUri: window.location.origin });
+  };
+
+  const title = () => {
+    if (hideEmployers) return 'Participant Expression of Interest';
+    if (location.pathname === Routes.EmployerForm || location.pathname === Routes.EmployerConfirmation) return 'Employer Expression of Interest';
+    return 'Employer Portal';
   };
 
   return (
@@ -112,13 +118,11 @@ export const Header = () => {
                 The Health Career Access Program
               </Typography>
               <Typography noWrap className={classes.title} variant="h1">
-                {location.pathname === Routes.EmployerForm || location.pathname === Routes.EmployerConfirmation
-                  ? 'Employer Expression of Interest'
-                  : 'Employer Portal'}
+                {title()}
               </Typography>
             </div>
           </div>
-          <div className={classes.buttonWrapper}>
+          {!hideEmployers && <div className={classes.buttonWrapper}>
             {(keycloak.authenticated && location.pathname !== Routes.Admin) && (
               <Button
                 className={classes.button}
@@ -148,7 +152,7 @@ export const Header = () => {
                 onClick={handleLoginClick}
               />
             }
-          </div>
+          </div>}
         </Toolbar>
       </AppBar>
     </div>

--- a/client/src/components/generic/Page.js
+++ b/client/src/components/generic/Page.js
@@ -10,11 +10,12 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export const Page = ({ children }) => {
+// hideEmployers set to true for participant-facing pages
+export const Page = ({ children, hideEmployers=false }) => {
   const classes = useStyles();
   return (
     <Fragment>
-      <Header />
+      <Header hideEmployers={hideEmployers}/>
       <Grid className={classes.root} container justify="center">
         {children}
       </Grid>

--- a/client/src/components/modal-forms/NewParticipantForm.js
+++ b/client/src/components/modal-forms/NewParticipantForm.js
@@ -1,11 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import { Button } from '../generic';
 import { Box } from '@material-ui/core';
 import { RenderDateField, RenderCheckbox, RenderTextField, RenderSelectField } from '../fields';
 import { Field, Formik, Form as FormikForm } from 'formik';
 import { getTodayDate } from '../../utils';
-import store from 'store';
 
 export const NewParticipantForm = ({ initialValues, validationSchema, onSubmit, onClose, sites }) => {
 

--- a/client/src/components/participant-form/Fields.js
+++ b/client/src/components/participant-form/Fields.js
@@ -40,7 +40,7 @@ export const Fields = ({ isDisabled }) => {
         </Grid>
         <Grid item xs={12}>
           <Typography>
-            <b>* Are you a Canadian citizen, permanent resident or <Link href="https://www.canada.ca/en/immigration-refugees-citizenship/services/work-canada/permit/temporary/eligibility.html" target="__blank" rel="noreferrer noopener">otherwise legally eligible to work in Canada?</Link></b>
+            <b>* Are you a Canadian citizen, permanent resident or <Link href="https://www.canada.ca/en/immigration-refugees-citizenship/services/work-canada.html" target="__blank" rel="noreferrer noopener">otherwise legally eligible to work in Canada?</Link></b>
           </Typography>
         </Grid>
         <Grid item xs={12}>

--- a/client/src/components/participant-form/index.js
+++ b/client/src/components/participant-form/index.js
@@ -31,7 +31,7 @@ export const Form = ({ initialValues, isDisabled }) => {
   const handleSubmit = async (values) => {
     setSubmitLoading(true);
 
-    const response = await fetch('/api/v1/participant-form', {
+    const response = await fetch('/api/v1/participants', {
       method: 'POST',
       headers: { 'Accept': 'application/json', 'Content-type': 'application/json' },
       body: JSON.stringify(values),

--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -1,8 +1,11 @@
 export default Object.freeze({
+  // Hostname
+  ParticipantHostname: 'hcapparticipants.gov.bc.ca',
+
   // Public routes
   Login: '/login',
   Keycloak: '/keycloak',
-  EmployerForm: '/',
+  Base: '/', // This routes to employer form or participant form based on hostname
   ParticipantForm: '/participant-form',
   ParticipantConfirmation: '/participant-confirmation',
   EmployerConfirmation: '/employer-confirmation',

--- a/client/src/pages/public/ParticipantConfirmation.js
+++ b/client/src/pages/public/ParticipantConfirmation.js
@@ -13,7 +13,7 @@ export default () => {
   if (!location.state) return <Redirect to={Routes.ParticipantForm} />
   return (
     <div id="confirmation">
-      <Page>
+      <Page hideEmployers={true}>
         <Grid item xs={12} sm={11} md={10} lg={8} xl={6}>
 
           {/** Status */}

--- a/client/src/pages/public/ParticipantForm.js
+++ b/client/src/pages/public/ParticipantForm.js
@@ -5,7 +5,7 @@ import { Form } from '../../components/participant-form';
 
 export default () => {
   return (
-    <Page>
+    <Page hideEmployers={true}>
       <Form />
     </Page>
   );

--- a/client/src/routes/index.js
+++ b/client/src/routes/index.js
@@ -22,7 +22,7 @@ const EmployerForm = lazy(() => import('../pages/public/EmployerForm'));
 const Login = lazy(() => import('../pages/public/Login'));
 const ParticipantConfirmation = lazy(() => import('../pages/public/ParticipantConfirmation'));
 const EmployerConfirmation = lazy(() => import('../pages/public/EmployerConfirmation'));
-const KeycloackRedirect = lazy(() => import('../pages/public/Keycloak'));
+const KeycloakRedirect = lazy(() => import('../pages/public/Keycloak'));
 
 const PrivateRoute = ({ component: Component, path, ...rest }) => {
   const [keycloak] = useKeycloak();
@@ -91,7 +91,10 @@ export default () => {
         <Suspense fallback={<LinearProgress />}>
           <Switch>
             <Route exact path={Routes.Login} component={Login} />
-            <Route exact path={Routes.EmployerForm} component={EmployerForm} />
+            <Route exact path={Routes.Base} render={() => {
+              if (window.location.hostname === Routes.ParticipantHostname) return <ParticipantForm/>
+              return <EmployerForm/>
+            }} />
             <Route exact path={Routes.ParticipantForm} component={ParticipantForm} />
             <Route exact path={Routes.ParticipantConfirmation} component={ParticipantConfirmation} />
             <Route exact path={Routes.EmployerConfirmation} component={EmployerConfirmation} />
@@ -106,7 +109,7 @@ export default () => {
             <PrivateRoute exact path={Routes.ParticipantUpload} component={ParticipantUpload} />
             <PrivateRoute exact path={Routes.ParticipantUploadResults} component={ParticipantUploadResults} />
             <PrivateRoute exact path={Routes.Admin} component={Admin} />
-            <Route exact path={Routes.Keycloak} component={KeycloackRedirect} />
+            <Route exact path={Routes.Keycloak} component={KeycloakRedirect} />
             <Route component={EmployerForm} />
           </Switch>
         </Suspense>

--- a/server/server.js
+++ b/server/server.js
@@ -315,6 +315,7 @@ app.post(`${apiBaseUrl}/participants`,
 
     const participant = {
       ...req.body,
+      formVersion: 'v1',
       maximusId: null,
       postalCodeFsa: req.body.postalCode.substr(0, 3),
       preferredLocation: req.body.preferredLocation.join(';'),


### PR DESCRIPTION
Participant form is visible at `/participant-form`. It is also shown at `/` depending on hostname. For now, a hostname of `hcapparticipants.gov.bc.ca` will show the participant form at the base path.