### PR TITLE
HCAP-817 | HCAP-818 | Date Display and Past Cohorts

### DIFF
--- a/client/src/pages/private/CohortTable.js
+++ b/client/src/pages/private/CohortTable.js
@@ -64,9 +64,8 @@ export default ({ cohorts }) => {
                 </Link>
               );
             if (columnId === 'start_date' || columnId === 'end_date') {
-              const d = new Date(row[columnId]);
               // Parses the relevant section of the date string
-              return d.toUTCString().split(' ').slice(1, 4).join(' ');
+              return new Date(row[columnId]).toUTCString().split(' ').slice(1, 4).join(' ');
             }
 
             if (columnId === 'remaining_seats')

--- a/client/src/pages/private/CohortTable.js
+++ b/client/src/pages/private/CohortTable.js
@@ -65,7 +65,8 @@ export default ({ cohorts }) => {
               );
             if (columnId === 'start_date' || columnId === 'end_date') {
               const d = new Date(row[columnId]);
-              return d.toDateString();
+              // Parses the relevant section of the date string
+              return d.toUTCString().split(' ').slice(1, 4).join(' ');
             }
 
             if (columnId === 'remaining_seats')

--- a/client/src/pages/private/PSIViewDetails.js
+++ b/client/src/pages/private/PSIViewDetails.js
@@ -1,4 +1,4 @@
-import React, { lazy, useEffect, useState } from 'react';
+import React, { lazy, useEffect, useState, useMemo } from 'react';
 import { Card, Page, CheckPermissions, Dialog } from '../../components/generic';
 import Button from '@material-ui/core/Button';
 import { Box, Grid, Link, Typography } from '@material-ui/core';
@@ -21,6 +21,18 @@ export default ({ match }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const [activeModalForm, setActiveModalForm] = useState(null);
   const psiID = parseInt(match.params.id, 10);
+
+  const openCohorts = useMemo(
+    () =>
+      cohorts.filter(
+        (cohort) =>
+          cohort.cohort_size - cohort.participants.length > 0 &&
+          new Date(cohort.end_date) > new Date()
+      ).length,
+    [cohorts]
+  );
+
+  const closedCohorts = useMemo(() => cohorts.length - openCohorts, [cohorts, openCohorts]);
 
   const handleManagePSIClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -226,22 +238,9 @@ export default ({ match }) => {
                     <Typography id='totalCohorts'>{cohorts.length}</Typography>
 
                     {/* Open Cohorts have less participants than their size */}
-                    <Typography id='openCohorts'>
-                      {
-                        cohorts.filter(
-                          (cohort) => cohort.cohort_size - cohort.participants.length > 0
-                        ).length
-                      }
-                    </Typography>
+                    <Typography id='openCohorts'>{openCohorts}</Typography>
 
-                    {/* Closed Cohorts have equal participants to their size */}
-                    <Typography id='closedCohorts'>
-                      {
-                        cohorts.filter(
-                          (cohort) => cohort.cohort_size - cohort.participants.length === 0
-                        ).length
-                      }
-                    </Typography>
+                    <Typography id='closedCohorts'>{closedCohorts}</Typography>
                   </Grid>
                 </Grid>
               </Box>

--- a/cypress/integration/psiDetailView.spec.js
+++ b/cypress/integration/psiDetailView.spec.js
@@ -1,5 +1,5 @@
 describe('Tests the PSI View', () => {
-  // Seed the db with at least one PSI
+  // Seed the db with two PSIs
   before(() => {
     cy.kcLogin('test-moh');
     cy.visit('/psi-view');
@@ -52,8 +52,22 @@ describe('Tests the PSI View', () => {
     cy.get('button').contains('Submit').click();
     cy.contains('No Cohorts Added').should('not.exist');
     cy.contains('Angular Observations').should('exist');
+    cy.contains('01 Sep 2020').should('exist'); // Start Date displays properly
+    cy.contains('01 Sep 2021').should('exist'); // End Date displays properly
     cy.get('p#totalCohorts').should('have.text', 1);
     cy.get('p#openCohorts').should('have.text', 1);
     cy.get('p#closedCohorts').should('have.text', 0);
+
+    // Adds a past cohort, checks to make sure it's marked as closed
+    cy.get('button').contains('Manage PSI').click();
+    cy.get('li').contains('Add Cohort').should('be.visible').click();
+    cy.get('input#cohortName').type('Obtuse Ontologies');
+    cy.get('input[name="StartDate"]').type('19200901');
+    cy.get('input[name="EndDate"]').type('19210901');
+    cy.get('input#cohortSize').type('144');
+    cy.get('button').contains('Submit').click();
+    cy.get('p#totalCohorts').should('have.text', 2);
+    cy.get('p#openCohorts').should('have.text', 1);
+    cy.get('p#closedCohorts').should('have.text', 1);
   });
 });


### PR DESCRIPTION
Dates now display accurately, past cohorts are identified as closed. Cypress tests added.

Addresses https://freshworks.atlassian.net/secure/RapidBoard.jspa?rapidView=206&modal=detail&selectedIssue=HCAP-818
and https://freshworks.atlassian.net/secure/RapidBoard.jspa?rapidView=206&modal=detail&selectedIssue=HCAP-817