### PR TITLE
HCAP-1033 | HCAP-1087 | HCAP-1088 | BugFix | Update unsuccessful cohort label with date

### DIFF
--- a/client/src/components/participant-details/track-graduation.js
+++ b/client/src/components/participant-details/track-graduation.js
@@ -66,13 +66,6 @@ export const TrackGraduation = (props) => {
         <Grid item xs={4}>
           <Typography variant='subtitle2'>Graduation Status</Typography>
           <Typography>{props?.participant?.postHireStatusLabel || 'N/A'}</Typography>
-          {props?.participant?.postHireStatus?.status === postHireStatuses.cohortUnsuccessful && (
-            <Typography>
-              Unsuccessful cohort date:
-              {props?.participant?.postHireStatus?.data?.unsuccessfulCohortDate}
-            </Typography>
-          )}
-
           <Grid item xs={6}>
             <Button
               color='default'

--- a/client/src/services/participant.js
+++ b/client/src/services/participant.js
@@ -11,7 +11,7 @@ const getPostHireStatusLabel = ({ status, data = {} } = {}) => {
     case postHireStatuses.postSecondaryEducationCompleted:
       return `Graduation Completed on - ${data.graduationDate}`;
     case postHireStatuses.cohortUnsuccessful:
-      return `Unsuccessful/incomplete course.`;
+      return `Unsuccessful/incomplete course - ${data.unsuccessfulCohortDate}`;
     default:
       return `Status not recorded`;
   }


### PR DESCRIPTION
- [x] Add date label for participant unsuccessful cohort status in participant details page [HCAP-1087](https://freshworks.atlassian.net/browse/HCAP-1087)
- [x] Remove extra line of status from track graduation tab details [HCAP-1088](https://freshworks.atlassian.net/browse/HCAP-1088)  