### PR TITLE
Switched to bitnami node docker image

### DIFF
--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -1,10 +1,9 @@
-FROM node:14-alpine
+FROM public.ecr.aws/bitnami/node:14.17.3
 
 # Allow node modules to be called directly
 ENV PATH $PATH:/usr/src/app/node_modules/.bin
 
 # Configure server
-RUN apk add --no-cache git
 WORKDIR /server
 COPY package*.json ./
 RUN npm set progress=false && npm ci --no-cache


### PR DESCRIPTION
Swapping out the docker image version based off of wills suggestion. Hopefully this should bypass dockerhubs pull limit. 