### PR TITLE
Fixed W capitalization on login button

### DIFF
--- a/client/src/pages/public/ParticipantLogin.js
+++ b/client/src/pages/public/ParticipantLogin.js
@@ -84,6 +84,7 @@ export default () => {
               fullWidth={false}
               variant='contained'
               color='primary'
+              style={{ 'text-transform': 'none' }}
               text={'Login with BC Services Card'}
             />
             <Typography variant={'body2'}>


### PR DESCRIPTION
Looks like MUI buttons automatically capitalize each word. This conflicted with BC gov style guide-lines. 