### PR TITLE
Lift Tab State (HCAP-660 #4)

### DIFF
--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -68,6 +68,25 @@ export const defaultTableState = {
   siteSelector: '',
 };
 
+export const tabStatuses = {
+  'Available Participants': ['open'],
+  'My Candidates': ['prospecting', 'interviewing', 'offer_made', 'unavailable'],
+  'Archived Candidates': ['rejected'],
+  'Hired Candidates': ['hired'],
+  Participants: ['open', 'prospecting', 'interviewing', 'offer_made', 'rejected', 'hired'],
+};
+
+export const tabsByRole = {
+  ministry_of_health: ['Participants'],
+  health_authority: [
+    'Available Participants',
+    'My Candidates',
+    'Archived Candidates',
+    'Hired Candidates',
+  ],
+  employer: ['Available Participants', 'My Candidates', 'Archived Candidates', 'Hired Candidates'],
+};
+
 const columns = {
   id: { id: 'id', name: 'ID', sortOrder: 1 },
   lastName: { id: 'lastName', name: 'Last Name', sortOrder: 2 },

--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -77,6 +77,7 @@ export const tabStatuses = {
 };
 
 export const tabsByRole = {
+  superuser: ['Participants'],
   ministry_of_health: ['Participants'],
   health_authority: [
     'Available Participants',

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -323,7 +323,6 @@ export default () => {
   }, [selectedTab]);
 
   useEffect(() => {
-    const currentPage = reducerState.pagination?.currentPage || 0;
     const isMoH = roles.includes('ministry_of_health');
     const isSuperUser = roles.includes('superuser');
 
@@ -332,8 +331,11 @@ export default () => {
     setLocations(
       isMoH || isSuperUser ? regions : roles.map((loc) => regionLabelsMap[loc]).filter(Boolean)
     );
+  }, [roles]);
 
+  useEffect(() => {
     const getParticipants = async () => {
+      const currentPage = reducerState.pagination?.currentPage || 0;
       if (!columns) return;
       if (!selectedTab) return;
       setLoadingData(true);

--- a/client/src/providers/ParticipantsContext.js
+++ b/client/src/providers/ParticipantsContext.js
@@ -14,24 +14,30 @@ const participantsReducer = (state, action) => {
   const { UPDATE_ROLE, SELECT_TAB } = types;
 
   switch (type) {
-    case UPDATE_ROLE:
+    case UPDATE_ROLE: {
       const tabs = tabsByRole[payload];
       const defaultTab = tabs[0];
       const columns = columnsByRole[payload][defaultTab];
       columns?.sort((a, b) => a.sortOrder - b.sortOrder);
       return {
         ...state,
+        role: payload,
         columns,
         tabs,
         selectedTab: defaultTab,
         selectedTabStatuses: tabStatuses[defaultTab],
       };
-    case SELECT_TAB:
+    }
+    case SELECT_TAB: {
+      const columns = columnsByRole[state.role][payload];
+      columns?.sort((a, b) => a.sortOrder - b.sortOrder);
       return {
         ...state,
+        columns,
         selectedTab: payload,
         selectedTabStatuses: tabStatuses[payload],
       };
+    }
     default:
       return state;
   }
@@ -43,7 +49,7 @@ const participantsReducer = (state, action) => {
 
 const ParticipantsProvider = ({ role, children }) => {
   const [state, dispatch] = useReducer(participantsReducer, {
-    role: null,
+    role,
     columns: null,
     tabs: null,
     selectedTab: null,

--- a/client/src/providers/ParticipantsContext.js
+++ b/client/src/providers/ParticipantsContext.js
@@ -1,24 +1,36 @@
-import React, { useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 
-import { columnsByRole } from '../constants/participantTableConstants';
+import { columnsByRole, tabStatuses, tabsByRole } from '../constants/participantTableConstants';
 
 const ParticipantsContext = React.createContext();
 
 const types = {
-  CHANGE_COLUMNS: 'CHANGE_COLUMNS',
+  UPDATE_ROLE: 'UPDATE_ROLE',
+  SELECT_TAB: 'SELECT_TAB',
 };
 
 const participantsReducer = (state, action) => {
   const { type, payload } = action;
-  const { CHANGE_COLUMNS } = types;
+  const { UPDATE_ROLE, SELECT_TAB } = types;
 
   switch (type) {
-    case CHANGE_COLUMNS:
-      const columns = columnsByRole?.[payload.role]?.[payload.tab];
+    case UPDATE_ROLE:
+      const tabs = tabsByRole[payload];
+      const defaultTab = tabs[0];
+      const columns = columnsByRole[payload][defaultTab];
       columns?.sort((a, b) => a.sortOrder - b.sortOrder);
       return {
-        user: payload,
+        ...state,
         columns,
+        tabs,
+        selectedTab: defaultTab,
+        selectedTabStatuses: tabStatuses[defaultTab],
+      };
+    case SELECT_TAB:
+      return {
+        ...state,
+        selectedTab: payload,
+        selectedTabStatuses: tabStatuses[payload],
       };
     default:
       return state;
@@ -29,10 +41,21 @@ const participantsReducer = (state, action) => {
  * For more: https://kentcdodds.com/blog/how-to-use-react-context-effectively
  */
 
-const ParticipantsProvider = ({ children }) => {
+const ParticipantsProvider = ({ role, children }) => {
   const [state, dispatch] = useReducer(participantsReducer, {
+    role: null,
     columns: null,
+    tabs: null,
+    selectedTab: null,
+    selectedTabStatuses: null,
   });
+
+  useEffect(() => {
+    dispatch({
+      type: types.UPDATE_ROLE,
+      payload: role,
+    });
+  }, [role]);
 
   const value = { state, dispatch };
 


### PR DESCRIPTION
Also simplified how participant context calculates state based on auth (it consumes the auth context and doesn't need to be updated from participantTable)

