### PR TITLE
HCAP-983 | overwrite non-object histories

### DIFF
--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -123,9 +123,11 @@ const createChangeHistory = (participantBody, changes) => {
     timestamp: new Date(),
     changes: [...changeDetails],
   };
-  newBody.history = participantBody.history
-    ? [newHistory, ...participantBody.history]
-    : [newHistory];
+  // handle histories that have bad data/aren't objects
+  newBody.history =
+    participantBody.history && typeof participantBody.history === 'object'
+      ? [newHistory, ...participantBody.history]
+      : [newHistory];
   return newBody;
 };
 


### PR DESCRIPTION
If the current history value isn't an object then overwrite it with the given entry

https://freshworks.atlassian.net/browse/HCAP-983