### PR TITLE
HCAP-978 | Fix CSP by applying a nonce to inline scripts and styles

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta property="csp-nonce" content="__CSP_NONCE__" />
     <title>Health Career Access Program Employer Portal - Province of British Columbia</title>
     <script src="%PUBLIC_URL%/ie.js"></script>
   </head>

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 const cors = require('cors');
 const express = require('express');
 const helmet = require('helmet');
+const uuid = require('uuid');
 const bodyParser = require('body-parser');
 const path = require('path');
 const apiRouter = require('./routes');
@@ -18,6 +19,15 @@ if (
 ) {
   app.use(cors());
 }
+
+/**
+ * Apply nonce for use in CSP and static files
+ */
+app.use((req, res, next) => {
+  const nonce = Buffer.from(uuid.v4()).toString('base64');
+  res.locals.cspNonce = nonce;
+  next();
+});
 
 app.use(
   helmet({
@@ -39,7 +49,7 @@ app.use(
         'object-src': ["'none'"],
         'script-src': ["'self'"],
         'script-src-attr': ["'none'"],
-        'style-src': ["'self'", "'unsafe-inline'"],
+        'style-src': ["'self'", (req, res) => `'nonce-${res.locals.cspNonce}'`],
         'upgrade-insecure-requests': [],
         'form-action': ["'self'"],
       },

--- a/server/server.js
+++ b/server/server.js
@@ -85,7 +85,8 @@ app.get('/', (req, res) => {
 
   const html = fs.readFileSync(path.join(__dirname, './build/index.html'), 'utf-8');
 
-  const newHTML = html.replace(/<(script|style)/g, `<$1 nonce="${cspNonce}"`);
+  let newHTML = html.replace(/<(script|style)/g, `<$1 nonce="${cspNonce}"`);
+  newHTML = newHTML.replace(/__CSP_NONCE__/g, `${cspNonce}`);
 
   res.send(newHTML);
 });

--- a/server/server.js
+++ b/server/server.js
@@ -83,14 +83,14 @@ app.use(`${apiBaseUrl}`, apiRouter);
 app.get('/', (req, res) => {
   const { cspNonce } = res.locals;
 
-  const html = fs.readFileSync(path.join(__dirname, './build/index.html'), 'utf-8');
+  const html = fs.readFileSync(path.join(__dirname, '../client/build/index.html'), 'utf-8');
 
   let newHTML = html.replace(/<(script|style)/g, `<$1 nonce="${cspNonce}"`);
   newHTML = newHTML.replace(/__CSP_NONCE__/g, `${cspNonce}`);
 
   res.send(newHTML);
 });
-app.use(express.static(path.join(__dirname, './build')));
+app.use(express.static(path.join(__dirname, '../client/build')));
 app.use(errorHandler);
 
 module.exports = app;

--- a/server/server.js
+++ b/server/server.js
@@ -48,7 +48,7 @@ app.use(
         'frame-ancestors': ["'self'"],
         'img-src': ["'self'", 'data:'],
         'object-src': ["'none'"],
-        'script-src': ["'self'"],
+        'script-src': ["'self'", (req, res) => `'nonce-${res.locals.cspNonce}'`],
         'script-src-attr': ["'none'"],
         'style-src': ["'self'", (req, res) => `'nonce-${res.locals.cspNonce}'`],
         'upgrade-insecure-requests': [],


### PR DESCRIPTION
- Middleware to generate a nonce per-request
- Inject nonce to `index.html`
  - Once for the script files
  - Once for the meta tag to be consumed by JSS
- Use the same nonce in the CSP

https://freshworks.atlassian.net/browse/HCAP-978