### PR TITLE
HCAP-1175 | Multiselect anchoring

### DIFF
--- a/client/src/components/fields/RenderMultiSelectField.js
+++ b/client/src/components/fields/RenderMultiSelectField.js
@@ -20,6 +20,11 @@ export const RenderMultiSelectField = ({ field, form, label, options, placeholde
     return defaultPlaceholder;
   };
 
+  const menuProps = {
+    variant: 'menu',
+    getContentAnchorEl: null,
+  };
+
   return (
     <Fragment>
       {label && <InputFieldLabel label={label} />}
@@ -32,6 +37,7 @@ export const RenderMultiSelectField = ({ field, form, label, options, placeholde
         error={touched && !!error}
         inputProps={{ displayEmpty: true }}
         value={field.value || []}
+        MenuProps={menuProps}
         {...props}
       >
         <MenuItem value='' disabled>


### PR DESCRIPTION
https://freshworks.atlassian.net/jira/software/c/projects/HCAP/boards/192?selectedIssue=HCAP-1107

- Found that the issue we were experiencing with the select was a known issue with the component: https://github.com/mui/material-ui/issues/19977

- Solution referenced in issue worked, and covers in detail why it happens (TLDR: it recalculates the anchor point when you select something new): https://stackoverflow.com/questions/59785482/multiselect-box-popover-keeps-jumping-when-scroll-or-select-items/59790471#59790471