### PR TITLE
MOH-30 | route is catch-all, not just root

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -80,7 +80,7 @@ app.use(expressAccessLogger);
 app.use(bodyParser.json());
 app.use(`${apiBaseUrl}`, apiRouter);
 // Client app
-app.get('/', (req, res) => {
+app.get('/*', (req, res) => {
   const { cspNonce } = res.locals;
 
   const html = fs.readFileSync(path.join(__dirname, '../client/build/index.html'), 'utf-8');


### PR DESCRIPTION
Refreshing any page gives an error because we're only serving from `/` not `/*`