### PR TITLE
Use state to determine columns (HCAP-660 #3)

### DIFF
--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -68,6 +68,26 @@ export const defaultTableState = {
   siteSelector: '',
 };
 
+export const tabStatuses = {
+  'Available Participants': ['open'],
+  'My Candidates': ['prospecting', 'interviewing', 'offer_made', 'unavailable'],
+  'Archived Candidates': ['rejected'],
+  'Hired Candidates': ['hired'],
+  Participants: ['open', 'prospecting', 'interviewing', 'offer_made', 'rejected', 'hired'],
+};
+
+export const tabsByRole = {
+  superuser: ['Participants'],
+  ministry_of_health: ['Participants'],
+  health_authority: [
+    'Available Participants',
+    'My Candidates',
+    'Archived Candidates',
+    'Hired Candidates',
+  ],
+  employer: ['Available Participants', 'My Candidates', 'Archived Candidates', 'Hired Candidates'],
+};
+
 const columns = {
   id: { id: 'id', name: 'ID', sortOrder: 1 },
   lastName: { id: 'lastName', name: 'Last Name', sortOrder: 2 },

--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -1,37 +1,6 @@
 import ToastStatus from './toast';
 export const pageSize = 10;
 
-export const defaultColumns = [
-  { id: 'id', name: 'ID' },
-  { id: 'lastName', name: 'Last Name' },
-  { id: 'firstName', name: 'First Name' },
-  { id: 'postalCodeFsa', name: 'FSA' },
-  { id: 'preferredLocation', name: 'Preferred Region(s)' },
-  { id: 'nonHCAP', name: 'Non-HCAP' },
-  { id: 'userUpdatedAt', name: 'Last Updated' },
-  { id: 'callbackStatus', name: 'Callback Status' },
-];
-
-export const sortOrder = [
-  'id',
-  'lastName',
-  'firstName',
-  'status',
-  'statusInfo',
-  'postalCodeFsa',
-  'phoneNumber',
-  'emailAddress',
-  'preferredLocation',
-  'distance',
-  'interested',
-  'nonHCAP',
-  'crcClear',
-  'callbackStatus',
-  'userUpdatedAt',
-  'engage',
-  'edit',
-];
-
 export const tabs = {
   // Tabs, associated allowed roles, displayed statuses
   'Available Participants': {

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -74,10 +74,10 @@ const reducer = (state, action) => {
   switch (type) {
     // Add pagination to a key update
     case 'updateKeyWithPagination':
-      newstate.pagination = (prev) => ({
-        ...prev,
+      newstate.pagination = {
+        ...newstate,
         currentPage: 0,
-      });
+      };
       newstate[key] = value;
       return newstate;
     // Update any key in state with the corresponding value

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useReducer, useState } from 'react';
+import React, { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import Grid from '@material-ui/core/Grid';
 import { withStyles } from '@material-ui/core/styles';
 import Tabs from '@material-ui/core/Tabs';
@@ -36,6 +36,40 @@ import { DebounceTextField } from '../../components/generic/DebounceTextField';
 import { getDialogTitle, prettifyStatus } from '../../utils';
 import moment from 'moment';
 import { AuthContext } from '../../providers';
+let renderCount = 0;
+
+const usePrevious = (value, initialValue) => {
+  const ref = useRef(initialValue);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+const useEffectDebugger = (effectHook, dependencies, dependencyNames = []) => {
+  const previousDeps = usePrevious(dependencies, []);
+
+  const changedDeps = dependencies.reduce((accum, dependency, index) => {
+    if (dependency !== previousDeps[index]) {
+      const keyName = dependencyNames[index] || index;
+      return {
+        ...accum,
+        [keyName]: {
+          before: previousDeps[index],
+          after: dependency,
+        },
+      };
+    }
+
+    return accum;
+  }, {});
+
+  if (Object.keys(changedDeps).length) {
+    console.log('[use-effect-debugger] ', changedDeps);
+  }
+
+  useEffect(effectHook, dependencies);
+};
 
 const CustomTabs = withStyles((theme) => ({
   root: {
@@ -320,7 +354,7 @@ export default () => {
     setLoadingData(false);
   };
 
-  useEffect(() => {
+  useEffectDebugger(() => {
     const resultColumns = [...defaultColumns];
     const currentPage = reducerState.pagination?.currentPage || 0;
     const fetchUserInfo = async () => {
@@ -521,6 +555,8 @@ export default () => {
     return row[columnId];
   };
 
+  renderCount += 1;
+  console.log(`ParticipantTable. renderCount: `, renderCount);
   return (
     <>
       <Dialog

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -172,7 +172,11 @@ export default () => {
   const sites = useMemo(() => auth.user?.sites || [], [auth.user?.sites]);
   let hasWithdrawnParticipant = false;
 
-  const [reducerState, dispatch] = useReducer(reducer, defaultTableState);
+  const [reducerState, dispatch] = useReducer(reducer, {
+    ...defaultTableState,
+    tabValue: Object.keys(tabs) // Set selected tab to first tab allowed for role
+      .find((key) => tabs[key].roles.some((role) => roles.includes(role))),
+  });
   const filterData = (data, columns) => {
     hasWithdrawnParticipant = false;
     const mapItemToColumns = (item, columns) => {
@@ -357,14 +361,6 @@ export default () => {
   useEffectDebugger(() => {
     const resultColumns = [...defaultColumns];
     const currentPage = reducerState.pagination?.currentPage || 0;
-    if (!reducerState.tabValue) {
-      dispatch({
-        type: 'updateKeyWithPagination',
-        key: 'tabValue',
-        value: Object.keys(tabs) // Set selected tab to first tab allowed for role
-          .find((key) => tabs[key].roles.some((role) => roles.includes(role))),
-      });
-    }
     const isMoH = roles.includes('ministry_of_health');
     const isSuperUser = roles.includes('superuser');
     if (isMoH || isSuperUser) {

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -16,7 +16,6 @@ import {
   regionLabelsMap,
   API_URL,
   pageSize,
-  tabs,
   makeToasts,
   defaultTableState,
 } from '../../constants';
@@ -183,19 +182,14 @@ export default () => {
   const [activeModalForm, setActiveModalForm] = useState(null);
   const [locations, setLocations] = useState([]);
   const {
-    state: { columns },
+    state: { columns, tabs, selectedTab, selectedTabStatuses },
     dispatch: participantsDispatch,
   } = ParticipantsContext.useParticipantsContext();
   const { auth } = AuthContext.useAuth();
-  const permissionRole = auth.permissionRole;
   const roles = useMemo(() => auth.user?.roles || [], [auth.user?.roles]);
   const sites = useMemo(() => auth.user?.sites || [], [auth.user?.sites]);
 
-  const [reducerState, dispatch] = useReducer(reducer, {
-    ...defaultTableState,
-    tabValue: Object.keys(tabs) // Set selected tab to first tab allowed for role
-      .find((key) => tabs[key].roles.some((role) => roles.includes(role))),
-  });
+  const [reducerState, dispatch] = useReducer(reducer, defaultTableState);
 
   const fetchParticipants = async (
     offset,
@@ -295,7 +289,7 @@ export default () => {
 
   const forceReload = async () => {
     if (!columns) return;
-    if (!reducerState.tabValue) return;
+    if (!selectedTab) return;
     const currentPage = reducerState.pagination?.currentPage || 0;
     setLoadingData(true);
     const { data, pagination } = await fetchParticipants(
@@ -307,7 +301,7 @@ export default () => {
       reducerState.order.field,
       reducerState.order.direction,
       reducerState.siteSelector,
-      tabs[reducerState.tabValue].statuses
+      selectedTabStatuses
     );
     dispatch({
       type: 'updateKey',
@@ -324,12 +318,11 @@ export default () => {
 
   useEffect(() => {
     setHideLastNameAndEmailFilter(
-      ['Available Participants', 'Archived Candidates'].includes(reducerState.tabValue)
+      ['Available Participants', 'Archived Candidates'].includes(selectedTab)
     );
-  }, [reducerState.tabValue]);
+  }, [selectedTab]);
 
   useEffect(() => {
-    const currentPage = reducerState.pagination?.currentPage || 0;
     const isMoH = roles.includes('ministry_of_health');
     const isSuperUser = roles.includes('superuser');
 
@@ -338,15 +331,13 @@ export default () => {
     setLocations(
       isMoH || isSuperUser ? regions : roles.map((loc) => regionLabelsMap[loc]).filter(Boolean)
     );
+  }, [roles]);
 
-    participantsDispatch({
-      type: ParticipantsContext.types.CHANGE_COLUMNS,
-      payload: { role: permissionRole, tab: reducerState.tabValue },
-    });
-
+  useEffect(() => {
     const getParticipants = async () => {
+      const currentPage = reducerState.pagination?.currentPage || 0;
       if (!columns) return;
-      if (!reducerState.tabValue) return;
+      if (!selectedTab) return;
       setLoadingData(true);
       const { data, pagination } = await fetchParticipants(
         currentPage * pageSize,
@@ -357,7 +348,7 @@ export default () => {
         reducerState.order.field,
         reducerState.order.direction,
         reducerState.siteSelector,
-        tabs[reducerState.tabValue].statuses
+        selectedTabStatuses
       );
       dispatch({
         type: 'updateKey',
@@ -381,11 +372,10 @@ export default () => {
     reducerState.lastNameFilter,
     reducerState.fsaFilter,
     reducerState.order,
-    reducerState.tabValue,
     roles,
     columns,
-    participantsDispatch,
-    permissionRole,
+    selectedTab,
+    selectedTabStatuses,
   ]);
 
   const defaultOnClose = () => {
@@ -398,7 +388,7 @@ export default () => {
       return row[columnId] ? 'Primed' : 'Available';
     }
     if (columnId === 'status') {
-      return prettifyStatus(row[columnId], row.id, reducerState.tabValue, handleEngage);
+      return prettifyStatus(row[columnId], row.id, selectedTab, handleEngage);
     }
     if (columnId === 'distance') {
       if (row[columnId] !== null && row[columnId] !== undefined) {
@@ -757,7 +747,7 @@ export default () => {
                 </Box>
               </Grid>
             )}
-            {reducerState.tabValue === 'Hired Candidates' && (
+            {selectedTab === 'Hired Candidates' && (
               <Grid container item xs={2} style={{ marginLeft: 'auto', marginRight: 20 }}>
                 <Button
                   onClick={() => setActiveModalForm('new-participant')}
@@ -769,17 +759,18 @@ export default () => {
           </Grid>
           <Box pt={2} pb={2} pl={2} pr={2} width='100%'>
             <CustomTabs
-              value={reducerState.tabValue || false}
-              onChange={(event, property) =>
-                dispatch({ type: 'updateKeyWithPagination', key: 'tabValue', value: property })
+              value={selectedTab || false}
+              onChange={(_, property) =>
+                participantsDispatch({
+                  type: ParticipantsContext.types.SELECT_TAB,
+                  payload: property,
+                })
               }
             >
               {
-                Object.keys(tabs)
-                  .filter((key) => roles.some((role) => tabs[key].roles.includes(role))) // Only display tabs for user role
-                  .map((key) => (
-                    <CustomTab key={key} label={key} value={key} disabled={isLoadingData} />
-                  )) // Tab component with tab name as value
+                tabs.map((key) => (
+                  <CustomTab key={key} label={key} value={key} disabled={isLoadingData} />
+                )) // Tab component with tab name as value
               }
             </CustomTabs>
             <Table

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -359,10 +359,18 @@ export default () => {
   };
 
   useEffectDebugger(() => {
-    const resultColumns = [...defaultColumns];
     const currentPage = reducerState.pagination?.currentPage || 0;
     const isMoH = roles.includes('ministry_of_health');
     const isSuperUser = roles.includes('superuser');
+
+    // Either returns all location roles or a role mapping with a Boolean filter removes all undefined values
+    const regions = Object.values(regionLabelsMap).filter((value) => value !== 'None');
+    setLocations(
+      isMoH || isSuperUser ? regions : roles.map((loc) => regionLabelsMap[loc]).filter(Boolean)
+    );
+
+    const resultColumns = [...defaultColumns];
+
     if (isMoH || isSuperUser) {
       resultColumns.push(
         { id: 'interested', name: 'Interest' },
@@ -371,12 +379,6 @@ export default () => {
         { id: 'edit' }
       );
     }
-
-    // Either returns all location roles or a role mapping with a Boolean filter removes all undefined values
-    const regions = Object.values(regionLabelsMap).filter((value) => value !== 'None');
-    setLocations(
-      isMoH || isSuperUser ? regions : roles.map((loc) => regionLabelsMap[loc]).filter(Boolean)
-    );
 
     if (!isMoH) {
       resultColumns.push(

--- a/client/src/pages/private/ParticipantView.js
+++ b/client/src/pages/private/ParticipantView.js
@@ -4,7 +4,7 @@ import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import { withStyles } from '@material-ui/core/styles';
 import { Page, CheckPermissions } from '../../components/generic';
-import { AuthContext } from '../../providers';
+import { AuthContext, ParticipantsContext } from '../../providers';
 
 const ParticipantTable = lazy(() => import('./ParticipantTable'));
 const SiteTable = lazy(() => import('./SiteTable'));
@@ -65,7 +65,12 @@ export default () => {
           </CustomTabs>
         </Grid>
         <Grid container alignItems='center' justify='flex-start' direction='column'>
-          {tabValue === 0 && <ParticipantTable />}
+          {tabValue === 0 && (
+            <ParticipantsContext.ParticipantsProvider role={auth.permissionRole}>
+              <ParticipantTable />
+            </ParticipantsContext.ParticipantsProvider>
+          )}
+
           {tabValue === 1 && <SiteTable sites={sites} />}
         </Grid>
       </CheckPermissions>


### PR DESCRIPTION
This branch removes the complex logic and decisions that build the array of columns used in the table depending on the role and selected tab.

A previous PR introduced new data objects + context that we can use to lift up state and simplify logic across this component. 

https://freshworks.atlassian.net/browse/HCAP-660

- Rerenders on this component have been reduced from >20 to ~5 (still some work to do)
- UseEffect activations are down from ~6 to 2
- Unnecessary network calls have been prevented (participants are only fetched once)

#### Next Steps:
- Lift Tab state into context
- Add asynchronous actions to context for API requests
- Split components
- Lift rest of state (where it makes sense)