### PR TITLE
HCAP-706 | HCAP-793: Separate user-details route.

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,10 +1,8 @@
 const csv = require('fast-csv');
 const dayjs = require('dayjs');
 const express = require('express');
-const { getParticipantsForUser } = require('../services/participants.js');
 const { getSites } = require('../services/employers.js');
 const { getReport, getHiredParticipantsReport } = require('../services/reporting.js');
-const { getUserSites } = require('../services/user.js');
 const { validate, AccessRequestApproval } = require('../validation.js');
 const logger = require('../logger.js');
 const { dbClient, collections } = require('../db');
@@ -101,7 +99,6 @@ apiRouter.get(
   })
 );
 
-
 // Get pending users from Keycloak
 apiRouter.get(
   `/pending-users`,
@@ -137,7 +134,6 @@ apiRouter.get(
     return res.json({ data: scrubbed });
   })
 );
-
 
 apiRouter.post(
   `/approve-user`,

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -1,0 +1,74 @@
+// Libs
+const express = require('express');
+
+// Frameworks
+const keycloak = require('../keycloak');
+const logger = require('../logger.js');
+const { asyncMiddleware } = require('../error-handler.js');
+const { expressRequestBodyValidator } = require('../middleware');
+const { AccessRequestApproval } = require('../validation.js');
+const { dbClient, collections } = require('../db');
+
+// Services
+const { getUserSites } = require('../services/user.js');
+
+/**
+ * User details router
+ */
+const userDetailsRouter = express.Router();
+userDetailsRouter.use(keycloak.allowRolesMiddleware('ministry_of_health'));
+// Index: Get
+// Get user details - Different from /user, this returns the
+// full user sites and role specified in the query id
+userDetailsRouter.get(
+  '/',
+  asyncMiddleware(async (req, res) => {
+    const { query: { id: userId } = {} } = req;
+    if (!userId) return res.status(400).send('No user id');
+    const roles = await keycloak.getUserRoles(userId);
+    const sites = await getUserSites(userId);
+    return res.status(200).json({
+      roles,
+      sites,
+    });
+  })
+);
+
+// Index: Patch
+userDetailsRouter.patch(
+  '/',
+  [
+    keycloak.allowRolesMiddleware('ministry_of_health'),
+    keycloak.getUserInfoMiddleware(),
+    expressRequestBodyValidator(AccessRequestApproval)
+  ],
+  asyncMiddleware(async (req, res) => {
+    const { hcapUserInfo: user, body: { userId, role, regions, sites } = {} } = req;
+    const { username, id } = user;
+    await keycloak.setUserRoles(userId, role, regions);
+    await dbClient.db[collections.USERS].updateDoc(
+      {
+        keycloakId: userId,
+      },
+      {
+        sites,
+      }
+    );
+    logger.info({
+      action: 'user-details_patch',
+      performed_by: {
+        username,
+        id,
+      },
+      role_assigned: role,
+      granted_access_to: userId,
+      regions_assigned: regions,
+      siteIds_assigned: sites,
+    });
+    return res.json({});
+  })
+);
+
+module.exports = {
+  userDetailsRouter,
+};

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -40,7 +40,7 @@ userDetailsRouter.patch(
   [
     keycloak.allowRolesMiddleware('ministry_of_health'),
     keycloak.getUserInfoMiddleware(),
-    expressRequestBodyValidator(AccessRequestApproval)
+    expressRequestBodyValidator(AccessRequestApproval),
   ],
   asyncMiddleware(async (req, res) => {
     const { hcapUserInfo: user, body: { userId, role, regions, sites } = {} } = req;

--- a/server/tests/user-details.e2e.test.js
+++ b/server/tests/user-details.e2e.test.js
@@ -1,0 +1,33 @@
+/**
+ * Tests for route /api/v1/user-details
+ * Test Standalone execution: npm run test:debug user-details.e2e.test
+ */
+const request = require('supertest');
+const app = require('../server');
+const { startDB, closeDB } = require('./util/db');
+const { getKeycloakToken, superuser } = require('./util/keycloak');
+ 
+
+describe('api-e2e tests for /api/v1/user-details', () => {
+  beforeAll(async () => {
+    await startDB();
+    server = app.listen();
+  });
+
+  afterAll(async () => {
+    await closeDB();
+    await server.close();
+  });
+
+  it('should not get user details but error 400', async () => {
+    const header = await getKeycloakToken(superuser);
+    const res = await request(app).get('/api/v1/user-details').set(header);
+    expect(res.status).toEqual(400);
+  });
+
+  it('should not update user but get error 400', async () => {
+    const header = await getKeycloakToken(superuser);
+    const res = await request(app).patch('/api/v1/user-details').set(header).send({});
+    expect(res.status).toEqual(400);
+  });
+});

--- a/server/tests/user-details.e2e.test.js
+++ b/server/tests/user-details.e2e.test.js
@@ -6,9 +6,9 @@ const request = require('supertest');
 const app = require('../server');
 const { startDB, closeDB } = require('./util/db');
 const { getKeycloakToken, superuser } = require('./util/keycloak');
- 
 
 describe('api-e2e tests for /api/v1/user-details', () => {
+  let server;
   beforeAll(async () => {
     await startDB();
     server = app.listen();


### PR DESCRIPTION
N.B: Keeping route `/users`, `/approve-user` and `/user` in API root route. This three routes are completely has no common prefixes, so creation of three different router would be pure overhead.