### PR TITLE
HCAP-808 | customised regions table to avoid 'None'

### DIFF
--- a/client/src/constants/label.js
+++ b/client/src/constants/label.js
@@ -6,3 +6,11 @@ export const regionLabelsMap = {
   region_northern: 'Northern',
   none: 'None',
 };
+
+export const psiRegionLabelsMap = {
+  region_interior: 'Interior',
+  region_fraser: 'Fraser',
+  region_vancouver_coastal: 'Vancouver Coastal',
+  region_vancouver_island: 'Vancouver Island',
+  region_northern: 'Northern',
+};

--- a/client/src/pages/private/PSITable.js
+++ b/client/src/pages/private/PSITable.js
@@ -8,6 +8,8 @@ import { Routes, regionLabelsMap } from '../../constants';
 import { TableFilter } from '../../components/generic/TableFilter';
 import { AuthContext } from '../../providers';
 
+const { none, ...customLabelsMap } = regionLabelsMap;
+
 const columns = [
   { id: 'institute_name', name: 'Institutes' },
   { id: 'health_authority', name: 'Health Authority' },
@@ -47,8 +49,8 @@ export default ({ PSIs, handleAddCohortClick }) => {
   useEffect(() => {
     setHealthAuthorities(
       roles.includes('superuser') || roles.includes('ministry_of_health')
-        ? Object.values(regionLabelsMap)
-        : roles.map((loc) => regionLabelsMap[loc]).filter(Boolean)
+        ? Object.values(customLabelsMap)
+        : roles.map((loc) => customLabelsMap[loc]).filter(Boolean)
     );
   }, [roles]);
 

--- a/client/src/pages/private/PSITable.js
+++ b/client/src/pages/private/PSITable.js
@@ -4,11 +4,9 @@ import { useHistory } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import { Box, Typography, Link } from '@material-ui/core';
 import { Table, Button } from '../../components/generic';
-import { Routes, regionLabelsMap } from '../../constants';
+import { Routes, psiRegionLabelsMap } from '../../constants';
 import { TableFilter } from '../../components/generic/TableFilter';
 import { AuthContext } from '../../providers';
-
-const { none, ...customLabelsMap } = regionLabelsMap;
 
 const columns = [
   { id: 'institute_name', name: 'Institutes' },
@@ -49,8 +47,8 @@ export default ({ PSIs, handleAddCohortClick }) => {
   useEffect(() => {
     setHealthAuthorities(
       roles.includes('superuser') || roles.includes('ministry_of_health')
-        ? Object.values(customLabelsMap)
-        : roles.map((loc) => customLabelsMap[loc]).filter(Boolean)
+        ? Object.values(psiRegionLabelsMap)
+        : roles.map((loc) => psiRegionLabelsMap[loc]).filter(Boolean)
     );
   }, [roles]);
 


### PR DESCRIPTION
Deconstructed the regionLabelsMap to remove 'None'.

Addresses the following ticket:
https://freshworks.atlassian.net/browse/HCAP-808?atlOrigin=eyJpIjoiMzA4NjgyOTVmZDJmNGJkYzk0OWQ0NmI3MzI0NGYwYjciLCJwIjoiaiJ9