### PR TITLE
HCAP-389: Single site POST - BE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export OS_NAMESPACE_SUFFIX?=dev
 export COMMIT_SHA:=$(shell git rev-parse --short=7 HEAD)
 export TARGET_NAMESPACE=$(OS_NAMESPACE_PREFIX)-$(OS_NAMESPACE_SUFFIX)
 export TOOLS_NAMESPACE=$(OS_NAMESPACE_PREFIX)-tools
-export DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}
+export DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${POSTGRES_DB}
 
 # Status Output
 

--- a/server/server.js
+++ b/server/server.js
@@ -407,6 +407,9 @@ app.post(`${apiBaseUrl}/employer-sites`,
 
       return res.status(201).json(response);
     } catch (excp) {
+      if (excp.code === '23505') {
+        return res.status(400).send({ siteId: req.body.siteId, status: 'Duplicate' });
+      }
       return res.status(400).send(`${excp}`);
     }
   }));

--- a/server/server.js
+++ b/server/server.js
@@ -405,7 +405,7 @@ app.post(`${apiBaseUrl}/employer-sites`,
         site_id: response.siteId,
       });
 
-      return res.json(response);
+      return res.status(201).json(response);
     } catch (excp) {
       return res.status(400).send(`${excp}`);
     }

--- a/server/services/employers.js
+++ b/server/services/employers.js
@@ -12,23 +12,8 @@ const getEmployers = async (user) => {
 const getEmployerByID = async (id) => dbClient.db[collections.EMPLOYER_FORMS].findDoc({ id });
 
 const saveSingleSite = async (siteJson) => {
-  const res = dbClient.db.saveDoc(collections.EMPLOYER_SITES, siteJson);
+  const res = await dbClient.db.saveDoc(collections.EMPLOYER_SITES, siteJson);
   return res;
-
-  // const res = await dbClient.db.saveDoc(collections.EMPLOYER_SITES, siteJson);
-  // const { siteId } = res;
-  // switch (res.status) {
-  //   case 'fulfilled':
-  //     res.push({ siteId, status: 'Success' });
-  //     break;
-  //   default:
-  //     if (res.reason.code === '23505') {
-  //       res.push({ siteId, status: 'Duplicate' });
-  //     } else {
-  //       res.push({ siteId, status: 'Error', message: res.reason });
-  //     }
-  // }
-  // return res;
 };
 
 const saveSites = async (sitesArg) => {

--- a/server/services/employers.js
+++ b/server/services/employers.js
@@ -12,20 +12,23 @@ const getEmployers = async (user) => {
 const getEmployerByID = async (id) => dbClient.db[collections.EMPLOYER_FORMS].findDoc({ id });
 
 const saveSingleSite = async (siteJson) => {
-  const res = await dbClient.db.saveDoc(collections.EMPLOYER_SITES, siteJson);
-  const { siteId } = res;
-  switch (res.status) {
-    case 'fulfilled':
-      res.push({ siteId, status: 'Success' });
-      break;
-    default:
-      if (res.reason.code === '23505') {
-        res.push({ siteId, status: 'Duplicate' });
-      } else {
-        res.push({ siteId, status: 'Error', message: res.reason });
-      }
-  }
+  const res = dbClient.db.saveDoc(collections.EMPLOYER_SITES, siteJson);
   return res;
+
+  // const res = await dbClient.db.saveDoc(collections.EMPLOYER_SITES, siteJson);
+  // const { siteId } = res;
+  // switch (res.status) {
+  //   case 'fulfilled':
+  //     res.push({ siteId, status: 'Success' });
+  //     break;
+  //   default:
+  //     if (res.reason.code === '23505') {
+  //       res.push({ siteId, status: 'Duplicate' });
+  //     } else {
+  //       res.push({ siteId, status: 'Error', message: res.reason });
+  //     }
+  // }
+  // return res;
 };
 
 const saveSites = async (sitesArg) => {

--- a/server/services/employers.js
+++ b/server/services/employers.js
@@ -11,6 +11,23 @@ const getEmployers = async (user) => {
 
 const getEmployerByID = async (id) => dbClient.db[collections.EMPLOYER_FORMS].findDoc({ id });
 
+const saveSingleSite = async (siteJson) => {
+  const res = await dbClient.db.saveDoc(collections.EMPLOYER_SITES, siteJson);
+  const { siteId } = res;
+  switch (res.status) {
+    case 'fulfilled':
+      res.push({ siteId, status: 'Success' });
+      break;
+    default:
+      if (res.reason.code === '23505') {
+        res.push({ siteId, status: 'Duplicate' });
+      } else {
+        res.push({ siteId, status: 'Error', message: res.reason });
+      }
+  }
+  return res;
+};
+
 const saveSites = async (sitesArg) => {
   const sites = Array.isArray(sitesArg) ? sitesArg : [sitesArg];
   await validate(EmployerSiteBatchSchema, sites);
@@ -57,6 +74,7 @@ const getSiteByID = async (id) => {
 module.exports = {
   getEmployers,
   getEmployerByID,
+  saveSingleSite,
   saveSites,
   updateSite,
   getSites,

--- a/server/tests/employer.form.test.js
+++ b/server/tests/employer.form.test.js
@@ -1,17 +1,8 @@
 const request = require('supertest');
-const { ValidationError } = require('yup');
-const { v4 } = require('uuid');
 const app = require('../server');
 const {
-  saveSites, getSites, getSiteByID, getEmployers, getEmployerByID,
-  updateSite,
+  getEmployers, getEmployerByID,
 } = require('../services/employers.js');
-const {
-  getParticipants,
-  makeParticipant,
-  setParticipantStatus,
-  getHiredParticipantsBySite,
-} = require('../services/participants.js');
 
 const { startDB, closeDB } = require('./util/db');
 
@@ -29,56 +20,6 @@ describe('Server V1 Form Endpoints', () => {
   });
 
   const formEndpoint = '/api/v1/employer-form';
-
-  const employerAId = v4();
-  const employerBId = v4();
-  const participant1 = {
-    maximusId: 648690,
-    lastName: 'Extra',
-    firstName: 'Eddy',
-    postalCode: 'V1V2V3',
-    postalCodeFsa: 'V1V',
-    phoneNumber: '2502223333',
-    emailAddress: 'eddy@example.com',
-    interested: 'yes',
-    nonHCAP: 'yes',
-    crcClear: 'yes',
-    preferredLocation: 'Fraser',
-  };
-
-  const participant2 = {
-    maximusId: 648691,
-    lastName: 'Finkleman',
-    firstName: 'Freduardo',
-    postalCode: 'V1V2V3',
-    postalCodeFsa: 'V1V',
-    phoneNumber: '2502223333',
-    emailAddress: 'freddy@example.com',
-    interested: 'yes',
-    nonHCAP: 'yes',
-    crcClear: 'yes',
-    preferredLocation: 'Fraser',
-  };
-
-  const site = {
-    siteId: 67,
-    siteName: 'Test site',
-    phaseOneAllocation: 1,
-    address: '123 XYZ',
-    city: 'Victoria',
-    healthAuthority: 'Vancouver Island',
-    postalCode: 'V8V 1M5',
-    registeredBusinessName: 'AAA',
-    operatorName: 'Test Operator',
-    operatorContactFirstName: 'AABB',
-    operatorContactLastName: 'CCC',
-    operatorEmail: 'test@hcpa.fresh',
-    operatorPhone: '2219909090',
-    siteContactFirstName: 'NNN',
-    siteContactLastName: 'PCP',
-    siteContactPhoneNumber: '2219909091',
-    siteContactEmailAddress: 'test.site@hcpa.fresh',
-  };
 
   const form = {
 
@@ -214,142 +155,19 @@ describe('Server V1 Form Endpoints', () => {
     expect(res.statusCode).toEqual(400);
   });
 
-  it('Create new site, receive success', async () => {
-    const res = await saveSites(site);
-    const expectedRes = [
-      { siteId: 67, status: 'Success' },
-    ];
-    expect(res).toEqual(expectedRes);
-  });
-
-  it('Get sites, receive all successfully', async () => {
-    const res = await getSites();
-    expect(res).toEqual(
-      expect.arrayContaining(
-        [site].map((item) => (expect.objectContaining(item))),
-      ),
-    );
-  });
-
-  it('Gets a single site', async () => {
-    const res = await getSiteByID(1);
-    expect(res).toEqual(
-      expect.arrayContaining(
-        [site].map((item) => (expect.objectContaining(item))),
-      ),
-    );
-  });
-
-  it('gets a site before and after hires have been made', async () => {
-    const [res] = await getSiteByID(1);
-    expect(res.hcapHires).toEqual('0');
-    expect(res.nonHcapHires).toEqual('0');
-    await makeParticipant(participant1);
-    await makeParticipant(participant2);
-    const { data: [ppt, ppt2] } = await getParticipants({ isMoH: true });
-    await setParticipantStatus(employerAId, ppt.id, 'prospecting');
-    await setParticipantStatus(employerAId, ppt.id, 'interviewing');
-    await setParticipantStatus(employerAId, ppt.id, 'offer_made');
-    await setParticipantStatus(employerAId, ppt.id, 'hired', {
-      site: res.siteId,
-      nonHcapOpportunity: false,
-      positionTitle: 'title',
-      positionType: 'posType',
-      hiredDate: new Date(),
-      startDate: new Date(),
-    });
-    await setParticipantStatus(employerBId, ppt2.id, 'prospecting');
-    await setParticipantStatus(employerBId, ppt2.id, 'interviewing');
-    await setParticipantStatus(employerBId, ppt2.id, 'offer_made');
-    await setParticipantStatus(employerBId, ppt2.id, 'hired', {
-      site: res.siteId,
-      nonHcapOpportunity: true,
-      positionTitle: 'title',
-      positionType: 'posType',
-      hiredDate: new Date(),
-      startDate: new Date(),
-    });
-    const [res1] = await getSiteByID(1);
-    expect(res1.hcapHires).toEqual('1');
-    expect(res1.nonHcapHires).toEqual('1');
-  });
-
-  it('Create new site, receive validation error', async () => {
-    expect(
-      saveSites({ ...site, siteContactPhoneNumber: '1' }),
-    ).rejects.toEqual(new ValidationError('Phone number must be provided as 10 digits (index 0)'));
-  });
-
-  it('Create new site, receive duplicated', async () => {
-    const res = await saveSites(site);
-    const expectedRes = [
-      { siteId: 67, status: 'Duplicate' },
-    ];
-    expect(res).toEqual(expectedRes);
-  });
-
-  it('Update site, receive success', async () => {
-    const res = await updateSite(1, {
-      siteName: 'test',
-      history: [{ timestamp: new Date(), changes: [{ field: 'siteName', from: 'test1', to: 'test' }] }],
-    });
-    expect(res[0].siteName).toEqual('test');
-  });
-
-  it('fetches the list of employers', async () => {
+  it('fetches the list of employer expression of interest forms', async () => {
     const res = await getEmployers({
       isSuperUser: false, isMoH: false, isHA: true, regions: ['Vancouver Island'],
     });
     expect(res).toEqual([]);
   });
 
-  it('fetches a single employer', async () => {
+  it('fetches a single employer expression of interest form', async () => {
     const res = await getEmployerByID(1);
     expect(res).toEqual(
       expect.arrayContaining(
         [form].map((item) => (expect.objectContaining(item))),
       ),
     );
-  });
-
-  it('checks response from the site participants endpoint', async () => {
-    await closeDB();
-    await startDB();
-
-    const siteResponse = await saveSites(site);
-    const expectedSite = [
-      { siteId: 67, status: 'Success' },
-    ];
-    expect(siteResponse).toEqual(expectedSite);
-
-    const [res] = await getSiteByID(1);
-    await makeParticipant(participant1);
-    await makeParticipant(participant2);
-    const { data: [ppt, ppt2] } = await getParticipants({ isMoH: true });
-    await setParticipantStatus(employerAId, ppt.id, 'prospecting');
-    await setParticipantStatus(employerAId, ppt.id, 'interviewing');
-    await setParticipantStatus(employerAId, ppt.id, 'offer_made');
-    await setParticipantStatus(employerAId, ppt.id, 'hired', {
-      site: res.siteId,
-      nonHcapOpportunity: false,
-      positionTitle: 'title',
-      positionType: 'posType',
-      hiredDate: new Date(),
-      startDate: new Date(),
-    });
-    await setParticipantStatus(employerBId, ppt2.id, 'prospecting');
-    await setParticipantStatus(employerBId, ppt2.id, 'interviewing');
-    await setParticipantStatus(employerBId, ppt2.id, 'offer_made');
-    await setParticipantStatus(employerBId, ppt2.id, 'hired', {
-      site: res.siteId,
-      nonHcapOpportunity: true,
-      positionTitle: 'title',
-      positionType: 'posType',
-      hiredDate: new Date(),
-      startDate: new Date(),
-    });
-    const [site1] = await getSiteByID(1);
-    const res2 = await getHiredParticipantsBySite(site1.siteId);
-    expect(res2.length).toEqual(2);
   });
 });

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -83,7 +83,8 @@ describe('Employer Site Endpoints', () => {
     const expectedRes = [
       { siteId: 90, status: 'Success' },
     ];
-    expect(res).toEqual(expectedRes);
+    expect(res.statusCode).toEqual(200);
+    expect(res.siteId).toEqual(expectedRes.siteId);
   });
 
   it('Create duplicate single site, receive dupe', async () => {
@@ -93,7 +94,8 @@ describe('Employer Site Endpoints', () => {
     const expectedRes = [
       { siteId: 91, status: 'Success' },
     ];
-    expect(res).toEqual(expectedRes);
+    expect(res.statusCode).toEqual(200);
+    expect(res.siteId).toEqual(expectedRes.siteId);
 
     const dupeRes = await saveSingleSite(singleSite);
     const expectedDupeRes = [

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -1,0 +1,201 @@
+const { ValidationError } = require('yup');
+const { v4 } = require('uuid');
+const app = require('../server');
+const {
+  saveSites, getSites, getSiteByID, updateSite,
+} = require('../services/employers.js');
+const {
+  getParticipants,
+  makeParticipant,
+  setParticipantStatus,
+  getHiredParticipantsBySite,
+} = require('../services/participants.js');
+
+const { startDB, closeDB } = require('./util/db');
+
+describe('Employer Site Endpoints', () => {
+  let server;
+
+  beforeAll(async () => {
+    await startDB();
+    server = app.listen();
+  });
+
+  afterAll(async () => {
+    await closeDB();
+    server.close();
+  });
+
+  const employerAId = v4();
+  const employerBId = v4();
+  const participant1 = {
+    maximusId: 648690,
+    lastName: 'Extra',
+    firstName: 'Eddy',
+    postalCode: 'V1V2V3',
+    postalCodeFsa: 'V1V',
+    phoneNumber: '2502223333',
+    emailAddress: 'eddy@example.com',
+    interested: 'yes',
+    nonHCAP: 'yes',
+    crcClear: 'yes',
+    preferredLocation: 'Fraser',
+  };
+
+  const participant2 = {
+    maximusId: 648691,
+    lastName: 'Finkleman',
+    firstName: 'Freduardo',
+    postalCode: 'V1V2V3',
+    postalCodeFsa: 'V1V',
+    phoneNumber: '2502223333',
+    emailAddress: 'freddy@example.com',
+    interested: 'yes',
+    nonHCAP: 'yes',
+    crcClear: 'yes',
+    preferredLocation: 'Fraser',
+  };
+
+  const site = {
+    siteId: 67,
+    siteName: 'Test site',
+    phaseOneAllocation: 1,
+    address: '123 XYZ',
+    city: 'Victoria',
+    healthAuthority: 'Vancouver Island',
+    postalCode: 'V8V 1M5',
+    registeredBusinessName: 'AAA',
+    operatorName: 'Test Operator',
+    operatorContactFirstName: 'AABB',
+    operatorContactLastName: 'CCC',
+    operatorEmail: 'test@hcpa.fresh',
+    operatorPhone: '2219909090',
+    siteContactFirstName: 'NNN',
+    siteContactLastName: 'PCP',
+    siteContactPhoneNumber: '2219909091',
+    siteContactEmailAddress: 'test.site@hcpa.fresh',
+  };
+
+  it('Create new site via batch, receive success', async () => {
+    const res = await saveSites(site);
+    const expectedRes = [
+      { siteId: 67, status: 'Success' },
+    ];
+    expect(res).toEqual(expectedRes);
+  });
+
+  it('Get sites, receive all successfully', async () => {
+    const res = await getSites();
+    expect(res).toEqual(
+      expect.arrayContaining(
+        [site].map((item) => (expect.objectContaining(item))),
+      ),
+    );
+  });
+
+  it('Gets a single site', async () => {
+    const res = await getSiteByID(1);
+    expect(res).toEqual(
+      expect.arrayContaining(
+        [site].map((item) => (expect.objectContaining(item))),
+      ),
+    );
+  });
+
+  it('gets a site before and after hires have been made', async () => {
+    const [res] = await getSiteByID(1);
+    expect(res.hcapHires).toEqual('0');
+    expect(res.nonHcapHires).toEqual('0');
+    await makeParticipant(participant1);
+    await makeParticipant(participant2);
+    const { data: [ppt, ppt2] } = await getParticipants({ isMoH: true });
+    await setParticipantStatus(employerAId, ppt.id, 'prospecting');
+    await setParticipantStatus(employerAId, ppt.id, 'interviewing');
+    await setParticipantStatus(employerAId, ppt.id, 'offer_made');
+    await setParticipantStatus(employerAId, ppt.id, 'hired', {
+      site: res.siteId,
+      nonHcapOpportunity: false,
+      positionTitle: 'title',
+      positionType: 'posType',
+      hiredDate: new Date(),
+      startDate: new Date(),
+    });
+    await setParticipantStatus(employerBId, ppt2.id, 'prospecting');
+    await setParticipantStatus(employerBId, ppt2.id, 'interviewing');
+    await setParticipantStatus(employerBId, ppt2.id, 'offer_made');
+    await setParticipantStatus(employerBId, ppt2.id, 'hired', {
+      site: res.siteId,
+      nonHcapOpportunity: true,
+      positionTitle: 'title',
+      positionType: 'posType',
+      hiredDate: new Date(),
+      startDate: new Date(),
+    });
+    const [res1] = await getSiteByID(1);
+    expect(res1.hcapHires).toEqual('1');
+    expect(res1.nonHcapHires).toEqual('1');
+  });
+
+  it('Create new site, receive validation error', async () => {
+    expect(
+      saveSites({ ...site, siteContactPhoneNumber: '1' }),
+    ).rejects.toEqual(new ValidationError('Phone number must be provided as 10 digits (index 0)'));
+  });
+
+  it('Create new site, receive duplicated', async () => {
+    const res = await saveSites(site);
+    const expectedRes = [
+      { siteId: 67, status: 'Duplicate' },
+    ];
+    expect(res).toEqual(expectedRes);
+  });
+
+  it('Update site, receive success', async () => {
+    const res = await updateSite(1, {
+      siteName: 'test',
+      history: [{ timestamp: new Date(), changes: [{ field: 'siteName', from: 'test1', to: 'test' }] }],
+    });
+    expect(res[0].siteName).toEqual('test');
+  });
+
+  it('checks response from the site participants endpoint', async () => {
+    await closeDB();
+    await startDB();
+
+    const siteResponse = await saveSites(site);
+    const expectedSite = [
+      { siteId: 67, status: 'Success' },
+    ];
+    expect(siteResponse).toEqual(expectedSite);
+
+    const [res] = await getSiteByID(1);
+    await makeParticipant(participant1);
+    await makeParticipant(participant2);
+    const { data: [ppt, ppt2] } = await getParticipants({ isMoH: true });
+    await setParticipantStatus(employerAId, ppt.id, 'prospecting');
+    await setParticipantStatus(employerAId, ppt.id, 'interviewing');
+    await setParticipantStatus(employerAId, ppt.id, 'offer_made');
+    await setParticipantStatus(employerAId, ppt.id, 'hired', {
+      site: res.siteId,
+      nonHcapOpportunity: false,
+      positionTitle: 'title',
+      positionType: 'posType',
+      hiredDate: new Date(),
+      startDate: new Date(),
+    });
+    await setParticipantStatus(employerBId, ppt2.id, 'prospecting');
+    await setParticipantStatus(employerBId, ppt2.id, 'interviewing');
+    await setParticipantStatus(employerBId, ppt2.id, 'offer_made');
+    await setParticipantStatus(employerBId, ppt2.id, 'hired', {
+      site: res.siteId,
+      nonHcapOpportunity: true,
+      positionTitle: 'title',
+      positionType: 'posType',
+      hiredDate: new Date(),
+      startDate: new Date(),
+    });
+    const [site1] = await getSiteByID(1);
+    const res2 = await getHiredParticipantsBySite(site1.siteId);
+    expect(res2.length).toEqual(2);
+  });
+});

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -2,7 +2,7 @@ const { ValidationError } = require('yup');
 const { v4 } = require('uuid');
 const app = require('../server');
 const {
-  saveSites, getSites, getSiteByID, updateSite,
+  saveSingleSite, saveSites, getSites, getSiteByID, updateSite,
 } = require('../services/employers.js');
 const {
   getParticipants,
@@ -75,6 +75,32 @@ describe('Employer Site Endpoints', () => {
     siteContactPhoneNumber: '2219909091',
     siteContactEmailAddress: 'test.site@hcpa.fresh',
   };
+
+  it('Create new single site, receive success', async () => {
+    const singleSite = site;
+    singleSite.siteId = 90;
+    const res = await saveSingleSite(singleSite);
+    const expectedRes = [
+      { siteId: 90, status: 'Success' },
+    ];
+    expect(res).toEqual(expectedRes);
+  });
+
+  it('Create duplicate single site, receive dupe', async () => {
+    const singleSite = site;
+    singleSite.siteId = 91;
+    const res = await saveSingleSite(singleSite);
+    const expectedRes = [
+      { siteId: 91, status: 'Success' },
+    ];
+    expect(res).toEqual(expectedRes);
+
+    const dupeRes = await saveSingleSite(singleSite);
+    const expectedDupeRes = [
+      { siteId: 91, status: 'Duplicate' },
+    ];
+    expect(dupeRes).toEqual(expectedDupeRes);
+  });
 
   it('Create new site via batch, receive success', async () => {
     const res = await saveSites(site);

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -83,7 +83,6 @@ describe('Employer Site Endpoints', () => {
     const expectedRes = [
       { siteId: 90, status: 'Success' },
     ];
-    expect(res.statusCode).toEqual(201);
     expect(res.siteId).toEqual(expectedRes.siteId);
   });
 
@@ -94,7 +93,6 @@ describe('Employer Site Endpoints', () => {
     const expectedRes = [
       { siteId: 91, status: 'Success' },
     ];
-    expect(res.statusCode).toEqual(201);
     expect(res.siteId).toEqual(expectedRes.siteId);
 
     const dupeRes = await saveSingleSite(singleSite);

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -80,20 +80,20 @@ describe('Employer Site Endpoints', () => {
     const singleSite = site;
     singleSite.siteId = 90;
     const res = await saveSingleSite(singleSite);
-    const expectedRes = [
-      { siteId: 90, status: 'Success' },
-    ];
-    expect(res.siteId).toEqual(expectedRes.siteId);
+    // const expectedRes = [
+    //   { siteId: 90, status: 'Success' },
+    // ];
+    expect(res.siteId).toEqual(90);
   });
 
   it('Create duplicate single site, receive dupe', async () => {
     const singleSite = site;
     singleSite.siteId = 91;
     const res = await saveSingleSite(singleSite);
-    const expectedRes = [
-      { siteId: 91, status: 'Success' },
-    ];
-    expect(res.siteId).toEqual(expectedRes.siteId);
+    // const expectedRes = [
+    //   { siteId: 91, status: 'Success' },
+    // ];
+    expect(res.siteId).toEqual(91);
 
     const dupeRes = await saveSingleSite(singleSite);
     const expectedDupeRes = [

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -56,6 +56,28 @@ describe('Employer Site Endpoints', () => {
     preferredLocation: 'Fraser',
   };
 
+  // Used for single site POST
+  // siteId must be assigned by the test
+  const siteBaseFields = {
+    siteName: 'Test site',
+    phaseOneAllocation: 1,
+    address: '123 XYZ',
+    city: 'Victoria',
+    healthAuthority: 'Vancouver Island',
+    postalCode: 'V8V 1M5',
+    registeredBusinessName: 'AAA',
+    operatorName: 'Test Operator',
+    operatorContactFirstName: 'AABB',
+    operatorContactLastName: 'CCC',
+    operatorEmail: 'test@hcpa.fresh',
+    operatorPhone: '2219909090',
+    siteContactFirstName: 'NNN',
+    siteContactLastName: 'PCP',
+    siteContactPhone: '2219909091',
+    siteContactEmail: 'test.site@hcpa.fresh',
+  };
+
+  // Used for batch site POST
   const site = {
     siteId: 67,
     siteName: 'Test site',
@@ -77,29 +99,23 @@ describe('Employer Site Endpoints', () => {
   };
 
   it('Create new single site, receive success', async () => {
-    const singleSite = site;
-    singleSite.siteId = 90;
-    const res = await saveSingleSite(singleSite);
-    // const expectedRes = [
-    //   { siteId: 90, status: 'Success' },
-    // ];
+    siteBaseFields.siteId = 90;
+    const res = await saveSingleSite(siteBaseFields);
     expect(res.siteId).toEqual(90);
+    expect(res.id).toBeDefined();
   });
 
   it('Create duplicate single site, receive dupe', async () => {
-    const singleSite = site;
-    singleSite.siteId = 91;
-    const res = await saveSingleSite(singleSite);
-    // const expectedRes = [
-    //   { siteId: 91, status: 'Success' },
-    // ];
+    siteBaseFields.siteId = 91;
+    const res = await saveSingleSite(siteBaseFields);
     expect(res.siteId).toEqual(91);
+    expect(res.id).toBeDefined();
 
-    const dupeRes = await saveSingleSite(singleSite);
-    const expectedDupeRes = [
-      { siteId: 91, status: 'Duplicate' },
-    ];
-    expect(dupeRes).toEqual(expectedDupeRes);
+    try {
+      await saveSingleSite(siteBaseFields);
+    } catch (excp) {
+      expect(excp.code).toEqual('23505');
+    }
   });
 
   it('Create new site via batch, receive success', async () => {
@@ -120,10 +136,15 @@ describe('Employer Site Endpoints', () => {
   });
 
   it('Gets a single site', async () => {
-    const res = await getSiteByID(1);
+    siteBaseFields.siteId = 92;
+    const sitePostRes = await saveSingleSite(siteBaseFields);
+    expect(sitePostRes.siteId).toEqual(92);
+    expect(sitePostRes.id).toBeDefined();
+
+    const res = await getSiteByID(sitePostRes.id);
     expect(res).toEqual(
       expect.arrayContaining(
-        [site].map((item) => (expect.objectContaining(item))),
+        [siteBaseFields].map((item) => (expect.objectContaining(item))),
       ),
     );
   });

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -83,7 +83,7 @@ describe('Employer Site Endpoints', () => {
     const expectedRes = [
       { siteId: 90, status: 'Success' },
     ];
-    expect(res.statusCode).toEqual(200);
+    expect(res.statusCode).toEqual(201);
     expect(res.siteId).toEqual(expectedRes.siteId);
   });
 
@@ -94,7 +94,7 @@ describe('Employer Site Endpoints', () => {
     const expectedRes = [
       { siteId: 91, status: 'Success' },
     ];
-    expect(res.statusCode).toEqual(200);
+    expect(res.statusCode).toEqual(201);
     expect(res.siteId).toEqual(expectedRes.siteId);
 
     const dupeRes = await saveSingleSite(singleSite);

--- a/server/validation.js
+++ b/server/validation.js
@@ -384,7 +384,27 @@ const ParticipantEditSchema = yup.object().noUnknown('Unknown field in entry').s
   id: yup.number().required('User ID is required'),
 });
 
-const EditSiteSchema = yup.object().shape({
+const CreateSiteSchema = yup.object().noUnknown('Unknown field in entry').shape({
+  siteId: yup.number().required('Site ID is required'),
+  siteName: yup.string().required(errorMessage),
+  phaseOneAllocation: yup.number().nullable().test('validate-blank-or-number', 'Must be a positive number', validateBlankOrPositiveInteger),
+  address: yup.string().nullable(),
+  city: yup.string().nullable(),
+  healthAuthority: yup.string().required(errorMessage).oneOf(healthRegions, 'Invalid region'),
+  postalCode: yup.string().required(errorMessage).matches(/^[A-Z]\d[A-Z]\s?\d[A-Z]\d$/, 'Format as A1A 1A1'),
+  registeredBusinessName: yup.string().nullable(),
+  operatorName: yup.string().nullable(),
+  operatorContactFirstName: yup.string().nullable(),
+  operatorContactLastName: yup.string().nullable(),
+  operatorEmail: yup.string().nullable().email('Invalid email address'),
+  operatorPhone: yup.string().nullable().matches(/^([0-9]{10})?$/, 'Phone number must be provided as 10 digits'),
+  siteContactFirstName: yup.string().nullable(),
+  siteContactLastName: yup.string().nullable(),
+  siteContactPhone: yup.string().nullable().matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
+  siteContactEmail: yup.string().nullable().email('Invalid email address'),
+});
+
+const EditSiteSchema = yup.object().noUnknown('Unknown field in entry').shape({
   siteContactFirstName: yup.string().required(errorMessage),
   siteContactLastName: yup.string().required(errorMessage),
   siteContactPhone: yup.string().required(errorMessage).matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
@@ -417,5 +437,6 @@ module.exports = {
   ParticipantQuerySchema,
   ParticipantEditSchema,
   EmployerSiteBatchSchema,
+  CreateSiteSchema,
   EditSiteSchema,
 };


### PR DESCRIPTION
- Discovered nothing was using the existing sites POST endpoint - all our scripts to create sites go directly via the DB using saveSites in employers.js
- Repurposed the existing endpoint to be a single site POST endpoint, limited to MOH and with new validation
- The main validation difference between POST/PATCH is that single site POST requires Site ID, and also supports Operator Name - these are both already supported in the batch DB operation (which has its own validation as well)

Incidentally this is how I'm noticing we forgot to put the Operator Name in the single site view FE. 🙃 

Other cleanup:
- Split the employer form (EEOI) tests vs. site tests into separate files
- Added new tests for single site POST