### PR TITLE
HCAP-931 + HCAP-981 | indigenous question

### DIFF
--- a/client/src/components/modal-forms/IndigenousDeclarationForm.js
+++ b/client/src/components/modal-forms/IndigenousDeclarationForm.js
@@ -1,0 +1,135 @@
+import React from 'react';
+import { Button, InputFieldError } from '../generic';
+import { Box, Checkbox, FormControl, FormControlLabel, Grid, Typography } from '@material-ui/core';
+import { RenderRadioGroup } from '../fields';
+import { Field, Formik, Form as FormikForm, ErrorMessage } from 'formik';
+import { IndigenousDeclarationSchema } from '../../constants';
+
+export const indigenousIdentityOptions = {
+  FIRST_NATIONS: 'first-nations',
+  INUIT: 'inuit',
+  METIS: 'metis',
+  OTHER: 'other',
+  UNKNOWN: 'unknown',
+};
+
+export const IndigenousDeclarationForm = () => {
+  const initialValues = {
+    isIndigenous: null,
+    [indigenousIdentityOptions.FIRST_NATIONS]: false,
+    [indigenousIdentityOptions.INUIT]: false,
+    [indigenousIdentityOptions.METIS]: false,
+    [indigenousIdentityOptions.OTHER]: false,
+    [indigenousIdentityOptions.UNKNOWN]: false,
+  };
+
+  const handleSubmit = (values) => {
+    // console.log(values);
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={IndigenousDeclarationSchema}
+      onSubmit={handleSubmit}
+    >
+      {({ values, errors }) => (
+        <FormikForm>
+          <Box display='flex' flexDirection='column' padding={2} maxWidth={'500px'}>
+            <Box marginBottom={2}>
+              <Typography variant='h4' component='h1'>
+                Complete your Participant Expression of Interest
+              </Typography>
+            </Box>
+
+            <Typography variant='h5' component='p'>
+              Please answer the following question to complete your Participant Expression of
+              Interest
+            </Typography>
+
+            <Box margin={3} marginBottom={0}>
+              <Box marginBottom={2}>
+                <FormControl component='fieldset'>
+                  <FormControl component='legend'>
+                    <Typography variant='subtitle2'>
+                      Do you identify as an Indigenous Person?
+                    </Typography>
+                  </FormControl>
+
+                  <Field
+                    id='isIndigenous'
+                    name='isIndigenous'
+                    component={RenderRadioGroup}
+                    row
+                    options={[
+                      { value: true, label: 'Yes' },
+                      { value: false, label: 'No' },
+                    ]}
+                  />
+                </FormControl>
+              </Box>
+
+              {values.isIndigenous ? (
+                <Box
+                  padding={2}
+                  marginBottom={2}
+                  style={{
+                    backgroundColor: 'rgb(243, 244, 246)',
+                  }}
+                >
+                  <FormControl component='fieldset'>
+                    <FormControl component='legend'>
+                      <Typography variant='subtitle2'>What is your Indigenous Identity?</Typography>
+                      <Typography>Choose all that apply</Typography>
+                    </FormControl>
+                    {[
+                      { label: 'First Nations', value: indigenousIdentityOptions.FIRST_NATIONS },
+                      { label: 'Inuit', value: indigenousIdentityOptions.INUIT },
+                      { label: 'Métis', value: indigenousIdentityOptions.METIS },
+                      { label: 'Other', value: indigenousIdentityOptions.OTHER },
+                      { label: 'Unknown', value: indigenousIdentityOptions.UNKNOWN },
+                    ].map((item) => (
+                      // Not useing RenderCheckbox because I don't want it's errors here
+                      <Field name={item.value} key={item.value}>
+                        {({ field }) => (
+                          <FormControlLabel
+                            label={item.label}
+                            labelPlacement='end'
+                            control={
+                              <Checkbox
+                                sx={{ '& .MuiSvgIcon-root': { fontSize: 28 } }}
+                                size='small'
+                                color='primary'
+                                checked={field.value === true}
+                              />
+                            }
+                            {...field}
+                          />
+                        )}
+                      </Field>
+                    ))}
+                  </FormControl>
+
+                  {/* If an error exists for any, show one of them. Their errors are tightly coupled */}
+                  {(errors[indigenousIdentityOptions.FIRST_NATIONS] ||
+                    errors[indigenousIdentityOptions.INUIT] ||
+                    errors[indigenousIdentityOptions.METIS] ||
+                    errors[indigenousIdentityOptions.OTHER] ||
+                    errors[indigenousIdentityOptions.UNKNOWN]) && (
+                    <InputFieldError
+                      error={<ErrorMessage name={indigenousIdentityOptions.FIRST_NATIONS} />}
+                    />
+                  )}
+                </Box>
+              ) : null}
+            </Box>
+
+            <Grid container justify='flex-end'>
+              <Button type='submit' color='primary' text='Submit' fullWidth={false} />
+            </Grid>
+          </Box>
+        </FormikForm>
+      )}
+    </Formik>
+  );
+};

--- a/client/src/components/modal-forms/IndigenousDeclarationForm.js
+++ b/client/src/components/modal-forms/IndigenousDeclarationForm.js
@@ -13,7 +13,7 @@ export const indigenousIdentityOptions = {
   UNKNOWN: 'unknown',
 };
 
-export const IndigenousDeclarationForm = () => {
+export const IndigenousDeclarationForm = ({ handleSubmit }) => {
   const initialValues = {
     isIndigenous: null,
     [indigenousIdentityOptions.FIRST_NATIONS]: false,
@@ -21,10 +21,6 @@ export const IndigenousDeclarationForm = () => {
     [indigenousIdentityOptions.METIS]: false,
     [indigenousIdentityOptions.OTHER]: false,
     [indigenousIdentityOptions.UNKNOWN]: false,
-  };
-
-  const handleSubmit = (values) => {
-    // console.log(values);
   };
 
   return (

--- a/client/src/components/modal-forms/IndigenousDeclarationForm.js
+++ b/client/src/components/modal-forms/IndigenousDeclarationForm.js
@@ -5,7 +5,7 @@ import { RenderRadioGroup } from '../fields';
 import { Field, Formik, Form as FormikForm, ErrorMessage } from 'formik';
 import { IndigenousDeclarationSchema } from '../../constants';
 
-export const indigenousIdentityOptions = {
+export const indigenousIdentities = {
   FIRST_NATIONS: 'first-nations',
   INUIT: 'inuit',
   METIS: 'metis',
@@ -13,14 +13,22 @@ export const indigenousIdentityOptions = {
   UNKNOWN: 'unknown',
 };
 
+export const indigenousIdentityLabels = {
+  FIRST_NATIONS: 'First Nations',
+  INUIT: 'Inuit',
+  METIS: 'Métis',
+  OTHER: 'Other',
+  UNKNOWN: 'Unknown',
+};
+
 export const IndigenousDeclarationForm = ({ handleSubmit }) => {
   const initialValues = {
     isIndigenous: null,
-    [indigenousIdentityOptions.FIRST_NATIONS]: false,
-    [indigenousIdentityOptions.INUIT]: false,
-    [indigenousIdentityOptions.METIS]: false,
-    [indigenousIdentityOptions.OTHER]: false,
-    [indigenousIdentityOptions.UNKNOWN]: false,
+    [indigenousIdentities.FIRST_NATIONS]: false,
+    [indigenousIdentities.INUIT]: false,
+    [indigenousIdentities.METIS]: false,
+    [indigenousIdentities.OTHER]: false,
+    [indigenousIdentities.UNKNOWN]: false,
   };
 
   return (
@@ -78,43 +86,40 @@ export const IndigenousDeclarationForm = ({ handleSubmit }) => {
                       <Typography variant='subtitle2'>What is your Indigenous Identity?</Typography>
                       <Typography>Choose all that apply</Typography>
                     </FormControl>
-                    {[
-                      { label: 'First Nations', value: indigenousIdentityOptions.FIRST_NATIONS },
-                      { label: 'Inuit', value: indigenousIdentityOptions.INUIT },
-                      { label: 'Métis', value: indigenousIdentityOptions.METIS },
-                      { label: 'Other', value: indigenousIdentityOptions.OTHER },
-                      { label: 'Unknown', value: indigenousIdentityOptions.UNKNOWN },
-                    ].map((item) => (
-                      // Not useing RenderCheckbox because I don't want it's errors here
-                      <Field name={item.value} key={item.value}>
-                        {({ field }) => (
-                          <FormControlLabel
-                            label={item.label}
-                            labelPlacement='end'
-                            control={
-                              <Checkbox
-                                sx={{ '& .MuiSvgIcon-root': { fontSize: 28 } }}
-                                size='small'
-                                color='primary'
-                                checked={field.value === true}
-                              />
-                            }
-                            {...field}
-                          />
-                        )}
-                      </Field>
-                    ))}
+                    {Object.keys(indigenousIdentities)
+                      .map((key) => ({
+                        label: indigenousIdentityLabels[key],
+                        value: indigenousIdentities[key],
+                      }))
+                      .map((item) => (
+                        // Not useing RenderCheckbox because I don't want it's errors here
+                        <Field name={item.value} key={item.value}>
+                          {({ field }) => (
+                            <FormControlLabel
+                              label={item.label}
+                              labelPlacement='end'
+                              control={
+                                <Checkbox
+                                  sx={{ '& .MuiSvgIcon-root': { fontSize: 28 } }}
+                                  size='small'
+                                  color='primary'
+                                  checked={field.value === true}
+                                />
+                              }
+                              {...field}
+                            />
+                          )}
+                        </Field>
+                      ))}
                   </FormControl>
 
                   {/* If an error exists for any, show one of them. Their errors are tightly coupled */}
-                  {(errors[indigenousIdentityOptions.FIRST_NATIONS] ||
-                    errors[indigenousIdentityOptions.INUIT] ||
-                    errors[indigenousIdentityOptions.METIS] ||
-                    errors[indigenousIdentityOptions.OTHER] ||
-                    errors[indigenousIdentityOptions.UNKNOWN]) && (
-                    <InputFieldError
-                      error={<ErrorMessage name={indigenousIdentityOptions.FIRST_NATIONS} />}
-                    />
+                  {(errors[indigenousIdentities.FIRST_NATIONS] ||
+                    errors[indigenousIdentities.INUIT] ||
+                    errors[indigenousIdentities.METIS] ||
+                    errors[indigenousIdentities.OTHER] ||
+                    errors[indigenousIdentities.UNKNOWN]) && (
+                    <InputFieldError error={errors[indigenousIdentities.FIRST_NATIONS]} />
                   )}
                 </Box>
               ) : null}

--- a/client/src/components/modal-forms/IndigenousDeclarationForm.js
+++ b/client/src/components/modal-forms/IndigenousDeclarationForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, InputFieldError } from '../generic';
 import { Box, Checkbox, FormControl, FormControlLabel, Grid, Typography } from '@material-ui/core';
 import { RenderRadioGroup } from '../fields';
-import { Field, Formik, Form as FormikForm, ErrorMessage } from 'formik';
+import { Field, Formik, Form as FormikForm } from 'formik';
 import { IndigenousDeclarationSchema } from '../../constants';
 
 export const indigenousIdentities = {

--- a/client/src/components/participant-form/Fields.js
+++ b/client/src/components/participant-form/Fields.js
@@ -15,6 +15,7 @@ import {
   indigenousIdentityLabels,
 } from '../modal-forms/IndigenousDeclarationForm';
 import { Checkbox, FormControl, FormControlLabel } from '@material-ui/core';
+import { isNil } from 'lodash';
 
 const useStyles = makeStyles((theme) => ({
   info: {
@@ -72,7 +73,7 @@ export const Fields = ({ isDisabled, hideHelp, enableFields, isNonPortalHire, va
       <Card noShadow={isDisabled}>
         {/** Indigenous Identity - meant to be READ-ONLY, not set up for editing */}
         <Grid container spacing={2}>
-          {isDisabled && (
+          {isDisabled && !isNil(values.isIndigenous) && (
             <Grid item xs={12}>
               <Typography variant='subtitle2'>Indigenous Identity</Typography>
               <Divider />

--- a/client/src/components/participant-form/Fields.js
+++ b/client/src/components/participant-form/Fields.js
@@ -10,6 +10,11 @@ import { SpeakerNotesOutlined } from '@material-ui/icons';
 
 import { Card, Divider } from '../generic';
 import { RenderCheckbox, RenderCheckboxGroup, RenderTextField, RenderRadioGroup } from '../fields';
+import {
+  indigenousIdentities,
+  indigenousIdentityLabels,
+} from '../modal-forms/IndigenousDeclarationForm';
+import { Checkbox, FormControl, FormControlLabel } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   info: {
@@ -35,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const Fields = ({ isDisabled, hideHelp, enableFields, isNonPortalHire }) => {
+export const Fields = ({ isDisabled, hideHelp, enableFields, isNonPortalHire, values }) => {
   const classes = useStyles();
   const [isCollectionNoticeExpanded, setCollectionNoticeExpanded] = useState(
     window.innerWidth > 750
@@ -63,8 +68,66 @@ export const Fields = ({ isDisabled, hideHelp, enableFields, isNonPortalHire }) 
           </Box>
         </Box>
       )}
+
       <Card noShadow={isDisabled}>
+        {/** Indigenous Identity - meant to be READ-ONLY, not set up for editing */}
         <Grid container spacing={2}>
+          {isDisabled && (
+            <Grid item xs={12}>
+              <Typography variant='subtitle2'>Indigenous Identity</Typography>
+              <Divider />
+
+              <Box display='flex' flexDirection='column'>
+                <FormControl component='fieldset'>
+                  <FormControl component='legend'>
+                    <Typography variant='subtitle2'>
+                      Do you identify as an Indigenous Person?
+                    </Typography>
+                  </FormControl>
+
+                  <FastField
+                    id='isIndigenous'
+                    name='isIndigenous'
+                    component={RenderRadioGroup}
+                    disabled
+                    row
+                    options={[
+                      { value: true, label: 'Yes' },
+                      { value: false, label: 'No' },
+                    ]}
+                  />
+                </FormControl>
+
+                <FormControl component='fieldset'>
+                  <FormControl component='legend'>
+                    <Typography variant='subtitle2'>What is your Indigenous Identity?</Typography>
+                    <Typography>Choose all that apply</Typography>
+                  </FormControl>
+                  {Object.keys(indigenousIdentities)
+                    .map((key) => ({
+                      label: indigenousIdentityLabels[key],
+                      value: indigenousIdentities[key],
+                    }))
+                    .map((item) => (
+                      <FormControlLabel
+                        disabled
+                        label={item.label}
+                        labelPlacement='end'
+                        control={
+                          <Checkbox
+                            sx={{ '& .MuiSvgIcon-root': { fontSize: 28 } }}
+                            size='medium'
+                            color='primary'
+                            checked={values.indigenousIdentities?.includes(item.value)}
+                          />
+                        }
+                      />
+                    ))}
+                </FormControl>
+              </Box>
+            </Grid>
+          )}
+
           {/** Eligibility */}
           <Grid item xs={12}>
             <Typography variant='subtitle2'>Check Your Eligibility</Typography>

--- a/client/src/components/participant-form/Fields.js
+++ b/client/src/components/participant-form/Fields.js
@@ -77,7 +77,7 @@ export const Fields = ({ isDisabled, hideHelp, enableFields, isNonPortalHire }) 
             </Typography>
           </Grid>
 
-          {isNonPortalHire ? null : (
+          {isDisabled && isNonPortalHire ? null : (
             <>
               <Grid item xs={12}>
                 <Typography>
@@ -247,7 +247,7 @@ export const Fields = ({ isDisabled, hideHelp, enableFields, isNonPortalHire }) 
 
         {/** Disclaimer and submission */}
         <Grid container spacing={2}>
-          {isNonPortalHire ? null : (
+          {isDisabled && isNonPortalHire ? null : (
             <Grid item xs={12}>
               <hr className={classes.line} />
               <Grid container spacing={2}>

--- a/client/src/components/participant-form/index.js
+++ b/client/src/components/participant-form/index.js
@@ -96,6 +96,7 @@ export const Form = ({
 
             <Box pt={2} pb={4} pl={2} pr={2}>
               <Fields
+                values={values}
                 isDisabled={isDisabled}
                 hideHelp={hideSummary}
                 enableFields={enableFields}

--- a/client/src/constants/theme.js
+++ b/client/src/constants/theme.js
@@ -84,6 +84,20 @@ export default createMuiTheme({
       letterSpacing: 'normal',
       color: '#000000',
     },
+    h4: {
+      fontWeight: 600,
+      fontSize: '20px',
+      lineHeight: '24px',
+      letterSpacing: 'normal',
+      color: '#000000',
+    },
+    h5: {
+      fontWeight: 400,
+      fontSize: '18px',
+      lineHeight: '22px',
+      letterSpacing: 'normal',
+      color: '#000000',
+    },
     subtitle1: {
       fontWeight: 500,
       fontSize: '20px',

--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -505,28 +505,12 @@ export const CreatePSISchema = yup.object().shape({
 
 export const IndigenousDeclarationSchema = yup.object().shape({
   isIndigenous: yup.boolean().nullable(),
-  [indigenousIdentities.FIRST_NATIONS]: yup
-    .boolean()
-    .test('identityRequired', 'Please complete this field', validateIdentity),
-  [indigenousIdentities.INUIT]: yup
-    .boolean()
-    .test('identityRequired', 'Please complete this field', validateIdentity),
-  [indigenousIdentities.METIS]: yup
-    .boolean()
-    .test('identityRequired', 'Please complete this field', validateIdentity),
-  [indigenousIdentities.OTHER]: yup
-    .boolean()
-    .test('identityRequired', 'Please complete this field', validateIdentity),
-  [indigenousIdentities.UNKNOWN]: yup
-    .boolean()
-    .test('identityRequired', 'Please complete this field', validateIdentity),
+  [indigenousIdentities.FIRST_NATIONS]: yup.boolean(),
+  [indigenousIdentities.INUIT]: yup.boolean(),
+  [indigenousIdentities.METIS]: yup.boolean(),
+  [indigenousIdentities.OTHER]: yup.boolean(),
+  [indigenousIdentities.UNKNOWN]: yup.boolean(),
 });
-
-function validateIdentity() {
-  if (!this.parent.isIndigenous) return true;
-  // Following checks if any of the options are false
-  return Object.values(indigenousIdentities).find((key) => this.parent[key]);
-}
 
 export const EditPSISchema = yup.object().shape({
   instituteName: yup.string().required(errorMessage),

--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -504,7 +504,7 @@ export const CreatePSISchema = yup.object().shape({
 });
 
 export const IndigenousDeclarationSchema = yup.object().shape({
-  isIndigenous: yup.boolean().nullable().required('Please complete this field'),
+  isIndigenous: yup.boolean().nullable(),
   [indigenousIdentityOptions.FIRST_NATIONS]: yup
     .boolean()
     .test('identityRequired', 'Please complete this field', validateIdentity),

--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -6,6 +6,7 @@ import {
   minDateString,
   maxDateString,
 } from './archiveParticipantsConstants';
+import { indigenousIdentityOptions } from '../components/modal-forms/IndigenousDeclarationForm';
 
 const healthRegions = ['Interior', 'Fraser', 'Vancouver Coastal', 'Vancouver Island', 'Northern'];
 
@@ -501,6 +502,31 @@ export const CreatePSISchema = yup.object().shape({
     .matches(/^[A-Z]\d[A-Z]\s?\d[A-Z]\d$/, 'Format as A1A 1A1'),
   healthAuthority: yup.string().required(errorMessage).oneOf(healthRegions, 'Invalid region'),
 });
+
+export const IndigenousDeclarationSchema = yup.object().shape({
+  isIndigenous: yup.boolean().nullable().required('Please complete this field'),
+  [indigenousIdentityOptions.FIRST_NATIONS]: yup
+    .boolean()
+    .test('identityRequired', 'Please complete this field', validateIdentity),
+  [indigenousIdentityOptions.INUIT]: yup
+    .boolean()
+    .test('identityRequired', 'Please complete this field', validateIdentity),
+  [indigenousIdentityOptions.METIS]: yup
+    .boolean()
+    .test('identityRequired', 'Please complete this field', validateIdentity),
+  [indigenousIdentityOptions.OTHER]: yup
+    .boolean()
+    .test('identityRequired', 'Please complete this field', validateIdentity),
+  [indigenousIdentityOptions.UNKNOWN]: yup
+    .boolean()
+    .test('identityRequired', 'Please complete this field', validateIdentity),
+});
+
+function validateIdentity() {
+  if (!this.parent.isIndigenous) return true;
+  // Following checks if any of the options are false
+  return Object.values(indigenousIdentityOptions).find((key) => this.parent[key]);
+}
 
 export const EditPSISchema = yup.object().shape({
   instituteName: yup.string().required(errorMessage),

--- a/client/src/constants/validation.js
+++ b/client/src/constants/validation.js
@@ -6,7 +6,7 @@ import {
   minDateString,
   maxDateString,
 } from './archiveParticipantsConstants';
-import { indigenousIdentityOptions } from '../components/modal-forms/IndigenousDeclarationForm';
+import { indigenousIdentities } from '../components/modal-forms/IndigenousDeclarationForm';
 
 const healthRegions = ['Interior', 'Fraser', 'Vancouver Coastal', 'Vancouver Island', 'Northern'];
 
@@ -505,19 +505,19 @@ export const CreatePSISchema = yup.object().shape({
 
 export const IndigenousDeclarationSchema = yup.object().shape({
   isIndigenous: yup.boolean().nullable(),
-  [indigenousIdentityOptions.FIRST_NATIONS]: yup
+  [indigenousIdentities.FIRST_NATIONS]: yup
     .boolean()
     .test('identityRequired', 'Please complete this field', validateIdentity),
-  [indigenousIdentityOptions.INUIT]: yup
+  [indigenousIdentities.INUIT]: yup
     .boolean()
     .test('identityRequired', 'Please complete this field', validateIdentity),
-  [indigenousIdentityOptions.METIS]: yup
+  [indigenousIdentities.METIS]: yup
     .boolean()
     .test('identityRequired', 'Please complete this field', validateIdentity),
-  [indigenousIdentityOptions.OTHER]: yup
+  [indigenousIdentities.OTHER]: yup
     .boolean()
     .test('identityRequired', 'Please complete this field', validateIdentity),
-  [indigenousIdentityOptions.UNKNOWN]: yup
+  [indigenousIdentities.UNKNOWN]: yup
     .boolean()
     .test('identityRequired', 'Please complete this field', validateIdentity),
 });
@@ -525,7 +525,7 @@ export const IndigenousDeclarationSchema = yup.object().shape({
 function validateIdentity() {
   if (!this.parent.isIndigenous) return true;
   // Following checks if any of the options are false
-  return Object.values(indigenousIdentityOptions).find((key) => this.parent[key]);
+  return Object.values(indigenousIdentities).find((key) => this.parent[key]);
 }
 
 export const EditPSISchema = yup.object().shape({

--- a/client/src/pages/private/ParticipantLanding.js
+++ b/client/src/pages/private/ParticipantLanding.js
@@ -117,7 +117,7 @@ export default () => {
 
   const hasEmptyIndigenousQuestions =
     interests.length > 0 &&
-    interests.find((item) => item.isIndigenous === null || item.isIndigenous === undefined);
+    !!interests.find((item) => item.isIndigenous === null || item.isIndigenous === undefined);
 
   const handleIndigenousIdentitySubmission = async (values) => {
     // If the user doesn't fill in the form, hide it for now, it will be shown again on next page load

--- a/client/src/pages/private/ParticipantLanding.js
+++ b/client/src/pages/private/ParticipantLanding.js
@@ -8,6 +8,8 @@ import { API_URL, Routes } from '../../constants';
 import { PEOIWithdrawalDialogForm } from '../../components/modal-forms/PEOIWithdrawalDialogForm';
 import { genericConfirm } from '../../constants/validation';
 import ParticipantLandingEmpty from './ParticipantLandingEmpty';
+import { IndigenousDeclarationForm } from '../../components/modal-forms/IndigenousDeclarationForm';
+
 const moment = require('moment');
 
 const useStyles = makeStyles(() => ({
@@ -107,6 +109,10 @@ export default () => {
     );
   }
 
+  const hasEmptyIndigenousQuestions = interests.find(
+    (item) => item.isIndigenous === null || item.isIndigenous === undefined
+  );
+
   return (
     <Page>
       <Dialog open={showWithdrawDialog}>
@@ -123,6 +129,9 @@ export default () => {
             history.push(Routes.ParticipantFullWithdraw);
           }}
         />
+      </Dialog>
+      <Dialog open={hasEmptyIndigenousQuestions}>
+        <IndigenousDeclarationForm />
       </Dialog>
       <Grid className={classes.posBox} container spacing={2}>
         <Grid style={{ paddingTop: 10 }} item xs={12}>

--- a/client/src/pages/private/ParticipantLanding.js
+++ b/client/src/pages/private/ParticipantLanding.js
@@ -4,12 +4,13 @@ import { Grid, Card, Box, Typography, Button, CardActions, Dialog } from '@mater
 import { makeStyles } from '@material-ui/core/styles';
 import store from 'store';
 import { Page } from '../../components/generic';
-import { API_URL, Routes } from '../../constants';
+import { API_URL, Routes, ToastStatus } from '../../constants';
 import { PEOIWithdrawalDialogForm } from '../../components/modal-forms/PEOIWithdrawalDialogForm';
 import { genericConfirm } from '../../constants/validation';
 import ParticipantLandingEmpty from './ParticipantLandingEmpty';
 import { IndigenousDeclarationForm } from '../../components/modal-forms/IndigenousDeclarationForm';
 import isNil from 'lodash/isNil';
+import { useToast } from '../../hooks';
 
 const rootUrl = `${API_URL}/api/v1/participant-user/participant`;
 
@@ -85,6 +86,7 @@ export default () => {
   const [hideIndigenousIdentityForm, setHideIndigenousIdentityForm] = useState(false);
   const classes = useStyles();
   const history = useHistory();
+  const { openToast } = useToast();
   const submitWithdrawal = async (values) => {
     if (values.confirmed) {
       await fetch(`${API_URL}/api/v1/participant-user/withdraw`, {
@@ -138,6 +140,11 @@ export default () => {
 
     if (response.ok) {
       await getParticipants().then((items) => setInterests(items));
+    } else {
+      openToast({
+        status: ToastStatus.Error,
+        message: response.error || response.statusText || 'Server error',
+      });
     }
   };
   const handleIndigenousIdentitySubmission = async (values) => {

--- a/client/src/pages/private/ParticipantLanding.js
+++ b/client/src/pages/private/ParticipantLanding.js
@@ -119,13 +119,19 @@ export default () => {
     (item) => item.isIndigenous === null || item.isIndigenous === undefined
   );
 
-  const updateUserIndigenousIdentities = async (id, values) => {
+  const handleIndigenousIdentitySubmission = async (values) => {
+    // If the user doesn't fill in the form, hide it for now, it will be shown again on next page load
+    if (isNil(values.isIndigenous)) {
+      setHideIndigenousIdentityForm(true);
+      return;
+    }
+
     const { isIndigenous, ...submittedIdentities } = values;
     const identities = Object.entries(submittedIdentities)
       .map(([identity, selected]) => (selected ? identity : null))
       .filter(Boolean);
 
-    const response = await fetch(`${rootUrl}/${id}`, {
+    const response = await fetch(`${rootUrl}/batch`, {
       method: 'PATCH',
       headers: {
         Authorization: `Bearer ${store.get('TOKEN')}`,
@@ -146,16 +152,6 @@ export default () => {
         message: response.error || response.statusText || 'Server error',
       });
     }
-  };
-  const handleIndigenousIdentitySubmission = async (values) => {
-    // If the user doesn't fill in the form, hide it for now, it will be shown again on next page load
-    if (isNil(values.isIndigenous)) {
-      setHideIndigenousIdentityForm(true);
-      return;
-    }
-
-    const ids = interests.map((item) => item.id);
-    await Promise.all(ids.map(async (id) => await updateUserIndigenousIdentities(id, values)));
   };
 
   return (

--- a/client/src/pages/private/ParticipantLanding.js
+++ b/client/src/pages/private/ParticipantLanding.js
@@ -115,9 +115,9 @@ export default () => {
     );
   }
 
-  const hasEmptyIndigenousQuestions = interests.find(
-    (item) => item.isIndigenous === null || item.isIndigenous === undefined
-  );
+  const hasEmptyIndigenousQuestions =
+    interests.length > 0 &&
+    interests.find((item) => item.isIndigenous === null || item.isIndigenous === undefined);
 
   const handleIndigenousIdentitySubmission = async (values) => {
     // If the user doesn't fill in the form, hide it for now, it will be shown again on next page load

--- a/client/src/pages/private/ParticipantLanding.js
+++ b/client/src/pages/private/ParticipantLanding.js
@@ -9,6 +9,7 @@ import { PEOIWithdrawalDialogForm } from '../../components/modal-forms/PEOIWithd
 import { genericConfirm } from '../../constants/validation';
 import ParticipantLandingEmpty from './ParticipantLandingEmpty';
 import { IndigenousDeclarationForm } from '../../components/modal-forms/IndigenousDeclarationForm';
+import isNil from 'lodash/isNil';
 
 const rootUrl = `${API_URL}/api/v1/participant-user/participant`;
 
@@ -81,6 +82,7 @@ export default () => {
   const [interests, setInterests] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showWithdrawDialog, setShowWithdrawDialog] = useState(false);
+  const [hideIndigenousIdentityForm, setHideIndigenousIdentityForm] = useState(false);
   const classes = useStyles();
   const history = useHistory();
   const submitWithdrawal = async (values) => {
@@ -139,6 +141,12 @@ export default () => {
     }
   };
   const handleIndigenousIdentitySubmission = async (values) => {
+    // If the user doesn't fill in the form, hide it for now, it will be shown again on next page load
+    if (isNil(values.isIndigenous)) {
+      setHideIndigenousIdentityForm(true);
+      return;
+    }
+
     const ids = interests.map((item) => item.id);
     await Promise.all(ids.map(async (id) => await updateUserIndigenousIdentities(id, values)));
   };
@@ -160,7 +168,7 @@ export default () => {
           }}
         />
       </Dialog>
-      <Dialog open={hasEmptyIndigenousQuestions}>
+      <Dialog open={hasEmptyIndigenousQuestions && !hideIndigenousIdentityForm}>
         <IndigenousDeclarationForm handleSubmit={handleIndigenousIdentitySubmission} />
       </Dialog>
       <Grid className={classes.posBox} container spacing={2}>

--- a/client/src/utils/isNonPortalHire.js
+++ b/client/src/utils/isNonPortalHire.js
@@ -6,5 +6,5 @@
  * @returns {boolean} True if the PEOI is a non-portal hire.
  */
 export const isNonPortalHire = (peoi) => {
-  return !peoi.formVersion;
+  return !peoi?.formVersion;
 };

--- a/server/routes/participant-user.js
+++ b/server/routes/participant-user.js
@@ -69,7 +69,13 @@ router.get(
 );
 
 // Update user info
-const patchableFields = ['phoneNumber', 'postalCode', 'postalCodeFsa'];
+const patchableFields = [
+  'phoneNumber',
+  'postalCode',
+  'postalCodeFsa',
+  'isIndigenous',
+  'indigenousIdentities',
+];
 router.patch(
   '/participant/:id',
   asyncMiddleware(async (req, res) => {

--- a/server/validation.js
+++ b/server/validation.js
@@ -689,6 +689,7 @@ const ParticipantQuerySchema = yup.object().shape({
   statusFilters: yup.array().of(yup.string().oneOf(participantStatuses, 'Invalid status')),
 });
 
+const validIndigenousIdentities = ['first-nations', 'inuit', 'metis', 'other', 'unknown'];
 const UserParticipantEditSchema = yup.object().shape({
   postalCode: yup
     .string()
@@ -699,7 +700,16 @@ const UserParticipantEditSchema = yup.object().shape({
     .nullable()
     .matches(/^[A-Z]\d[A-Z]$/),
   phoneNumber: yup.string().matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
+  isIndigenous: yup.boolean(),
+  indigenousIdentities: yup.array().when('isIndigenous', {
+    is: true,
+    then: yup
+      .array()
+      .of(yup.string().oneOf(validIndigenousIdentities, 'Invalid identity'))
+      .required('Indigenous Identity is required'),
+  }),
 });
+
 const ParticipantEditSchema = yup
   .object()
   .noUnknown('Unknown field in entry')

--- a/server/validation.js
+++ b/server/validation.js
@@ -693,16 +693,12 @@ const UserParticipantEditSchema = yup.object().shape({
   postalCode: yup
     .string()
     .nullable()
-    .required()
     .matches(/^[A-Z]\d[A-Z]\s?\d[A-Z]\d$/),
   postalCodeFsa: yup
     .string()
     .nullable()
     .matches(/^[A-Z]\d[A-Z]$/),
-  phoneNumber: yup
-    .string()
-    .required(errorMessage)
-    .matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
+  phoneNumber: yup.string().matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
 });
 const ParticipantEditSchema = yup
   .object()

--- a/server/validation.js
+++ b/server/validation.js
@@ -703,10 +703,7 @@ const UserParticipantEditSchema = yup.object().shape({
   isIndigenous: yup.boolean(),
   indigenousIdentities: yup.array().when('isIndigenous', {
     is: true,
-    then: yup
-      .array()
-      .of(yup.string().oneOf(validIndigenousIdentities, 'Invalid identity'))
-      .required('Indigenous Identity is required'),
+    then: yup.array().of(yup.string().oneOf(validIndigenousIdentities, 'Invalid identity')),
   }),
 });
 


### PR DESCRIPTION
- Participants who log in and have a PEOI without an indigenous identity answered see the form
- Form submission updates all associated PEOIs (1 network request per PEOI, should I create a bulk edit endpoint?)
  - After speaking with David, this will be upgraded to a batch edit feature (apply edits across all of a user's PEOIs)
- Includes fixes for HCAP-981 
- Read only version of these new questions viewable on PEOI form
- Add styling for `h4` + `h5`
- Validation: First question optional, if first question is 'Yes', second question is required
- New `participant` fields:
```
isIndigenous?: boolean;
identities: indigenousIdentityOptions 

const indigenousIdentityOptions = {
  FIRST_NATIONS: 'first-nations',
  INUIT: 'inuit',
  METIS: 'metis',
  OTHER: 'other',
  UNKNOWN: 'unknown',
}
```

![image](https://user-images.githubusercontent.com/71518072/140553081-5767d870-c09f-4cba-a8fb-16e28073b289.png)
![image](https://user-images.githubusercontent.com/71518072/140553098-6b94d9c5-7b7a-41b6-a9d1-14dd6f18fb78.png)
![image](https://user-images.githubusercontent.com/71518072/140553130-a49adb1f-71fb-4be4-a7b1-7e84ba9461fc.png)
![image](https://user-images.githubusercontent.com/71518072/140553142-0371a8fc-30a8-44e3-9da8-caff2d852ff5.png)
