### PR TITLE
Hcap 404 improve routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ To run server tests:
 - Cypress tests may be run with
   - `make local-cypress-tests`
 
+This application depends on your hostname suffix to server the right routes. To access the
+employer content you need to specify http://`hcapemployers`.local.freshworks.club in your
+browser or http://`hcapparticipants`.local.freshworks.club for the participant's. In case you
+don't want an external DNS resolving to your localhost you can add an alias to your `hosts` file
+resolving to `*.your-prefix`.
+
 ### Public Front End Views
 
 ##### /

--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -1,6 +1,8 @@
 export default Object.freeze({
   // Hostname
-  ParticipantHostname: 'hcapparticipants.gov.bc.ca',
+  // ParticipantHostname: 'hcapparticipants.gov.bc.ca',
+  ParticipantHostname: 'hcapparticipants.local.freshworks.club',
+  EmployerHostname: 'hcapemployers.local.freshworks.club',
 
   // Public routes
   Login: '/login',

--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -1,8 +1,7 @@
 export default Object.freeze({
   // Hostname
-  // ParticipantHostname: 'hcapparticipants.gov.bc.ca',
-  ParticipantHostname: 'hcapparticipants.local.freshworks.club',
-  EmployerHostname: 'hcapemployers.local.freshworks.club',
+  ParticipantHostname: 'hcapparticipants.*',
+  EmployerHostname: 'hcapemployers.*',
 
   // Public routes
   Login: '/login',

--- a/client/src/routes/index.js
+++ b/client/src/routes/index.js
@@ -95,11 +95,10 @@ export default () => {
           <Switch>
             <Route exact path={Routes.Login} component={Login} />
             <Route exact path={Routes.Keycloak} component={KeycloakRedirect} />
-            <Redirect to='/' />
           </Switch>
           <RootUrlSwitch rootUrl={Routes.ParticipantHostname}>
             <Route exact path={Routes.ParticipantConfirmation} component={ParticipantConfirmation} />
-            <Route exact path={Routes.Base} component={ParticipantForm} />
+            <Route component={ParticipantForm} />
           </RootUrlSwitch>
           <RootUrlSwitch rootUrl={Routes.EmployerHostname}>
             <PrivateRoute exact path={Routes.Admin} component={Admin} />
@@ -114,7 +113,7 @@ export default () => {
             <PrivateRoute exact path={Routes.ParticipantView} component={ParticipantView} />
             <PrivateRoute exact path={Routes.ParticipantUpload} component={ParticipantUpload} />
             <PrivateRoute exact path={Routes.ParticipantUploadResults} component={ParticipantUploadResults} />
-            <Route exact path={Routes.Base} component={EmployerForm} />
+            <Route component={EmployerForm} />
           </RootUrlSwitch>
         </Suspense>
       </BrowserRouter>

--- a/client/src/routes/index.js
+++ b/client/src/routes/index.js
@@ -2,6 +2,7 @@ import React, { Suspense, lazy, useEffect, useState, } from 'react';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { useKeycloak, KeycloakProvider } from '@react-keycloak/web';
+import { matchRuleShort } from '../utils'
 import store from 'store';
 import Keycloak from 'keycloak-js';
 
@@ -43,6 +44,8 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
     />
   );
 };
+
+const RootUrlSwitch = ({ rootUrl, children }) => matchRuleShort(window.location.hostname, rootUrl) && <Switch>{children}</Switch>
 
 export default () => {
 
@@ -91,12 +94,15 @@ export default () => {
         <Suspense fallback={<LinearProgress />}>
           <Switch>
             <Route exact path={Routes.Login} component={Login} />
-            <Route exact path={Routes.Base} render={() => {
-              if (window.location.hostname === Routes.ParticipantHostname) return <ParticipantForm/>
-              return <EmployerForm/>
-            }} />
-            <Route exact path={Routes.ParticipantForm} component={ParticipantForm} />
+            <Route exact path={Routes.Keycloak} component={KeycloakRedirect} />
+            <Redirect to='/' />
+          </Switch>
+          <RootUrlSwitch rootUrl={Routes.ParticipantHostname}>
             <Route exact path={Routes.ParticipantConfirmation} component={ParticipantConfirmation} />
+            <Route exact path={Routes.Base} component={ParticipantForm} />
+          </RootUrlSwitch>
+          <RootUrlSwitch rootUrl={Routes.EmployerHostname}>
+            <PrivateRoute exact path={Routes.Admin} component={Admin} />
             <Route exact path={Routes.EmployerConfirmation} component={EmployerConfirmation} />
             <PrivateRoute exact path={Routes.UserPending} component={UserView} />
             <PrivateRoute exact path={Routes.UserEdit} component={UserView} />
@@ -108,10 +114,8 @@ export default () => {
             <PrivateRoute exact path={Routes.ParticipantView} component={ParticipantView} />
             <PrivateRoute exact path={Routes.ParticipantUpload} component={ParticipantUpload} />
             <PrivateRoute exact path={Routes.ParticipantUploadResults} component={ParticipantUploadResults} />
-            <PrivateRoute exact path={Routes.Admin} component={Admin} />
-            <Route exact path={Routes.Keycloak} component={KeycloakRedirect} />
-            <Route component={EmployerForm} />
-          </Switch>
+            <Route exact path={Routes.Base} component={EmployerForm} />
+          </RootUrlSwitch>
         </Suspense>
       </BrowserRouter>
     </KeycloakProvider>

--- a/client/src/routes/index.js
+++ b/client/src/routes/index.js
@@ -98,7 +98,8 @@ export default () => {
           </Switch>
           <RootUrlSwitch rootUrl={Routes.ParticipantHostname}>
             <Route exact path={Routes.ParticipantConfirmation} component={ParticipantConfirmation} />
-            <Route component={ParticipantForm} />
+            <Route exact path={Routes.Base} component={ParticipantForm} />
+            <Redirect to={Routes.Base} />
           </RootUrlSwitch>
           <RootUrlSwitch rootUrl={Routes.EmployerHostname}>
             <PrivateRoute exact path={Routes.Admin} component={Admin} />
@@ -113,7 +114,8 @@ export default () => {
             <PrivateRoute exact path={Routes.ParticipantView} component={ParticipantView} />
             <PrivateRoute exact path={Routes.ParticipantUpload} component={ParticipantUpload} />
             <PrivateRoute exact path={Routes.ParticipantUploadResults} component={ParticipantUploadResults} />
-            <Route component={EmployerForm} />
+            <Route exact path={Routes.Base} component={EmployerForm} />
+            <Redirect to={Routes.Base} />
           </RootUrlSwitch>
         </Suspense>
       </BrowserRouter>

--- a/client/src/utils/misc.js
+++ b/client/src/utils/misc.js
@@ -1,5 +1,5 @@
 export const scrollUp = () => window.scrollTo({top: 0, behavior: 'smooth'});
 export const matchRuleShort = (str, rule) => {
-  const escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+  const escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|[\]/\\])/g, "\\$1");
   return new RegExp("^" + rule.split("*").map(escapeRegex).join(".*") + "$").test(str);
 }

--- a/client/src/utils/misc.js
+++ b/client/src/utils/misc.js
@@ -1,1 +1,5 @@
 export const scrollUp = () => window.scrollTo({top: 0, behavior: 'smooth'});
+export const matchRuleShort = (str, rule) => {
+  const escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+  return new RegExp("^" + rule.split("*").map(escapeRegex).join(".*") + "$").test(str);
+}

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:4000",
+  "baseUrl": "http://hcapemployers.local.freshworks.club:4000",
   "chromeWebSecurity": false,
   "video": false
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,6 +7,8 @@ services:
     build:
       context: ./client
       dockerfile: Dockerfile.dev
+    environment:
+      - DANGEROUSLY_DISABLE_HOST_CHECK=true
     ports:
       - 4000:4000
     volumes:


### PR DESCRIPTION
This PR will only work on dev/test if we create the **hcapparticipants** and **hcapemployers** suffixes. 

To test locally just use **http://hcapemployers.local.freshworks.club/** and **http://hcapparticipants.local.freshworks.club:4000/** instead of localhost:4000