### PR TITLE
Fixed filter

### DIFF
--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -361,8 +361,8 @@ export const EditParticipantFormSchema = yup.object().shape({
   postalCode: yup
     .string()
     .required('Postal code is required')
-    .test('isnot-null', 'Postal code is required!', (v) =>{ 
-      return v!==undefined && v!=='' && v!==null 
+    .test('isnot-null', 'Postal code is required!', (v) => {
+      return v !== undefined && v !== '' && v !== null;
     })
     .matches(/^[A-Z]\d[A-Z]\s?\d[A-Z]\d$/, 'Invalid postal code'),
   emailAddress: yup.string().required(errorMessage).email('Invalid email address'),

--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -361,7 +361,9 @@ export const EditParticipantFormSchema = yup.object().shape({
   postalCode: yup
     .string()
     .required('Postal code is required')
-    .test('is-null', 'Postal code is required!', (v) => v != null && v != '')
+    .test('isnot-null', 'Postal code is required!', (v) =>{ 
+      return v!==undefined && v!=='' && v!==null 
+    })
     .matches(/^[A-Z]\d[A-Z]\s?\d[A-Z]\d$/, 'Invalid postal code'),
   emailAddress: yup.string().required(errorMessage).email('Invalid email address'),
   interested: yup.string().nullable(),

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -487,7 +487,9 @@ export default () => {
             });
 
             const participant = await response.json();
-
+            if(participant[0].postalCode===undefined){
+              participant[0].postalCode='';
+            }
             setActionMenuParticipant(participant[0]);
             setActiveModalForm('edit-participant');
             setAnchorElement(null);

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -487,8 +487,8 @@ export default () => {
             });
 
             const participant = await response.json();
-            if(participant[0].postalCode===undefined){
-              participant[0].postalCode='';
+            if (participant[0].postalCode === undefined) {
+              participant[0].postalCode = '';
             }
             setActionMenuParticipant(participant[0]);
             setActiveModalForm('edit-participant');


### PR DESCRIPTION
It turns out that for some reason, up doesn't display validation errors on fields that are undefined. 
Before the active participant is assigned, if the postalCode is undefined, I set it to the empty string so Yup has a value to check. 