### PR TITLE
Added post import migration

### DIFF
--- a/server/migrations/1616190016615_post-import-cleanup.js
+++ b/server/migrations/1616190016615_post-import-cleanup.js
@@ -1,27 +1,31 @@
-/* eslint-disable camelcase */
+/* eslint-disable camelcase, no-console */
 const { dbClient, collections } = require('../db');
 
 exports.up = async () => {
   await dbClient.db.withTransaction(async (tx) => {
-    await tx[collections.PARTICIPANTS].updateDoc(
+    const postalCodes = await tx[collections.PARTICIPANTS].updateDoc(
       {
         postalCode: 'Z1Z1Z1',
       },
       { postalCode: '' },
     );
 
-    await tx[collections.PARTICIPANTS].updateDoc(
+    const nonHCAPs = await tx[collections.PARTICIPANTS].updateDoc(
       {
         nonHCAP: 'NULL',
       },
       { nonHCAP: '' },
     );
 
-    await tx[collections.PARTICIPANTS].updateDoc(
+    const crcClears = await tx[collections.PARTICIPANTS].updateDoc(
       {
         crcClear: 'NULL',
       },
       { crcClear: '' },
     );
+
+    console.log(`Updated ${postalCodes.length} postalCode fields`);
+    console.log(`Updated ${nonHCAPs.length} nonHCAP fields`);
+    console.log(`Updated ${crcClears.length} crcClear fields`);
   });
 };

--- a/server/migrations/1616190016615_post-import-cleanup.js
+++ b/server/migrations/1616190016615_post-import-cleanup.js
@@ -1,0 +1,27 @@
+/* eslint-disable camelcase */
+const { dbClient, collections } = require('../db');
+
+exports.up = async () => {
+  await dbClient.db.withTransaction(async (tx) => {
+    await tx[collections.PARTICIPANTS].updateDoc(
+      {
+        postalCode: 'Z1Z1Z1',
+      },
+      { postalCode: '' },
+    );
+
+    await tx[collections.PARTICIPANTS].updateDoc(
+      {
+        nonHCAP: 'NULL',
+      },
+      { nonHCAP: '' },
+    );
+
+    await tx[collections.PARTICIPANTS].updateDoc(
+      {
+        crcClear: 'NULL',
+      },
+      { crcClear: '' },
+    );
+  });
+};


### PR DESCRIPTION
For all participant records where the postal code is Z1Z1Z1, blank out the postal code entirely

Where the value of a field has been saved in the DB as NULL, replace a blank string or actual null - fields impacted: non-HCAP, CRC Clear. I didn’t find anything else on prod data