### PR TITLE
HCAP-827 | remove unneeded state call

### DIFF
--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -269,7 +269,7 @@ export default () => {
     if (!columns) return;
     if (!selectedTab) return;
     setLoadingData(true);
-    const { data, pagination } = await fetchParticipants(
+    const { data } = await fetchParticipants(
       currentPage * pageSize,
       reducerState.locationFilter,
       reducerState.fsaFilter,
@@ -280,10 +280,6 @@ export default () => {
       reducerState.siteSelector,
       selectedTabStatuses
     );
-    participantsDispatch({
-      type: ParticipantsContext.types.SELECT_TAB,
-      payload: pagination,
-    });
     const newRows = filterData(data, columns);
     setRows(newRows);
     setLoadingData(false);


### PR DESCRIPTION
This dispatch was breaking the component state, it seems like a mistake (passing pagination to the select tab action?) and the app seems to work great without it.

[MOH/HA/Employer > Blank screen on various actions](https://freshworks.atlassian.net/browse/HCAP-827)