### PR TITLE
V2.19 hotfixes

### DIFF
--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -19,8 +19,8 @@ const validatePastDateString = (s) => {
   return Date.parse(s) <= new Date();
 };
 const validateDateIsInThePast = (d) => {
-  return Date.parse(d) <= new Date()
-}
+  return Date.parse(d) <= new Date();
+};
 const validateUniqueArray = (a) => Array.isArray(a) && new Set(a).size === a.length;
 
 const validateBlankOrPositiveInteger = (n) =>
@@ -384,14 +384,13 @@ export const ArchiveHiredParticipantSchema = yup.object().shape({
     is: 'employmentEnded',
     then: yup.string().required('Please include a status').oneOf(archiveStatusOptions),
   }),
-  endDate: yup
-    .date()
-    .when('type', {
-      is:'employmentEnded',
-      then: yup.date()
-        .required('Please enter the date this participant was removed.')
-        .test('is-present', 'Invalid entry. Date must be in the past.', validateDateIsInThePast)
-    }),
+  endDate: yup.date().when('type', {
+    is: 'employmentEnded',
+    then: yup
+      .date()
+      .required('Please enter the date this participant was removed.')
+      .test('is-present', 'Invalid entry. Date must be in the past.', validateDateIsInThePast),
+  }),
   confirmed: yup.boolean().test('is-true', 'Please confirm', (v) => v === true),
 });
 

--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -18,7 +18,9 @@ const validatePastDateString = (s) => {
   if (!validateDateString(s)) return false;
   return Date.parse(s) <= new Date();
 };
-
+const validateDateIsInThePast = (d) => {
+  return Date.parse(d) <= new Date()
+}
 const validateUniqueArray = (a) => Array.isArray(a) && new Set(a).size === a.length;
 
 const validateBlankOrPositiveInteger = (n) =>
@@ -384,8 +386,12 @@ export const ArchiveHiredParticipantSchema = yup.object().shape({
   }),
   endDate: yup
     .date()
-    .required('Please enter the date this participant was removed.')
-    .test('is-present', 'Invalid entry. Date must be in the past.', validatePastDateString),
+    .when('type', {
+      is:'employmentEnded',
+      then: yup.date()
+        .required('Please enter the date this participant was removed.')
+        .test('is-present', 'Invalid entry. Date must be in the past.', validateDateIsInThePast)
+    }),
   confirmed: yup.boolean().test('is-true', 'Please confirm', (v) => v === true),
 });
 

--- a/server/validation.js
+++ b/server/validation.js
@@ -73,7 +73,6 @@ const validateDateString = (s) => {
 };
 
 const validatePastDateString = (s) => {
-  console.log(s)
   if (!validateDateString(s)) return false;
   return Date.parse(s) <= new Date();
 };
@@ -581,14 +580,17 @@ const ParticipantStatusChange = yup
             is: 'employmentEnded',
             then: yup.string().required('Please include a status').oneOf(archiveStatusOptions),
           }),
-          endDate: yup
-            .string()
-            .when('type',{
-              is:'employmentEnded',
-              then: yup.string()
-              .test('is-present', 'Invalid entry. Date must be in the past.', validatePastDateString)
+          endDate: yup.string().when('type', {
+            is: 'employmentEnded',
+            then: yup
+              .string()
+              .test(
+                'is-present',
+                'Invalid entry. Date must be in the past.',
+                validatePastDateString
+              )
               .required('Please enter the date this participant was removed.'),
-            }),
+          }),
           confirmed: yup.boolean().test('is-true', 'Please confirm', (v) => v === true),
         });
       }

--- a/server/validation.js
+++ b/server/validation.js
@@ -73,6 +73,7 @@ const validateDateString = (s) => {
 };
 
 const validatePastDateString = (s) => {
+  console.log(s)
   if (!validateDateString(s)) return false;
   return Date.parse(s) <= new Date();
 };
@@ -582,9 +583,12 @@ const ParticipantStatusChange = yup
           }),
           endDate: yup
             .string()
-            .test('is-date', 'Not a valid date', validateDateString)
-            .test('is-present', 'Invalid entry. Date must be in the past.', validatePastDateString)
-            .required('Please enter the date this participant was removed.'),
+            .when('type',{
+              is:'employmentEnded',
+              then: yup.string()
+              .test('is-present', 'Invalid entry. Date must be in the past.', validatePastDateString)
+              .required('Please enter the date this participant was removed.'),
+            }),
           confirmed: yup.boolean().test('is-true', 'Please confirm', (v) => v === true),
         });
       }


### PR DESCRIPTION
Updated validator to fix issues with endDate. 
The format of the string returned in certain circumstances did not match the expected pattern. 
Made endDate only validate when the type is "employmentEnded"