### PR TITLE
Confirm interest Logic update

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -191,7 +191,6 @@ app.get(
   asyncMiddleware(async (req, res) => {
     const confirmationId = req.query.id;
     const isValid = uuidValidate(confirmationId) && (await validateConfirmationId(confirmationId));
-
     if (isValid) {
       return res.status(200).send();
     }

--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -1,4 +1,3 @@
-const dayjs = require('dayjs');
 const readXlsxFile = require('node-xlsx').default;
 const { validate, ParticipantBatchSchema, isBooleanValue } = require('../validation.js');
 const { dbClient, collections } = require('../db');

--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -130,7 +130,7 @@ const validateConfirmationId = (id) =>
 
 const confirmParticipantInterest = async (id) => {
   const now = new Date().toJSON();
-
+  // Check to see if there are any matching records that have not withdrawn.
   const relatedParticipants = await dbClient.db[collections.PARTICIPANTS]
     .join({
       [collections.CONFIRM_INTEREST]: {
@@ -161,29 +161,30 @@ const confirmParticipantInterest = async (id) => {
         to: now,
         from: participant.body.userUpdatedAt,
         field: 'userUpdatedAt',
-      }
-    ]
-    if(participant.interested !=='yes'){
+      },
+    ];
+    if (participant.interested !== 'yes') {
       changes.push({
-        to:'yes',
-        from:participant.interested,
-        field:'interested'
-      })
+        to: 'yes',
+        from: participant.interested,
+        field: 'interested',
+      });
     }
     return {
-    id: participant.id,
-    userUpdatedAt: now,
-    interested: 'yes',
-    history: [
-      {
-        changes,
-        timestamp: now,
-        reason: 'Reconfirm Interest',
-      },
-      ...(participant.body.history ? participant.body.history : []),
-    ],
-  }
-});
+      id: participant.id,
+      userUpdatedAt: now,
+      interested: 'yes',
+      history: [
+        {
+          changes,
+          timestamp: now,
+          reason: 'Reconfirm Interest',
+        },
+        ...(participant.body.history ? participant.body.history : []),
+      ],
+    };
+  });
+  console.log(updatedParticipantFields);
   await Promise.all(
     updatedParticipantFields.map(({ id: participantId, ...fields }) => {
       const result = dbClient.db[collections.PARTICIPANTS].updateDoc({ id: participantId }, fields);
@@ -191,7 +192,7 @@ const confirmParticipantInterest = async (id) => {
     })
   );
   const deleted = await dbClient.db[collections.CONFIRM_INTEREST].destroy({ otp: id });
-  // Fail if the OTP didn't exist or if the list of participants 
+  // Fail if the OTP didn't exist or if the list of participants
   return deleted.length > 0 && updatedParticipantFields.length > 0;
 };
 

--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -150,11 +150,16 @@ const confirmParticipantInterest = async (id) => {
     .find({
       status: 'hired',
     });
-  const unhiredRelatedParticipants = relatedParticipants.filter(
-    (related) => !hiredParticipants.find((hired) => hired.id === related.id)
-  );
 
-  const updatedParticipantFields = unhiredRelatedParticipants.map((participant) => {
+  const hiredRelatedParticipants = relatedParticipants.filter((related) =>
+    hiredParticipants.find((hired) => hired.id === related.id)
+  );
+  // Return false if any of the related participants is hired
+  if (hiredRelatedParticipants.length > 0) {
+    return false;
+  }
+
+  const updatedParticipantFields = relatedParticipants.map((participant) => {
     const changes = [
       {
         to: now,

--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -184,7 +184,6 @@ const confirmParticipantInterest = async (id) => {
       ],
     };
   });
-  console.log(updatedParticipantFields);
   await Promise.all(
     updatedParticipantFields.map(({ id: participantId, ...fields }) => {
       const result = dbClient.db[collections.PARTICIPANTS].updateDoc({ id: participantId }, fields);


### PR DESCRIPTION
* fixed issue where the confirm-interest submit route was checking only records that had not been updated in the past 6 weeks. 
* Fixed issue where the change to the interested column is changed without logging the change. 
* Will now fail if no otp is deleted or no rows were updated. 

https://freshworks.atlassian.net/browse/HCAP-610