### PR TITLE
CHES auto reauthorization

### DIFF
--- a/server/scripts/sendEmailBlast.js
+++ b/server/scripts/sendEmailBlast.js
@@ -148,6 +148,15 @@ async function blast(start, end, batch) {
   );
 }
 
+const writeFailedSends = (failures) => {
+  console.log(`There were ${failures.length} failed sends.`);
+  if (failures.length === 0) return;
+  const timestamp = new Date().toJSON();
+  const failureJson = JSON.stringify(failures);
+  console.log(failures);
+  writeFileSync(path.join(__dirname, `failed_ches_sends-${timestamp}.json`), failureJson);
+};
+
 (async function emailBlast() {
   const arglength = process.argv.length;
   const mode = arglength > 2 ? process.argv[2] : 'default';
@@ -157,16 +166,12 @@ async function blast(start, end, batch) {
   switch (mode) {
     case 'all':
       await blast(0, -1, 100);
-      console.log(`There were ${failedSends.length} failed sends.`);
-      console.log(JSON.stringify(failedSends));
-      writeFileSync(path.join(__dirname, 'failed_ches_sends.json'), JSON.stringify(failedSends));
+      writeFailedSends(failedSends);
       break;
     case 'index':
       console.log(start, end, batch);
       await blast(start, end, batch);
-      console.log(`There were ${failedSends.length} failed sends.`);
-      console.log(JSON.stringify(failedSends));
-      writeFileSync(path.join(__dirname, 'failed_ches_sends.json'), JSON.stringify(failedSends));
+      writeFailedSends(failedSends);
       break;
     case 'count':
       console.log((await countEmails())[0].count);

--- a/server/scripts/sendEmailBlast.js
+++ b/server/scripts/sendEmailBlast.js
@@ -85,11 +85,11 @@ async function countEmails() {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function sendEmail(email, otp, index, conf) {
+async function sendEmail(email, otp, conf) {
   try {
     await axios.post(`${CHES_HOST}/api/v1/email`, createPayload(email, otp), conf);
   } catch (e) {
-    failedSends.push(index);
+    failedSends.push(otp);
     console.log(e.response?.data || e.response || e);
   }
 }
@@ -117,9 +117,7 @@ async function blastRecursive(start, end, max, batch, chesConfiguration) {
     }
   }
 
-  const promiseArr = emails.map((res, index) =>
-    sendEmail(res.email_address, res.otp, index + start, chesConfiguration)
-  );
+  const promiseArr = emails.map((res) => sendEmail(res.email_address, res.otp, chesConfiguration));
   Promise.all(promiseArr);
   await sleep((batch / MAIL_RATE) * 1000);
   const batchTime = (new Date() - now) / 1000;

--- a/server/scripts/sendEmailBlast.js
+++ b/server/scripts/sendEmailBlast.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
 require('dotenv').config({ path: '../.env' });
 const axios = require('axios');
+const path = require('path');
+const { writeFileSync } = require('fs');
 const { dbClient } = require('../db/db');
 
 const Reset = '\x1b[0m';
@@ -156,13 +158,15 @@ async function blast(start, end, batch) {
     case 'all':
       await blast(0, -1, 100);
       console.log(`There were ${failedSends.length} failed sends.`);
-      console.log(failedSends);
+      console.log(JSON.stringify(failedSends));
+      writeFileSync(path.join(__dirname, 'failed_ches_sends.json'), JSON.stringify(failedSends));
       break;
     case 'index':
       console.log(start, end, batch);
       await blast(start, end, batch);
       console.log(`There were ${failedSends.length} failed sends.`);
-      console.log(failedSends);
+      console.log(JSON.stringify(failedSends));
+      writeFileSync(path.join(__dirname, 'failed_ches_sends.json'), JSON.stringify(failedSends));
       break;
     case 'count':
       console.log((await countEmails())[0].count);

--- a/server/scripts/sendEmailBlast.js
+++ b/server/scripts/sendEmailBlast.js
@@ -98,7 +98,7 @@ async function updateToken() {
   config.headers.authorization = `Bearer ${await authenticateChes()}`;
 }
 
-async function blastRecursive(start, end, max, batch, chesConfirguration) {
+async function blastRecursive(start, end, max, batch, chesConfiguration) {
   const now = new Date();
   if (start >= max || (start >= end && end !== -1)) {
     return true;
@@ -106,7 +106,7 @@ async function blastRecursive(start, end, max, batch, chesConfirguration) {
   const emails = await getEmailBlock(start, batch);
   // test the token
   try {
-    await axios.get(`${CHES_HOST}/api/v1/health`, chesConfirguration);
+    await axios.get(`${CHES_HOST}/api/v1/health`, chesConfiguration);
   } catch (e) {
     if (e?.response?.data === 'Access denied') {
       console.log('Token Expired, Reauthorizing...');
@@ -118,7 +118,7 @@ async function blastRecursive(start, end, max, batch, chesConfirguration) {
   }
 
   const promiseArr = emails.map((res, index) =>
-    sendEmail(res.email_address, res.otp, index + start, chesConfirguration)
+    sendEmail(res.email_address, res.otp, index + start, chesConfiguration)
   );
   Promise.all(promiseArr);
   await sleep((batch / MAIL_RATE) * 1000);
@@ -130,7 +130,7 @@ async function blastRecursive(start, end, max, batch, chesConfirguration) {
       1
     )}${Reset}/s`
   );
-  return blastRecursive(start + batch, end, max, batch, chesConfirguration);
+  return blastRecursive(start + batch, end, max, batch, chesConfiguration);
 }
 
 async function blast(start, end, batch) {


### PR DESCRIPTION
Sends a test request to the health endpoint and if it fails it updates the token, this will save us from having to batch the emails (if we decide we don't want to)

Sample output: 

![image](https://user-images.githubusercontent.com/71518072/119740869-e0498b80-be41-11eb-87dd-227e7af6c312.png)
```
Blasting 9 emails...
Sent 0 to 1: 60.18s, 0.0/s
Sent 1 to 2: 60.19s, 0.0/s
Sent 2 to 3: 60.20s, 0.0/s
Sent 3 to 4: 60.19s, 0.0/s
Sent 4 to 5: 60.20s, 0.0/s
Token Expired, Reauthorizing...
Success, Token Reauthorized!
Sent 5 to 6: 60.22s, 0.0/s
Sent 6 to 7: 60.14s, 0.0/s
Sent 7 to 8: 60.13s, 0.0/s
Sent 8 to 9: 60.12s, 0.0/s
Sent 9 emails in 541.57s at a rate of 0.02
There were 0 failed sends.
[]
Process complete
```