### PR TITLE
Fix Git Build Issue | Fix PR merge deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,9 +96,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: 'dev'
-          fetch-depth: 0
       - name: Build & Deploy
         run: |
           cd "$GITHUB_WORKSPACE"


### PR DESCRIPTION
Current build workflow checking out `dev` ref (tag) to get commit sh as build id. Which is conflicting with PR merge workflow (pushing commit in master branch).

New workflow checkout code based on event source (branch: master / tag:dev)