### PR TITLE
HCAP-663 Pagination Performance

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -28,6 +28,7 @@
         "react-app-polyfill": "1.0.6",
         "react-dom": "16.13.1",
         "react-router-dom": "5.2.0",
+        "react-window": "1.8.6",
         "store": "2.0.12",
         "yup": "0.29.3"
       },
@@ -13111,6 +13112,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -16778,6 +16784,22 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
+      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/read-pkg": {
@@ -33450,6 +33472,11 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -36559,6 +36586,15 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-window": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.6.tgz",
+      "integrity": "sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-pkg": {

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "react-app-polyfill": "1.0.6",
     "react-dom": "16.13.1",
     "react-router-dom": "5.2.0",
+    "react-window": "1.8.6",
     "store": "2.0.12",
     "yup": "0.29.3"
   },

--- a/client/src/components/generic/Table.js
+++ b/client/src/components/generic/Table.js
@@ -1,4 +1,5 @@
 import React, { Fragment, useState } from 'react';
+import { FixedSizeList } from 'react-window';
 import MuiTable from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
@@ -96,6 +97,10 @@ const TablePaginationActions = (props) => {
     setAnchorEl(null);
   };
 
+  const menuMaxHeight = 400;
+  const menuItemCount = Math.ceil(count / rowsPerPage);
+  const menuItemSize = 45;
+
   return (
     <div className={classes.root}>
       <IconButton
@@ -140,16 +145,23 @@ const TablePaginationActions = (props) => {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
-        {/* This expression creates an array of integers 0..n */}
-        {[...Array(Math.ceil(count / rowsPerPage)).keys()].map((option) => (
-          <MenuItem
-            key={`page ${option}`}
-            selected={option === page}
-            onClick={(event) => handleMenuItemClick(event, option)}
-          >
-            Page {option + 1}
-          </MenuItem>
-        ))}
+        <FixedSizeList
+          height={Math.min(menuItemCount * menuItemSize, menuMaxHeight)}
+          width={120}
+          itemSize={menuItemSize}
+          itemCount={menuItemCount}
+        >
+          {({ index, style }) => (
+            <MenuItem
+              key={index}
+              style={style}
+              selected={index === page}
+              onClick={(event) => handleMenuItemClick(event, index)}
+            >
+              Page {index + 1}
+            </MenuItem>
+          )}
+        </FixedSizeList>
       </Menu>
     </div>
   );


### PR DESCRIPTION
The pagination component was rendering (total_participants / 10) elements every time the page loaded. I added react-window to virtualize this list to keep the same functionality while reducing the lag to practically 0

https://freshworks.atlassian.net/browse/HCAP-663

Reference: https://material-ui.com/components/lists/#virtualized-list