### PR TITLE
Added env for participant password

### DIFF
--- a/server/tests/util/keycloak.js
+++ b/server/tests/util/keycloak.js
@@ -13,7 +13,7 @@ const employer = {
 
 const participant = {
   username: 'test.participant',
-  password: 'password',
+  password: process.env.KC_TEST_PARTICIPANT_PWD || 'password',
 };
 
 const getKeycloakToken = async ({ username, password }) => {


### PR DESCRIPTION
Looks like hard coding the password for the participant test user was being flagged by scans. This isn't really an issue, but I added an environment variable to match the rest of the test users. 