### PR TITLE
HCAP-1140 | Enable MultiOrg display of prospecting statuses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ database: ## <Helper> :: Executes into database container.
 
 app: ## Bash into App container
 	@echo "Make: Shelling into local application container"
-	@docker-compose -f docker-compose.dev.yml exec server /bin/sh
+	@docker-compose -f docker-compose.dev.yml exec server /bin/bash
 
 # Git Tagging Aliases
 

--- a/server/constants/index.js
+++ b/server/constants/index.js
@@ -1,7 +1,9 @@
 const ros = require('./return-of-service');
 const validationConstants = require('./validation-constants');
+const participantStatus = require('./participant-status');
 
 module.exports = {
   ...validationConstants,
   ...ros,
+  ...participantStatus,
 };

--- a/server/constants/participant-status.js
+++ b/server/constants/participant-status.js
@@ -1,0 +1,13 @@
+const participantStatus = {
+  OPEN: 'open',
+  PROSPECTING: 'prospecting',
+  INTERVIEWING: 'interviewing',
+  OFFER_MADE: 'offer_made',
+  ARCHIVED: 'archived',
+  REJECTED: 'rejected',
+  HIRED: 'hired',
+};
+
+module.exports = {
+  participantStatus,
+};

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -216,7 +216,6 @@ class FieldsFilteredParticipantsFinder {
           on: {
             participant_id: 'id',
             current: true,
-            // ...(!isFetchingHiresStatus && { employer_id: user.id }),
           },
           employerInfo: {
             type: 'LEFT OUTER',

--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -653,6 +653,11 @@ const getParticipants = async (
           statusInfo.employerId !== user.id
       );
 
+      // Archived by org
+      const archivedByOrgStatus = item.statusInfos?.find(
+        (statusInfo) => statusInfo.status === 'archived' && statusInfo.employerId !== user.id
+      );
+
       // Handling withdrawn and already hired, putting withdrawn as higher priority
       let computedStatus;
       if (item.interested === 'withdrawn' || item.interested === 'no') {
@@ -677,6 +682,8 @@ const getParticipants = async (
             status: 'hired_by_peer',
           };
         }
+      } else if (archivedByOrgStatus) {
+        computedStatus = archivedByOrgStatus;
       }
 
       if (computedStatus) {

--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -15,6 +15,8 @@ const logger = require('../logger.js');
 const { getAssignCohort } = require('./cohorts');
 const { createPostHireStatus, getPostHireStatusesForParticipant } = require('./post-hire-flow');
 
+const { participantStatus } = require('../constants');
+
 const deleteParticipant = async ({ email }) => {
   await dbClient.db.withTransaction(async (tnx) => {
     // Delete entry from participant-user-map
@@ -286,11 +288,48 @@ const setParticipantStatus = async (
       if (items.length > 0) return { status: 'already_hired' };
     }
 
-    const item = await tx[collections.PARTICIPANTS_STATUS].findOne({
-      participant_id: participantId,
-      employer_id: employerId,
-      current: true,
-    });
+    const item =
+      (
+        await tx[collections.PARTICIPANTS_STATUS]
+          .join({
+            sites: {
+              type: 'LEFT OUTER',
+              relation: collections.SITE_PARTICIPANTS_STATUS,
+              on: {
+                participant_status_id: 'id',
+              },
+              siteDetails: {
+                type: 'LEFT OUTER',
+                relation: collections.EMPLOYER_SITES,
+                decomposeTo: 'object',
+                on: {
+                  id: 'sites.site_id',
+                },
+              },
+            },
+          })
+          .find({
+            participant_id: participantId,
+            current: true,
+            and: [
+              {
+                or: [
+                  {
+                    employer_id: employerId,
+                  },
+                  {
+                    and: [
+                      {
+                        'employer_id <>': employerId,
+                        'siteDetails.body.siteId IN': user.sites,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          })
+      )[0] || null;
     // Check the desired status against the current status:
     // -- Rejecting a participant is allowed even if they've been hired elsewhere (handled above)
     // -- Open is the starting point, there is no way to transition here from any other status
@@ -341,7 +380,31 @@ const setParticipantStatus = async (
         return { status: 'invalid_archive' };
       }
     }
+    // Get site association for prospecting status
+    let associatedSites = sites;
+    if (
+      [
+        participantStatus.INTERVIEWING,
+        participantStatus.OFFER_MADE,
+        participantStatus.REJECTED,
+      ].includes(status) &&
+      !sites &&
+      item.sites &&
+      item.sites.length > 0
+    ) {
+      associatedSites = item.sites.map((site) => ({ id: site.site_id }));
+    }
     // Invalidate pervious status
+    if (item && item.employer_id !== employerId) {
+      await tx[collections.PARTICIPANTS_STATUS].update(
+        {
+          employer_id: item.employer_id,
+          participant_id: participantId,
+          current: true,
+        },
+        { current: false }
+      );
+    }
     await tx[collections.PARTICIPANTS_STATUS].update(
       {
         employer_id: employerId,
@@ -361,9 +424,9 @@ const setParticipantStatus = async (
     });
 
     // Save sites if supplied
-    if (sites && sites.length > 0 && statusObj.id) {
+    if (associatedSites && associatedSites.length > 0 && statusObj.id) {
       await Promise.all(
-        sites.map(({ id }) =>
+        associatedSites.map(({ id }) =>
           tx[collections.SITE_PARTICIPANTS_STATUS].save({
             participant_status_id: statusObj.id,
             site_id: id,
@@ -625,7 +688,10 @@ const getParticipants = async (
       const statusInfos = item.statusInfos?.find(
         (statusInfo) =>
           statusInfo.employerId === user.id ||
-          (statusInfo.data && user.sites.includes(statusInfo.data.site))
+          (statusInfo.data && user.sites.includes(statusInfo.data.site)) ||
+          (statusInfo.associatedSitesIds &&
+            statusInfo.associatedSitesIds.length > 0 &&
+            statusInfo.associatedSitesIds.filter((id) => user.sites.includes(id)).length > 0)
       );
 
       if (statusInfos) {

--- a/server/services/participants.js
+++ b/server/services/participants.js
@@ -321,7 +321,7 @@ const setParticipantStatus = async (
                     and: [
                       {
                         'employer_id <>': employerId,
-                        'siteDetails.body.siteId IN': user.sites,
+                        'siteDetails.body.siteId IN': user?.sites || [],
                       },
                     ],
                   },

--- a/server/tests/participant-status.test.js
+++ b/server/tests/participant-status.test.js
@@ -148,5 +148,32 @@ describe('Test Participant status data model and service', () => {
     );
 
     expect(resultFailure.data.length).toBe(0);
+
+    // Now set next status
+    await setParticipantStatus(
+      emp2,
+      participant.id,
+      'interviewing',
+      {},
+      {
+        sites: [site1.siteId],
+      }
+    );
+
+    // Read by multi org employer
+    const resultSuccess2 = await getParticipants(
+      { isEmployer: true, id: emp1, regions, sites: [site1.siteId] },
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      ['interviewing']
+    );
+
+    expect(resultSuccess2.data.length).toBeGreaterThanOrEqual(1);
+    expect(resultSuccess2.data[0].id).toBe(participant.id);
   });
 });

--- a/server/tests/participant-status.test.js
+++ b/server/tests/participant-status.test.js
@@ -1,13 +1,15 @@
 // Test execution code: npm run test:debug participant-status.test.js
 const { v4 } = require('uuid');
 const { dbClient, collections } = require('../db');
-const { setParticipantStatus } = require('../services/participants');
+const { setParticipantStatus, getParticipants } = require('../services/participants');
 const { startDB, closeDB } = require('./util/db');
 const {
   makeTestParticipant,
   makeTestParticipantStatus,
   makeTestSite,
 } = require('./util/integrationTestData');
+
+const regions = ['Fraser', 'Interior', 'Northern', 'Vancouver Coastal', 'Vancouver Island'];
 
 describe('Test Participant status data model and service', () => {
   beforeAll(async () => {
@@ -94,5 +96,57 @@ describe('Test Participant status data model and service', () => {
       });
 
     expect(items.length).toBe(2);
+  });
+
+  it('should return multi org participant', async () => {
+    const participant = await makeTestParticipant({
+      emailAddress: 'test.site.participant.3@hcap.io',
+    });
+
+    const site1 = await makeTestSite({
+      siteId: 202204221211,
+      siteName: 'Test Site 1030',
+      city: 'Test City 1030',
+    });
+
+    const site2 = await makeTestSite({
+      siteId: 202204221212,
+      siteName: 'Test Site 1030',
+      city: 'Test City 1030',
+    });
+
+    const emp1 = v4();
+    const emp2 = v4();
+    const emp3 = v4();
+
+    await setParticipantStatus(emp1, participant.id, 'prospecting', {}, {}, [site1]);
+
+    const resultSuccess = await getParticipants(
+      { isEmployer: true, id: emp2, regions, sites: [site1.siteId] },
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      ['prospecting']
+    );
+    expect(resultSuccess.data.length).toBeGreaterThanOrEqual(1);
+    expect(resultSuccess.data[0].id).toBe(participant.id);
+
+    const resultFailure = await getParticipants(
+      { isEmployer: true, id: emp3, regions, sites: [site2.siteId] },
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      ['prospecting']
+    );
+
+    expect(resultFailure.data.length).toBe(0);
   });
 });


### PR DESCRIPTION
- [x] Update status-filter logic
- [x]  Update data display logic 
- [x]  Add logic to copy site association from one prospecting status to another
- [x] Update tests
- [x] Update status-filter to support multiorg archive display 

Ticket: [HCAP-1140](https://freshworks.atlassian.net/browse/HCAP-1140)