### PR TITLE
HCAP-1032 | Add new archive reason - 'Fail Cohort'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Local Data Storage
+.pgdata*
+.mongo-data
+
 # Dependencies
 node_modules
 

--- a/client/src/components/modal-forms/ArchiveHiredParticipantForm.js
+++ b/client/src/components/modal-forms/ArchiveHiredParticipantForm.js
@@ -10,6 +10,8 @@ import {
   archiveReasonOptions,
   archiveStatusOptions,
   archiveTypeOptions,
+  FailedCohortReason,
+  PSIEducationUnderwayStatus,
 } from '../../constants';
 import { getTodayDate } from '../../utils';
 
@@ -57,7 +59,11 @@ export const ArchiveHiredParticipantForm = ({ onSubmit, onClose }) => {
               <Field
                 name='status'
                 component={RenderSelectField}
-                options={statusOptions}
+                options={
+                  props.values.reason === FailedCohortReason
+                    ? [{ value: PSIEducationUnderwayStatus, label: PSIEducationUnderwayStatus }]
+                    : statusOptions
+                }
                 label='Status'
               />
               <Field

--- a/client/src/constants/archiveParticipantsConstants.js
+++ b/client/src/constants/archiveParticipantsConstants.js
@@ -1,3 +1,7 @@
+export const FailedCohortReason = 'Failed cohort, does not wish to continue in HCAP';
+
+export const PSIEducationUnderwayStatus = 'Post secondary education underway';
+
 export const archiveReasonOptions = [
   'No longer interested in HCA/HCSW role',
   'No longer interested in a career in health care',
@@ -8,14 +12,14 @@ export const archiveReasonOptions = [
   'Delay initiating education',
   'Did not meet program requirements',
   'Issue with mandatory vaccination',
-  'Failed cohort, does not wish to continue in HCAP',
+  FailedCohortReason,
   'Other',
 ];
 
 export const archiveStatusOptions = [
   'Not begun orientation or training',
   'Provincial orientation curriculum complete',
-  'Post secondary education underway',
+  PSIEducationUnderwayStatus,
   'Completed post secondary education',
 ];
 

--- a/client/src/constants/archiveParticipantsConstants.js
+++ b/client/src/constants/archiveParticipantsConstants.js
@@ -8,6 +8,7 @@ export const archiveReasonOptions = [
   'Delay initiating education',
   'Did not meet program requirements',
   'Issue with mandatory vaccination',
+  'Failed cohort, does not wish to continue in HCAP',
   'Other',
 ];
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -76,7 +76,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
-      - postgres-data-db:/var/lib/postgresql/data
+      - ./.pgdata:/var/lib/postgresql/data
       - ./.docker/postgres/sql-init:/docker-entrypoint-initdb.d
     ports:
       - '5432:5432'
@@ -97,8 +97,8 @@ services:
       - MONGO_INITDB_DATABASE=${MONGO_DB}
     volumes:
       - ./.docker/mongo/databaseInit:/docker-entrypoint-initdb.d
-      - mongo-log-configdb:/data/configdb
-      - mongo-log-db:/data/db
+      - ./.mongo-data/configdb:/data/configdb
+      - ./.mongo-data/logs:/data/db
     networks:
       - network
 
@@ -106,11 +106,3 @@ networks:
   network:
     name: ${APP_NAME}-network
     driver: bridge
-
-volumes:
-  mongo-log-configdb:
-    name: ${APP_NAME}-mongo-log-configdb
-  mongo-log-db:
-    name: ${APP_NAME}-mongo-log-db
-  postgres-data-db:
-    name: ${APP_NAME}-postgres-data-db

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -72,7 +72,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
-      - postgres-data-db:/var/lib/postgresql/data
+      - ./.pgdata-test:/var/lib/postgresql/data
       - ./.docker/postgres/sql-init:/docker-entrypoint-initdb.d
     ports:
       - '5432:5432'
@@ -112,7 +112,3 @@ services:
 networks:
   backend:
     driver: 'bridge'
-
-volumes:
-  postgres-data-db:
-    name: ${APP_NAME}-postgres-data-db

--- a/server/validation.js
+++ b/server/validation.js
@@ -73,6 +73,7 @@ const archiveReasonOptions = [
   'Delay initiating education',
   'Did not meet program requirements',
   'Issue with mandatory vaccination',
+  'Failed cohort, does not wish to continue in HCAP',
   'Other',
 ];
 


### PR DESCRIPTION
- Add new archive reason 'Failed cohort, does not wish to continue in HCAP'
- Only Keep single status 'Post secondary education underway' after above mentioned reason selection 
- In local dev, update docker compose to attach volume from local file dir.

Ticket: [HCAP-1032](https://freshworks.atlassian.net/browse/HCAP-1032)