### PR TITLE
HCAP-931 | Check for nullish, not falsey

### DIFF
--- a/client/src/components/participant-form/Fields.js
+++ b/client/src/components/participant-form/Fields.js
@@ -80,7 +80,7 @@ export const Fields = ({
       <Card noShadow={isDisabled}>
         {/** Indigenous Identity - meant to be READ-ONLY, not set up for editing */}
         <Grid container spacing={2}>
-          {isSubmitted && values.isIndigenous && (
+          {isSubmitted && !isNil(values.isIndigenous) && (
             <Grid item xs={12}>
               <Typography variant='subtitle2'>Indigenous Identity</Typography>
               <Divider />


### PR DESCRIPTION
The questions aren't rendered when a participant selects "No", it should only not show if the answer is null or undefined.