### PR TITLE
Hcap 696 final showdown

### DIFF
--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -21,7 +21,15 @@ export const tabs = {
   },
   Participants: {
     roles: ['ministry_of_health', 'superuser'],
-    statuses: ['open', 'prospecting', 'interviewing', 'offer_made','archived', 'rejected', 'hired'],
+    statuses: [
+      'open',
+      'prospecting',
+      'interviewing',
+      'offer_made',
+      'archived',
+      'rejected',
+      'hired',
+    ],
   },
 };
 

--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -21,7 +21,7 @@ export const tabs = {
   },
   Participants: {
     roles: ['ministry_of_health', 'superuser'],
-    statuses: ['open', 'prospecting', 'interviewing', 'offer_made', 'rejected', 'hired'],
+    statuses: ['open', 'prospecting', 'interviewing', 'offer_made','archived', 'rejected', 'hired'],
   },
 };
 

--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -1,6 +1,16 @@
 import ToastStatus from './toast';
 export const pageSize = 10;
 
+export const participantStatus = {
+  OPEN: 'open',
+  PROSPECTING: 'prospecting',
+  interviewing: 'interviewing',
+  OFFER_MAKDE: 'offer_made',
+  ARCHIVED: 'archived',
+  REJECTED: 'rejected',
+  HIRED: 'hired',
+};
+
 export const tabs = {
   // Tabs, associated allowed roles, displayed statuses
   'Available Participants': {

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -807,11 +807,20 @@ export default () => {
           <Box pt={2} pb={2} pl={2} pr={2} width='100%'>
             <CustomTabs
               value={selectedTab || false}
-              onChange={(_, property) =>
-                participantsDispatch({
-                  type: ParticipantsContext.types.SELECT_TAB,
-                  payload: property,
-                })
+              onChange={(_, property) =>{
+                  dispatch(
+                    {type:'updateKey',
+                    key:'pagination',value:{
+                      currentPage:0,
+                      offset:0,
+                      total:0
+                  }})
+                  participantsDispatch({
+                    type: ParticipantsContext.types.SELECT_TAB,
+                    payload: property,
+                  })
+
+                }
               }
             >
               {

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -807,21 +807,21 @@ export default () => {
           <Box pt={2} pb={2} pl={2} pr={2} width='100%'>
             <CustomTabs
               value={selectedTab || false}
-              onChange={(_, property) =>{
-                  dispatch(
-                    {type:'updateKey',
-                    key:'pagination',value:{
-                      currentPage:0,
-                      offset:0,
-                      total:0
-                  }})
-                  participantsDispatch({
-                    type: ParticipantsContext.types.SELECT_TAB,
-                    payload: property,
-                  })
-
-                }
-              }
+              onChange={(_, property) => {
+                dispatch({
+                  type: 'updateKey',
+                  key: 'pagination',
+                  value: {
+                    currentPage: 0,
+                    offset: 0,
+                    total: 0,
+                  },
+                });
+                participantsDispatch({
+                  type: ParticipantsContext.types.SELECT_TAB,
+                  payload: property,
+                });
+              }}
             >
               {
                 tabs.map((key) => (

--- a/client/src/pages/private/SiteParticipantsTable.js
+++ b/client/src/pages/private/SiteParticipantsTable.js
@@ -6,7 +6,13 @@ import store from 'store';
 import { Table, Button, Dialog } from '../../components/generic';
 import { getDialogTitle } from '../../utils';
 import { AuthContext } from '../../providers';
-import { ToastStatus, API_URL, makeToasts, ArchiveHiredParticipantSchema } from '../../constants';
+import {
+  ToastStatus,
+  API_URL,
+  makeToasts,
+  ArchiveHiredParticipantSchema,
+  participantStatus,
+} from '../../constants';
 import { ArchiveHiredParticipantForm } from '../../components/modal-forms';
 import { useToast } from '../../hooks';
 import moment from 'moment';
@@ -152,7 +158,7 @@ export default ({ siteId, onArchiveParticipantAction }) => {
       const index = rows.findIndex((row) => row.participantId === participantId);
       const { participantName } = rows[index];
       const toasts = makeToasts(participantName, '');
-      openToast(toasts['archived']);
+      openToast(toasts[participantStatus.ARCHIVED]);
       setActionMenuParticipant(null);
       setActiveModalForm(null);
     } else {
@@ -243,7 +249,7 @@ export default ({ siteId, onArchiveParticipantAction }) => {
             }}
             validationSchema={ArchiveHiredParticipantSchema}
             onSubmit={async (values) => {
-              await handleEngage(actionMenuParticipant.id, 'archived', values);
+              await handleEngage(actionMenuParticipant.id, participantStatus.ARCHIVED, values);
               if (onArchiveParticipantAction) {
                 onArchiveParticipantAction();
               } else {

--- a/client/src/pages/private/SiteParticipantsTable.js
+++ b/client/src/pages/private/SiteParticipantsTable.js
@@ -4,7 +4,7 @@ import Grid from '@material-ui/core/Grid';
 import { Box } from '@material-ui/core';
 import store from 'store';
 import { Table, Button, Dialog } from '../../components/generic';
-import { checkPermissions, getDialogTitle } from '../../utils';
+import {  getDialogTitle } from '../../utils';
 import { AuthContext } from '../../providers';
 import { ToastStatus, API_URL, makeToasts, ArchiveHiredParticipantSchema } from '../../constants';
 import { ArchiveHiredParticipantForm } from '../../components/modal-forms';
@@ -31,9 +31,9 @@ export default ({ siteId, onArchiveParticipantAction }) => {
   const { auth } = AuthContext.useAuth();
   const { openToast } = useToast();
   const roles = auth.user?.roles || [];
-  const isHA = checkPermissions(roles, ['health_authority']);
+  const isHA = roles.includes('health_authority');
   if (!isHA) {
-    columns = columns.filter((col) => col.id !== 'archived');
+    columns = columns.filter((col) => col.id !== 'archive');
   }
   const defaultOnClose = () => {
     setActiveModalForm(null);

--- a/client/src/pages/private/SiteParticipantsTable.js
+++ b/client/src/pages/private/SiteParticipantsTable.js
@@ -4,7 +4,7 @@ import Grid from '@material-ui/core/Grid';
 import { Box } from '@material-ui/core';
 import store from 'store';
 import { Table, Button, Dialog } from '../../components/generic';
-import {  getDialogTitle } from '../../utils';
+import { getDialogTitle } from '../../utils';
 import { AuthContext } from '../../providers';
 import { ToastStatus, API_URL, makeToasts, ArchiveHiredParticipantSchema } from '../../constants';
 import { ArchiveHiredParticipantForm } from '../../components/modal-forms';

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -2,6 +2,16 @@
 const { collections, views } = require('../db');
 const { userRegionQuery } = require('./user.js');
 
+const participantStatus = {
+  OPEN: 'open',
+  PROSPECTING: 'prospecting',
+  INTERVIEWING: 'interviewing',
+  OFFER_MADE: 'offer_made',
+  ARCHIVED: 'archived',
+  REJECTED: 'rejected',
+  HIRED: 'hired',
+};
+
 const scrubParticipantData = (raw, joinNames) =>
   raw.map((participant) => {
     const statusInfos = [];
@@ -59,7 +69,7 @@ const addDistanceToParticipantFields = (raw, siteDistanceJoin) =>
 // Find the previous status for each org, create a copy of it
 const revertToOldStatus = async (participantStatuses, setParticipantStatus) => {
   await participantStatuses.forEach(async (status) => {
-    if (status?.data?.previousStatus && status.data.previousStatus !== 'archived') {
+    if (status?.data?.previousStatus !== participantStatus.ARCHIVED) {
       await setParticipantStatus(
         status.employer_id,
         status.participant_id,
@@ -75,12 +85,17 @@ const revertToOldStatus = async (participantStatuses, setParticipantStatus) => {
 const insertWithdrawalParticipantStatus = async (participantStatuses, setParticipantStatus) => {
   participantStatuses.forEach(async (status) => {
     // Prevent locking the user into a loop of archived statuses
-    if (!(status.status && status.status === 'archived')) {
-      await setParticipantStatus(status.employer_id, status.participant_id, 'archived', {
-        final_status: 'Withdrawn by MoH',
-        previousStatus: status.status,
-        previousData: status.data,
-      });
+    if (!(status.status && status.status === participantStatus.ARCHIVED)) {
+      await setParticipantStatus(
+        status.employer_id,
+        status.participant_id,
+        participantStatus.ARCHIVED,
+        {
+          final_status: 'Withdrawn from HCAP',
+          previousStatus: status.status,
+          previousData: status.data,
+        }
+      );
     }
   });
 };
@@ -198,7 +213,7 @@ class FieldsFilteredParticipantsFinder {
           on: {
             participant_id: 'id',
             current: true,
-            status: 'hired',
+            status: participantStatus.HIRED,
           },
         },
         ...(siteIdDistance && {
@@ -243,7 +258,12 @@ class FieldsFilteredParticipantsFinder {
         // we don't want hired participants listed with such statuses:
         if (
           statusFilters.some((item) =>
-            ['open', 'prospecting', 'interviewing', 'offer_made'].includes(item)
+            [
+              participantStatus.OPEN,
+              participantStatus.PROSPECTING,
+              participantStatus.INTERVIEWING,
+              participantStatus.OFFER_MADE,
+            ].includes(item)
           )
         ) {
           criteria.or[0].and.push({ [`${hiredGlobalJoin}.status`]: null });

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -59,8 +59,8 @@ const addDistanceToParticipantFields = (raw, siteDistanceJoin) =>
 // Find the previous status for each org, create a copy of it 
 const  revertToOldStatus = async ( participantStatuses,setParticipantStatus)=>{
   await participantStatuses.forEach(async (status)=>{
-    if(status.final_status && status.final_status === 'Withdrawn by MoH'){
-      await setParticipantStatus(status.employer_id,status.participant_id, 'archived',{
+    if(status?.data?.previousStatus && status.data.previousStatus !=='archived' ){
+      const res = await setParticipantStatus(status.employer_id,status.participant_id, status.data.previousStatus,{
         ...status.data?.previousData|| {}
       } )
     }
@@ -69,14 +69,17 @@ const  revertToOldStatus = async ( participantStatuses,setParticipantStatus)=>{
 }
 // Withdraw the participant 
 const insertWithdrawalParticipantStatus = async (participantStatuses,setParticipantStatus) =>{ 
-  console.log(participantStatuses)
   participantStatuses.forEach( async (status)=>{
-    status
-    await setParticipantStatus(status.employer_id,status.participant_id, 'archived',{
-      final_status: 'Withdrawn by MoH',
-      previousStatus: status.status,
-      previousData: status.data
-    } )
+    // Prevent locking the user into a loop of archived statuses
+    if(status.status && status.status ==='archived'){
+      return;
+    }else{
+      await setParticipantStatus(status.employer_id,status.participant_id, 'archived',{
+        final_status: 'Withdrawn by MoH',
+        previousStatus: status.status,
+        previousData: status.data
+      } )
+    }
   })
 }
 

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -56,33 +56,36 @@ const addDistanceToParticipantFields = (raw, siteDistanceJoin) =>
     }),
   }));
 
-// Find the previous status for each org, create a copy of it 
-const  revertToOldStatus = async ( participantStatuses,setParticipantStatus)=>{
-  await participantStatuses.forEach(async (status)=>{
-    if(status?.data?.previousStatus && status.data.previousStatus !=='archived' ){
-      const res = await setParticipantStatus(status.employer_id,status.participant_id, status.data.previousStatus,{
-        ...status.data?.previousData|| {}
-      } )
+// Find the previous status for each org, create a copy of it
+const revertToOldStatus = async (participantStatuses, setParticipantStatus) => {
+  await participantStatuses.forEach(async (status) => {
+    if (status?.data?.previousStatus && status.data.previousStatus !== 'archived') {
+      const res = await setParticipantStatus(
+        status.employer_id,
+        status.participant_id,
+        status.data.previousStatus,
+        {
+          ...(status.data?.previousData || {}),
+        }
+      );
     }
-  })
-  
-}
-// Withdraw the participant 
-const insertWithdrawalParticipantStatus = async (participantStatuses,setParticipantStatus) =>{ 
-  participantStatuses.forEach( async (status)=>{
+  });
+};
+// Withdraw the participant
+const insertWithdrawalParticipantStatus = async (participantStatuses, setParticipantStatus) => {
+  participantStatuses.forEach(async (status) => {
     // Prevent locking the user into a loop of archived statuses
-    if(status.status && status.status ==='archived'){
+    if (status.status && status.status === 'archived') {
       return;
-    }else{
-      await setParticipantStatus(status.employer_id,status.participant_id, 'archived',{
+    } else {
+      await setParticipantStatus(status.employer_id, status.participant_id, 'archived', {
         final_status: 'Withdrawn by MoH',
         previousStatus: status.status,
-        previousData: status.data
-      } )
+        previousData: status.data,
+      });
     }
-  })
-}
-
+  });
+};
 
 const run = async (context) => {
   const {
@@ -345,8 +348,8 @@ class ParticipantsFinder {
   }
 }
 
-module.exports = { 
+module.exports = {
   ParticipantsFinder,
   revertToOldStatus,
-  insertWithdrawalParticipantStatus
+  insertWithdrawalParticipantStatus,
 };

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -60,7 +60,7 @@ const addDistanceToParticipantFields = (raw, siteDistanceJoin) =>
 const revertToOldStatus = async (participantStatuses, setParticipantStatus) => {
   await participantStatuses.forEach(async (status) => {
     if (status?.data?.previousStatus && status.data.previousStatus !== 'archived') {
-      const res = await setParticipantStatus(
+      await setParticipantStatus(
         status.employer_id,
         status.participant_id,
         status.data.previousStatus,
@@ -75,9 +75,7 @@ const revertToOldStatus = async (participantStatuses, setParticipantStatus) => {
 const insertWithdrawalParticipantStatus = async (participantStatuses, setParticipantStatus) => {
   participantStatuses.forEach(async (status) => {
     // Prevent locking the user into a loop of archived statuses
-    if (status.status && status.status === 'archived') {
-      return;
-    } else {
+    if (!(status.status && status.status === 'archived'))  {
       await setParticipantStatus(status.employer_id, status.participant_id, 'archived', {
         final_status: 'Withdrawn by MoH',
         previousStatus: status.status,

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -75,7 +75,7 @@ const revertToOldStatus = async (participantStatuses, setParticipantStatus) => {
 const insertWithdrawalParticipantStatus = async (participantStatuses, setParticipantStatus) => {
   participantStatuses.forEach(async (status) => {
     // Prevent locking the user into a loop of archived statuses
-    if (!(status.status && status.status === 'archived'))  {
+    if (!(status.status && status.status === 'archived')) {
       await setParticipantStatus(status.employer_id, status.participant_id, 'archived', {
         final_status: 'Withdrawn by MoH',
         previousStatus: status.status,

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -56,6 +56,31 @@ const addDistanceToParticipantFields = (raw, siteDistanceJoin) =>
     }),
   }));
 
+// Find the previous status for each org, create a copy of it 
+const  revertToOldStatus = async ( participantStatuses,setParticipantStatus)=>{
+  await participantStatuses.forEach(async (status)=>{
+    if(status.final_status && status.final_status === 'Withdrawn by MoH'){
+      await setParticipantStatus(status.employer_id,status.participant_id, 'archived',{
+        ...status.data?.previousData|| {}
+      } )
+    }
+  })
+  
+}
+// Withdraw the participant 
+const insertWithdrawalParticipantStatus = async (participantStatuses,setParticipantStatus) =>{ 
+  console.log(participantStatuses)
+  participantStatuses.forEach( async (status)=>{
+    status
+    await setParticipantStatus(status.employer_id,status.participant_id, 'archived',{
+      final_status: 'Withdrawn by MoH',
+      previousStatus: status.status,
+      previousData: status.data
+    } )
+  })
+}
+
+
 const run = async (context) => {
   const {
     table,
@@ -317,4 +342,8 @@ class ParticipantsFinder {
   }
 }
 
-module.exports = { ParticipantsFinder };
+module.exports = { 
+  ParticipantsFinder,
+  revertToOldStatus,
+  insertWithdrawalParticipantStatus
+};

--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -146,7 +146,7 @@ const updateParticipant = async (participantInfo) => {
       participant_id: participantInfo.id,
       current: true,
     });
-    //If no old statuses exist, no need to create a new one.
+    // If no old statuses exist, no need to create a new one.
     // setParticipantStatus was creating a circular dependancy and not getting loaded in, so I pass it in as a prop.
     if (participantStatuses.length) {
       if (changes.interested === 'yes') {

--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -34,15 +34,16 @@ const setParticipantStatus = async (
     // -- If interviewing, participant must be coming from prospecting status
     // -- If offer made, must be coming from interviewing
     // -- If hiring, must be coming from offer made
+    // -- If restoring a user from being archived, any status should be valid
     if (
-      status === 'open' ||
+      (status === 'open' ||
       (status === 'prospecting' &&
         item !== null &&
         item.status !== 'open' &&
         item.status !== 'rejected') ||
       (status === 'interviewing' && item?.status !== 'prospecting') ||
       (status === 'offer_made' && item?.status !== 'interviewing') ||
-      (status === 'hired' && item?.status !== 'offer_made')
+      (status === 'hired' && item?.status !== 'offer_made')) && (item?.status !== 'archived')
     )
       return { status: 'invalid_status_transition' };
 


### PR DESCRIPTION
Fixed HCAP-715 - Issue where the incorrect key and shape were used to check if a user was MoH in the SiteParticipants table. 

Improved the function of  HCAP-695 
- When navigating between tabs on the participant table, if you are on a page with a page number that is greater than the page total for the tab you are navigating to, you will be shown the first  page of that tab. The number will still be wrong as I haven't figured out why the component isn't updating. This also causes the page switch feature to respond improperly ( The component is set to the wrong page, so it wont update correctly until the user uses the controls to update it to the correct page. 

Fixed HCAP-696 

When a MoH withdraws a hired participant, their participant statuses were not being updated. 

Now when a MoH worker withdraws a user, a new participant status is added for each EOI. The previous status is stored in that data field and if that user's interest is switched back to 'yes', the previous status is restored. A record of this switch will exist in the database. 

Updated the Participants Table to show archived users to MoH

