### PR TITLE
Hcap 789 fix local cypress tests

### DIFF
--- a/client/src/components/modal-forms/EditParticipantForm.js
+++ b/client/src/components/modal-forms/EditParticipantForm.js
@@ -54,8 +54,18 @@ export const EditParticipantForm = ({ initialValues, onClose, submissionCallback
       {({ submitForm }) => (
         <FormikForm>
           <Box>
-            <Field name='firstName' component={RenderTextField} label='First Name' />
-            <Field name='lastName' component={RenderTextField} label='Last Name' />
+            <Field
+              data-cy={'editParticipantFirstName'}
+              name='firstName'
+              component={RenderTextField}
+              label='First Name'
+            />
+            <Field
+              data-cy={'editParticipantLastName'}
+              name='lastName'
+              component={RenderTextField}
+              label='Last Name'
+            />
             <Field
               name='phoneNumber'
               component={RenderTextField}
@@ -63,18 +73,21 @@ export const EditParticipantForm = ({ initialValues, onClose, submissionCallback
               type='tel'
             />
             <Field
+              data-cy={'editParticipantEmail'}
               name='emailAddress'
               component={RenderTextField}
               label='* Email Address'
               type='email'
             />
             <Field
+              data-cy={'editParticipantEmail'}
               name='postalCode'
               component={RenderTextField}
               label='* Postal Code'
               type='text'
             />
             <Field
+              data-cy={'editParticipantInterested'}
               name='interested'
               component={RenderSelectField}
               label='Program Interest'
@@ -90,7 +103,13 @@ export const EditParticipantForm = ({ initialValues, onClose, submissionCallback
                 <Button onClick={onClose} color='default' text='Cancel' />
               </Grid>
               <Grid item>
-                <Button onClick={submitForm} variant='contained' color='primary' text='Save' />
+                <Button
+                  data-cy={'editParticipantSave'}
+                  onClick={submitForm}
+                  variant='contained'
+                  color='primary'
+                  text='Save'
+                />
               </Grid>
             </Grid>
           </Box>

--- a/client/src/components/modal-forms/EditParticipantForm.js
+++ b/client/src/components/modal-forms/EditParticipantForm.js
@@ -55,40 +55,40 @@ export const EditParticipantForm = ({ initialValues, onClose, submissionCallback
         <FormikForm>
           <Box>
             <Field
-              data-cy={'editParticipantFirstName'}
+              test-id={'editParticipantFirstName'}
               name='firstName'
               component={RenderTextField}
               label='First Name'
             />
             <Field
-              data-cy={'editParticipantLastName'}
+              test-id={'editParticipantLastName'}
               name='lastName'
               component={RenderTextField}
               label='Last Name'
             />
             <Field
-              data-cy={'editParticipantPhone'}
+              test-id={'editParticipantPhone'}
               name='phoneNumber'
               component={RenderTextField}
               label='* Phone Number'
               type='tel'
             />
             <Field
-              data-cy={'editParticipantEmail'}
+              test-id={'editParticipantEmail'}
               name='emailAddress'
               component={RenderTextField}
               label='* Email Address'
               type='email'
             />
             <Field
-              data-cy={'editParticipantEmail'}
+              test-id={'editParticipantEmail'}
               name='postalCode'
               component={RenderTextField}
               label='* Postal Code'
               type='text'
             />
             <Field
-              data-cy={'editParticipantInterested'}
+              test-id={'editParticipantInterested'}
               name='interested'
               component={RenderSelectField}
               label='Program Interest'
@@ -105,7 +105,7 @@ export const EditParticipantForm = ({ initialValues, onClose, submissionCallback
               </Grid>
               <Grid item>
                 <Button
-                  data-cy={'editParticipantSave'}
+                  test-id={'editParticipantSave'}
                   onClick={submitForm}
                   variant='contained'
                   color='primary'

--- a/client/src/components/modal-forms/EditParticipantForm.js
+++ b/client/src/components/modal-forms/EditParticipantForm.js
@@ -67,6 +67,7 @@ export const EditParticipantForm = ({ initialValues, onClose, submissionCallback
               label='Last Name'
             />
             <Field
+              data-cy={'editParticipantPhone'}
               name='phoneNumber'
               component={RenderTextField}
               label='* Phone Number'

--- a/client/src/pages/private/ParticipantDetailsView.js
+++ b/client/src/pages/private/ParticipantDetailsView.js
@@ -268,7 +268,7 @@ export default () => {
                       </Typography>
                     </Grid>
                     <Grid item xs={6}>
-                      <Typography data-cy={'participantDetailsView' + key} variant='body1'>
+                      <Typography test-id={'participantDetailsView' + key} variant='body1'>
                         {participant[key]}
                       </Typography>
                     </Grid>
@@ -279,7 +279,7 @@ export default () => {
             <Grid container style={{ marginBottom: '10px', marginLeft: '10px' }}>
               <Grid item xs={4}>
                 <Button
-                  data-cy='editInfoButton'
+                  test-id='editInfoButton'
                   variant='outlined'
                   disabled={!enableEdit}
                   onClick={showEditInfoModal}

--- a/client/src/pages/private/ParticipantDetailsView.js
+++ b/client/src/pages/private/ParticipantDetailsView.js
@@ -268,7 +268,9 @@ export default () => {
                       </Typography>
                     </Grid>
                     <Grid item xs={6}>
-                      <Typography variant='body1'>{participant[key]}</Typography>
+                      <Typography data-cy={'participantDetailsView' + key} variant='body1'>
+                        {participant[key]}
+                      </Typography>
                     </Grid>
                   </Grid>
                 ))}
@@ -276,7 +278,12 @@ export default () => {
             </Box>
             <Grid container style={{ marginBottom: '10px', marginLeft: '10px' }}>
               <Grid item xs={4}>
-                <Button variant='outlined' disabled={!enableEdit} onClick={showEditInfoModal}>
+                <Button
+                  data-cy='editInfoButton'
+                  variant='outlined'
+                  disabled={!enableEdit}
+                  onClick={showEditInfoModal}
+                >
                   Edit Info
                 </Button>
               </Grid>

--- a/cypress.json
+++ b/cypress.json
@@ -2,7 +2,7 @@
   "baseUrl": "http://hcapemployers.local.freshworks.club:4000",
   "chromeWebSecurity": false,
   "video": false,
-  "isLocal": true,
+  "isLocal": false,
   "env": {
     "apiBaseURL": "http://hcapemployers.local.freshworks.club:8081/api/v1",
     "participantBaseUrl": "http://hcapparticipants.local.freshworks.club:4000"

--- a/cypress.json
+++ b/cypress.json
@@ -2,7 +2,7 @@
   "baseUrl": "http://hcapemployers.local.freshworks.club:4000",
   "chromeWebSecurity": false,
   "video": false,
-  "isLocal": false,
+  "isLocal": true,
   "env": {
     "apiBaseURL": "http://hcapemployers.local.freshworks.club:8081/api/v1",
     "participantBaseUrl": "http://hcapparticipants.local.freshworks.club:4000"

--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,7 @@
   "baseUrl": "http://hcapemployers.local.freshworks.club:4000",
   "chromeWebSecurity": false,
   "video": false,
+  "isLocal": false,
   "env": {
     "apiBaseURL": "http://hcapemployers.local.freshworks.club:8081/api/v1",
     "participantBaseUrl": "http://hcapparticipants.local.freshworks.club:4000"

--- a/cypress/integration/editParticipant.spec.js
+++ b/cypress/integration/editParticipant.spec.js
@@ -7,14 +7,14 @@ describe('EOI View', () => {
   });
   it('Should be able edit participant details', () => {
     cy.visit('participant-details/participant/1');
-    cy.get('[data-cy=editInfoButton]').click();
+    cy.get('[test-id=editInfoButton]').click();
     // Generate a new first name
     const newName = 'New Name' + Math.floor(Math.random() * 10000);
     // Edit first name
-    cy.get('[data-cy=editParticipantFirstName]>div>input').clear().type(newName);
+    cy.get('[test-id=editParticipantFirstName]>div>input').clear().type(newName);
     // Save
-    cy.get('[data-cy=editParticipantSave]').click();
+    cy.get('[test-id=editParticipantSave]').click();
     // Verify that saved results shows up
-    cy.get('[data-cy=participantDetailsViewfullName]').should('contain', newName);
+    cy.get('[test-id=participantDetailsViewfullName]').should('contain', newName);
   });
 });

--- a/cypress/integration/editParticipant.spec.js
+++ b/cypress/integration/editParticipant.spec.js
@@ -1,0 +1,20 @@
+describe('EOI View', () => {
+  beforeEach(() => {
+    cy.kcLogin('test-moh');
+  });
+  afterEach(() => {
+    cy.kcLogout();
+  });
+  it('Should be able edit participant details', () => {
+    cy.visit('participant-details/participant/1');
+    cy.get('[data-cy=editInfoButton]').click();
+    // Generate a new first name
+    const newName = 'New Name' + Math.floor(Math.random() * 10000);
+    // Edit first name
+    cy.get('[data-cy=editParticipantFirstName]>div>input').clear().type(newName);
+    // Save
+    cy.get('[data-cy=editParticipantSave]').click();
+    // Verify that saved results shows up
+    cy.get('[data-cy=participantDetailsViewfullName]').should('contain', newName);
+  });
+});

--- a/cypress/integration/participantView.spec.js
+++ b/cypress/integration/participantView.spec.js
@@ -59,30 +59,5 @@ describe('Participant View', () => {
     cy.contains('Preferred Location').click();
     cy.get('ul.MuiMenu-list[role=listbox]').should('be.visible');
     cy.get('ul.MuiMenu-list[role=listbox] > li').should('have.length', 6);
-
-    // Testing Tabs - DESCOPED FOR 165
-    // cy.get('ul.MuiMenu-list[role=listbox]').first().click();
-    // cy.get("button#sitesTab").click();
-    // cy.contains("My Sites").should('exist');
   });
-
-  // Disabled for the sake of getting this PR through
-  // it('Uses the MoH edit feature', () => {
-  //   cy.intercept('patch', '/api/v1/participant', (req) => {
-  //     expect(req.body.history[0].changes[0]).to.deep.equal({
-  //       field: 'firstName',
-  //       from: 'Graham',
-  //       to: 'Animal',
-  //     });
-  //     req.reply({ ok: true });
-  //   }).as('patchAnswer');
-  //   cy.kcLogin('test-moh');
-  //   cy.visit('/participant-view');
-  //   cy.contains('Edit').click();
-  //   cy.get('div.MuiDialog-scrollPaper').should('exist');
-  //   cy.get('input[name=firstName').should('have.value', 'Graham').clear().type('Animal');
-  //   cy.contains('Save').focus().click();
-  //   cy.wait('@patchAnswer');
-  //   cy.get('div.MuiDialog-scrollPaper').should('not.exist');
-  // });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,35 +23,23 @@ const getAuthCodeFromLocation = (location) => {
 
 const authBaseUrl = Cypress.env('KEYCLOAK_LOCAL_AUTH_URL') || Cypress.env('KEYCLOAK_AUTH_URL');
 
-Cypress.Commands.add('kcLogout', function () {
-  Cypress.log({ name: 'Logout' });
-  let realm = Cypress.env('KEYCLOAK_REALM');
-  return cy.request({
-    url: `${authBaseUrl}/realms/${realm}/protocol/openid-connect/logout`,
-  });
-});
-
-Cypress.Commands.add('kcLogin', (user) => {
-  Cypress.log({ name: 'Login' });
+const localLogin = (user) => {
   cy.fixture('users/' + user).then((userData) => {
     let realm = Cypress.env('KEYCLOAK_REALM');
     let client_id = Cypress.env('KEYCLOAK_API_CLIENTID');
-    let client_secret = Cypress.env('KEYCLOAK_LOCAL_SECRET');
 
     const base64URLEncode = (str) => {
       return str.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
     };
 
     const code_challenge = base64URLEncode(crypto.randomBytes(32));
-    const feebleOffering = authBaseUrl + '/realms/' + realm + '/protocol/openid-connect/auth';
+    const authCompleteUrl = authBaseUrl + '/realms/' + realm + '/protocol/openid-connect/auth';
     const queryObject = {
       client_id: client_id,
       redirect_uri: 'http%3A%2F%2Fhcapemployers.local.freshworks.club%3A4000%2Fkeycloak',
-      state: '0c323d9a-09ba-418c-8a9c-c4b818fb126a',
       response_mode: 'fragment',
       response_type: 'code',
       scope: 'openid',
-      nonce: '6c6dfb2b-de43-407e-af52-75279fc6302a',
       code_challenge,
       code_challenge_method: 'S256',
     };
@@ -60,7 +48,7 @@ Cypress.Commands.add('kcLogin', (user) => {
         return key + '=' + queryObject[key];
       })
       .join('&');
-    const url = feebleOffering + '?' + queryString;
+    const url = authCompleteUrl + '?' + queryString;
     cy.request({
       url,
       followRedirect: true,
@@ -74,6 +62,55 @@ Cypress.Commands.add('kcLogin', (user) => {
           method: 'POST',
           url: url,
           followRedirect: true,
+          form: true,
+          body: {
+            username: userData.username,
+            password: userData.password,
+          },
+        });
+      })
+      .then(function (response) {
+        expect(response.status).equal(200);
+      });
+  });
+};
+
+const pipelineLogin = (user) => {
+  cy.fixture('users/' + user).then((userData) => {
+    let realm = Cypress.env('KEYCLOAK_REALM');
+    let client_id = Cypress.env('KEYCLOAK_API_CLIENTID');
+    let client_secret = Cypress.env('KEYCLOAK_LOCAL_SECRET');
+
+    const base64URLEncode = (str) => {
+      return str.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    };
+
+    const code_challenge = base64URLEncode(crypto.randomBytes(32));
+
+    cy.request({
+      url: authBaseUrl + '/realms/' + realm + '/protocol/openid-connect/auth',
+
+      followRedirect: false,
+      qs: {
+        scope: 'openid',
+        response_type: 'code',
+        approval_prompt: 'auto',
+        redirect_uri: Cypress.config('baseUrl'),
+        client_id: client_id,
+        client_secret: client_secret,
+        code_challenge_method: 'plain',
+        code_challenge,
+      },
+    })
+      .then(function (response) {
+        let html = document.createElement('html');
+        html.innerHTML = response.body;
+        let form = html.getElementsByTagName('form')[0];
+        let url = form.action;
+        return cy.request({
+          method: 'POST',
+          url: url,
+          followRedirect: false,
           form: true,
           body: {
             username: userData.username,
@@ -99,6 +136,24 @@ Cypress.Commands.add('kcLogin', (user) => {
         }).its('body');
       });
   });
+};
+
+Cypress.Commands.add('kcLogout', function () {
+  Cypress.log({ name: 'Logout' });
+  let realm = Cypress.env('KEYCLOAK_REALM');
+  return cy.request({
+    url: `${authBaseUrl}/realms/${realm}/protocol/openid-connect/logout`,
+  });
+});
+
+Cypress.Commands.add('kcLogin', (user) => {
+  Cypress.log({ name: 'Login' });
+  cy.log(JSON.stringify(Cypress.env()));
+  //if (Cypress.env('isLocal')) {
+  localLogin(user);
+  //} else {
+  //  pipelineLogin(user);
+  //}
 });
 
 Cypress.Commands.add('kcLogout', function () {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -148,12 +148,11 @@ Cypress.Commands.add('kcLogout', function () {
 
 Cypress.Commands.add('kcLogin', (user) => {
   Cypress.log({ name: 'Login' });
-  cy.log(JSON.stringify(Cypress.env()));
-  //if (Cypress.env('isLocal')) {
-  localLogin(user);
-  //} else {
-  //  pipelineLogin(user);
-  //}
+  if (Cypress.env('isLocal')) {
+    localLogin(user);
+  } else {
+    pipelineLogin(user);
+  }
 });
 
 Cypress.Commands.add('kcLogout', function () {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -148,6 +148,7 @@ Cypress.Commands.add('kcLogout', function () {
 
 Cypress.Commands.add('kcLogin', (user) => {
   Cypress.log({ name: 'Login' });
+  // Change isLocal to true to enable local
   if (Cypress.env('isLocal')) {
     localLogin(user);
   } else {


### PR DESCRIPTION
I've fixed cypress tests for me locally (for the most part) .

Some environment variables needed. 
-- AUTH_URL needs to be set to the local keycloak url, http://keycloak.local.freshworks.club:8080/auth
-- The port of the backend url needs to be set to 8081
-- KEYCLOAK_LOCAL_AUTH_URL needs to be set to the same as the auth URL 

Keycloak needs some configuration 
-- The local service account needs to have it's password reset 
-- The local keycloak client secret needs to be set 

I rebuilt the login flow for local by copying the headers/paramteters that my browser used into postman and then translating that into cypress. 

Because the two login processes were quite different, I split them into two separate functions. I tried adding a variable into cypress.json to track this, but for some reason it's not being picked up. For now, just replace `Cypress.env('isLocal')` in the if statement with true if you want to run locally. 


I also included a test for my most recent ticket HCAP-1028. Adding data-cy attributes is best practice and something we should continue doing going forward. 

There are still some local issues, and I hope to fix them in good time. 

<img width="1673" alt="Screen Shot 2022-01-31 at 3 17 36 PM" src="https://user-images.githubusercontent.com/54554766/151888845-94b3a2a0-3374-4f47-be67-37e6cb475163.png">

