### PR TITLE
Hcap 851 close participant form

### DIFF
--- a/client/src/pages/public/ParticipantForm.js
+++ b/client/src/pages/public/ParticipantForm.js
@@ -1,12 +1,33 @@
 import React from 'react';
-
 import { Page } from '../../components/generic';
-import { Form } from '../../components/participant-form';
+import { Typography, Box, Icon } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import InfoIcon from '@material-ui/icons/Info';
 
+const useStyles = makeStyles((theme) => ({
+  info: {
+    color: 'rgb(13, 60, 97)',
+    backgroundColor: 'rgb(232, 244, 253)',
+    borderRadius: '4px',
+    border: '1px solid rgb(175, 217, 252)',
+    maxWidth: '800px',
+  },
+  icon: {
+    color: theme.palette.primary.dark,
+  },
+}));
 export default () => {
+  const classes = useStyles();
+  // TODO: Re-add the <Form/> component when slots open up.
   return (
     <Page hideEmployers={!window.location.hostname.includes('freshworks.club')}>
-      <Form />
+      <Box mt={4} m={2} py={1} px={2} display='flex' alignItems='center' className={classes.info}>
+        <Icon mx={2} component={InfoIcon} className={classes.icon} fontSize={'large'} />
+        <Typography>
+          The participant expression of interest for the HCAP program is now closed and may reopen
+          as more opportunities become available. Thank you for your interest in the program.
+        </Typography>
+      </Box>
     </Page>
   );
 };

--- a/server/routes/participant.js
+++ b/server/routes/participant.js
@@ -215,6 +215,10 @@ participantsRouter.post(
 participantsRouter.post(
   `/`,
   asyncMiddleware(async (req, res) => {
+    if (process.env.NODE_ENV !== 'test') {
+      return res.status(400).send({ message: 'This route has been close until further' });
+    }
+
     await validate(ParticipantSchema, req.body);
 
     const participant = {


### PR DESCRIPTION
Replace the form with Temporary Closure copy. 

Also close down the submission route. Since tests are broken locally, I apologize if this breaks tests when the PR is published.

Mobile View

<img width="374" alt="Screen Shot 2021-08-09 at 2 17 42 PM" src="https://user-images.githubusercontent.com/54554766/128777763-e079d5dd-4551-4c78-ac1f-ad2f7091d1f3.png">

Regular view
<img width="1679" alt="Screen Shot 2021-08-09 at 2 16 46 PM" src="https://user-images.githubusercontent.com/54554766/128777768-4e1938a4-1114-405a-9f2c-6c71dbe7cedb.png">
