### PR TITLE
HCAP-1107/1168 | Update service and api route to handle sites for prospecting statuses

### DIFF
--- a/server/routes/participant.js
+++ b/server/routes/participant.js
@@ -387,7 +387,8 @@ employerActionsRouter.post(
       req.body.participantId,
       req.body.status,
       req.body.data,
-      user
+      user,
+      req.body.sites || null
     );
     logger.info({
       action: 'employer-actions_post',

--- a/server/tests/employer-action.e2e.test.js
+++ b/server/tests/employer-action.e2e.test.js
@@ -1,0 +1,43 @@
+// Test Code: npm run test:debug employer-action.e2e.test.js
+const request = require('supertest');
+const app = require('../server');
+const { startDB, closeDB } = require('./util/db');
+const { getKeycloakToken, employer } = require('./util/keycloak');
+const { makeTestParticipant, makeTestSite } = require('./util/integrationTestData');
+
+describe('Test api/v1/employer-actions', () => {
+  let server;
+  beforeAll(async () => {
+    await startDB();
+    server = app.listen();
+  });
+
+  afterAll(async () => {
+    await closeDB();
+    await server.close();
+  });
+
+  it('should create participant status', async () => {
+    // Participant
+    const participant = await makeTestParticipant({
+      emailAddress: 'employer.action.e2e.1@hcap.io',
+    });
+    const site = await makeTestSite({
+      siteId: 202204201210,
+      siteName: 'Test Site e2e 01',
+      city: 'Test City e2e 01',
+    });
+
+    const header = await getKeycloakToken(employer);
+    const res = await request(app)
+      .post(`/api/v1/employer-actions`)
+      .set(header)
+      .send({
+        participantId: participant.id,
+        status: 'prospecting',
+        data: {},
+        sites: [site],
+      });
+    expect(res.statusCode).toBe(201);
+  });
+});

--- a/server/tests/participant.test.js
+++ b/server/tests/participant.test.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
+// Test: npm run test:debug participant.test.js
 const { readFileSync } = require('fs');
 const { join } = require('path');
 const request = require('supertest');

--- a/server/validators/participant.js
+++ b/server/validators/participant.js
@@ -244,6 +244,13 @@ const ParticipantStatusChange = yup
       );
     }),
     status: yup.string().oneOf(participantStatuses, 'Invalid status'),
+    sites: yup.array().when(['status'], (status, schema) => {
+      if (['interviewing', 'prospecting', 'prospecting', 'rejected'].includes(status)) {
+        // TODO: Change validation to required
+        return schema.optional('Sites is required');
+      }
+      return schema.optional().nullable();
+    }),
   });
 
 const ParticipantEditSchema = yup


### PR DESCRIPTION
- [x] Update service method `setParticipantStatus` to save associated sits with status
- [x] Update web rest api routes and validator  
- [x] Create tests  