### PR TITLE
HCAP-1106 | unsortable last engaged by column

### DIFF
--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -163,7 +163,7 @@ const columns = {
   rosStartDate: { id: 'rosStartDate', name: 'Return of Service Start Date', sortOrder: 22 },
   rosSiteName: { id: 'rosSiteName', name: 'Site Name', sortOrder: 23 },
   employerName: { id: 'employerName', name: 'Hired By', sortOrder: 24 },
-  engagedBy: { id: 'engagedBy', name: 'Last Engaged By', sortOrder: 16 },
+  engagedBy: { id: 'engagedBy', name: 'Last Engaged By', sortOrder: 16, sortable: false },
 };
 
 const {


### PR DESCRIPTION
Marking last engaged by column unsortable so that the sorting UI does not cause it to crash.