### PR TITLE
Email blast v2

### DIFF
--- a/server/migrations/1622565479621_update-otp-table.js
+++ b/server/migrations/1622565479621_update-otp-table.js
@@ -1,0 +1,9 @@
+/* eslint-disable camelcase */
+const { dbClient, collections } = require('../db');
+
+exports.up = () => {
+  dbClient.db.query(`
+    ALTER TABLE ${collections.CONFIRM_INTEREST}
+    ADD COLUMN email_sent BOOLEAN NOT NULL DEFAULT FALSE;
+  `);
+};

--- a/server/scripts/sendEmailBlast.js
+++ b/server/scripts/sendEmailBlast.js
@@ -7,6 +7,7 @@ const readline = require('readline');
 const { dbClient } = require('../db/db');
 const logger = require('../logger.js');
 
+// https://stackoverflow.com/a/40560590
 const colours = {
   reset: '\x1b[0m',
   fg: {

--- a/server/scripts/sendEmailBlast.js
+++ b/server/scripts/sendEmailBlast.js
@@ -53,7 +53,7 @@ function createPayload(recipient, uuid) {
   `);
 
   return {
-    from: 'noreply@hcapparticipants.gov.bc.ca',
+    from: 'noreply@gov.bc.ca',
     to: [recipient],
     subject: 'Health Career Access Program (HCAP) Participation',
     bodyType: 'html',
@@ -61,14 +61,20 @@ function createPayload(recipient, uuid) {
       <body>
         <h2>Are you still interested in the Health Career Access Program?</h2>
         <br />
-        <p>If you would still like to participate in the program,
-          <br />
-          please confirm your interest by clicking on the link below. Clicking on the link will reconfirm your interest in the program to ensure you remain visible to eligible employers.
+        <p>
+          If you would still like to participate in the program, please confirm your interest by clicking on the link below.
+          Clicking on the link will reconfirm your interest in the program to ensure you remain visible to eligible employers.
         </p>
         <a href="${`${process.env.CLIENT_URL}/confirm-interest?id=${uuid}`}" rel="noopener" target="_blank">
           Confirm Interest
         </a> <span>(${process.env.CLIENT_URL}/confirm-interest?id=${uuid})</span>
         <br />
+        <p>
+          There are still communities with high opportunities in HCAP, which are listed on the website
+          <a href="https://www2.gov.bc.ca/gov/content/covid-19/economic-recovery/work-in-health-care" rel="noopener" target="_blank">
+            here.
+          </a> <span>(https://www2.gov.bc.ca/gov/content/covid-19/economic-recovery/work-in-health-care)</span>
+        </p>
         <p>If you no longer wish to participate or be considered for the Health Career Access Program, please email us with the subject line WITHDRAW to <b>HCAPInfoQuery@gov.bc.ca</b> or or click the link below.</p>
         <a href="mailto:HCAPInfoQuery@gov.bc.ca?subject=${withdrawEmailSubject}&body=${withdrawEmailBody}">
           Withdraw from HCAP

--- a/server/scripts/sendEmailBlast.js
+++ b/server/scripts/sendEmailBlast.js
@@ -143,12 +143,12 @@ const serialSend = async (emails, retryDelay, retryLimit, mailRate) => {
           `ID: ${email.otp}`,
         ];
         printProgress(data.join('\t'));
-        // exit loop
         if (retryCounter > 0) {
           printProgress(
             `${colours.fg.green}Retry Success on ${colours.reset}${email.email_address}\n`
           );
         }
+        // exit loop
         sent = true;
       } catch (error) {
         // catch token expiration

--- a/server/scripts/sendEmailBlast.js
+++ b/server/scripts/sendEmailBlast.js
@@ -18,6 +18,7 @@ const colours = {
   },
 };
 
+const DAILY_MAIL_LIMIT = 10000;
 const CHES_HOST = process.env.CHES_HOST || 'https://ches-dev.apps.silver.devops.gov.bc.ca';
 const CHES_AUTH_URL =
   process.env.CHES_AUTH_URL ||
@@ -216,14 +217,15 @@ function askQuestion(query, defaultValue) {
   const mailRate = await askQuestion('Max Rate', 15);
   const retryDelay = await askQuestion('Retry Delay (ms)', 10000);
   const retryLimit = await askQuestion('Retry Limit', 10);
-  const mailLimit = await askQuestion('Total Mail Limit', 10000);
+  let mailLimit = await askQuestion('Total Mail Limit', DAILY_MAIL_LIMIT);
 
   /**
    * CHES Daily Limit = 10,000
    * https://github.com/bcgov/common-hosted-email-service/wiki/Best-Practices#rate-limits
    */
-  if (mailLimit > 10000) {
+  if (mailLimit > DAILY_MAIL_LIMIT) {
     console.log(`${colours.fg.red}Defaulting to 10,000 emails.${colours.reset}`);
+    mailLimit = DAILY_MAIL_LIMIT;
   }
 
   const emails = await getEmails(mailLimit);


### PR DESCRIPTION
Serial email sending, better UX, logging to mongo on hard failures

Script takes rate, retry limit, and retry delay as input

If an email fails `retryLimit` times, it's logged to mongo and skipped

![image](https://user-images.githubusercontent.com/71518072/120022360-8c59b680-bfa9-11eb-9c69-bace4393f4fa.png)
