### PR TITLE
www. is now a valid subdomain for redirection

### DIFF
--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -1,7 +1,8 @@
+/* eslint-disable no-useless-escape */
 export default Object.freeze({
   // Hostname
-  ParticipantHostname: 'hcapparticipants.*',
-  EmployerHostname: 'hcapemployers.*',
+  ParticipantHostname: RegExp('^(www\.)?hcapparticipants\..*'),
+  EmployerHostname: RegExp('^(www\.)?hcapemployers\..*'),
 
   // Public routes
   Login: '/login',

--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -1,7 +1,6 @@
-/* eslint-disable no-useless-escape */
 export default Object.freeze({
   // Hostname
-  ParticipantHostname: RegExp('^(www\.)?hcapparticipants\..*'),
+  ParticipantHostname: RegExp('^(www\\.)?hcapparticipants\\..*'),
   EmployerHostname: RegExp('^(www\\.)?hcapemployers\\..*'),
 
   // Public routes

--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -2,7 +2,7 @@
 export default Object.freeze({
   // Hostname
   ParticipantHostname: RegExp('^(www\.)?hcapparticipants\..*'),
-  EmployerHostname: RegExp('^(www\.)?hcapemployers\..*'),
+  EmployerHostname: RegExp('^(www\\.)?hcapemployers\\..*'),
 
   // Public routes
   Login: '/login',

--- a/client/src/routes/index.js
+++ b/client/src/routes/index.js
@@ -2,7 +2,6 @@ import React, { Suspense, lazy, useEffect, useState } from 'react';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { useKeycloak, KeycloakProvider } from '@react-keycloak/web';
-import { matchRuleShort } from '../utils';
 import store from 'store';
 import Keycloak from 'keycloak-js';
 
@@ -47,8 +46,10 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
   );
 };
 
-const RootUrlSwitch = ({ rootUrl, children }) =>
-  matchRuleShort(window.location.hostname, rootUrl) && <Switch>{children}</Switch>;
+// This function will either return a Switch for its child components or
+// nothing, depending on whether the hostname matches the passed regex
+const RootUrlSwitch = ({ rootUrlRegExp, children }) =>
+  rootUrlRegExp.test(window.location.hostname) && <Switch>{children}</Switch>;
 
 export default () => {
   const [keycloakInfo, setKeycloakInfo] = useState();
@@ -96,7 +97,7 @@ export default () => {
     >
       <BrowserRouter>
         <Suspense fallback={<LinearProgress />}>
-          <RootUrlSwitch rootUrl={Routes.ParticipantHostname}>
+          <RootUrlSwitch rootUrlRegExp={Routes.ParticipantHostname}>
             <Route
               exact
               path={Routes.ParticipantConfirmation}
@@ -105,7 +106,7 @@ export default () => {
             <Route exact path={Routes.Base} component={ParticipantForm} />
             <Redirect to={Routes.Base} />
           </RootUrlSwitch>
-          <RootUrlSwitch rootUrl={Routes.EmployerHostname}>
+          <RootUrlSwitch rootUrlRegExp={Routes.EmployerHostname}>
             <Route exact path={Routes.Login} component={Login} />
             <Route exact path={Routes.Keycloak} component={KeycloakRedirect} />
             <PrivateRoute exact path={Routes.Admin} component={Admin} />

--- a/client/src/utils/misc.js
+++ b/client/src/utils/misc.js
@@ -1,5 +1,1 @@
 export const scrollUp = () => window.scrollTo({ top: 0, behavior: 'smooth' });
-export const matchRuleShort = (str, rule) => {
-  const escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1');
-  return new RegExp('^' + rule.split('*').map(escapeRegex).join('.*') + '$').test(str);
-};


### PR DESCRIPTION
Simplified the logic behind how URL matching is performed. 

Resolving the 'invalid parameter: redirect_uri' involved altering one of the client values in keycloak to a wildcard match, which may need to be specified further in the case of non-local deployments.

We could also use a more intricate regex to match all of the hostnames for dev, test, and prod as well but brain hurt.