### PR TITLE
Stop sending node modules in build context

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,3 @@
+.eslintrc
+Dockerfile*
+node_modules

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,3 @@
+.eslintrc
+Dockerfile*
+node_modules


### PR DESCRIPTION
Before: 

```
Building server
Sending build context to Docker daemon  125.9MB

Building client
Sending build context to Docker daemon  261.1MB
```

After 

```
Building server
Sending build context to Docker daemon  9.435MB

Building client
Sending build context to Docker daemon  3.901MB

```