### PR TITLE
HCAP-1106 | Make Last Engaged By column sortable

### DIFF
--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -163,7 +163,7 @@ const columns = {
   rosStartDate: { id: 'rosStartDate', name: 'Return of Service Start Date', sortOrder: 22 },
   rosSiteName: { id: 'rosSiteName', name: 'Site Name', sortOrder: 23 },
   employerName: { id: 'employerName', name: 'Hired By', sortOrder: 24 },
-  engagedBy: { id: 'engagedBy', name: 'Last Engaged By', sortOrder: 16, sortable: false },
+  engagedBy: { id: 'engagedBy', name: 'Last Engaged By', sortOrder: 16 },
 };
 
 const {

--- a/server/constants/validation-constants.js
+++ b/server/constants/validation-constants.js
@@ -36,6 +36,7 @@ const sortFields = [
   'rosStartDate',
   'rosSiteName',
   'employerName',
+  'engagedBy',
 ];
 
 const roles = [

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -158,7 +158,7 @@ class FilteredParticipantsFinder {
       });
 
       // To manage employer name column sorting we need to sort by employer name
-      if (sortField === 'employerName') {
+      if (sortField === 'employerName' || sortField === 'engagedBy') {
         this.context.options.order.unshift(
           {
             field: `employerInfo.body.userInfo.firstName`,


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1106
- This is the second part of this story, the column has been added previously, now it is sortable.
- On first click, it sorts reverse alphabetical (2 clicks for alphabetical). However, I noticed that the Last Name column does as well.