### PR TITLE
HCAP-701: fix MoH participant 'Open' status

### DIFF
--- a/client/src/components/modal-forms/SelectProspectingSiteForm.js
+++ b/client/src/components/modal-forms/SelectProspectingSiteForm.js
@@ -99,7 +99,7 @@ export const SelectProspectingSiteForm = ({
                     {selected.map((participant, index) => (
                       <ListItem key={`p${index}`}>
                         <ListItemText
-                          primary={`${participant.id}   ${participant.firstName} ${participant.lastName}`}
+                          primary={`${participant.id} ${participant.firstName} ${participant.lastName}`}
                         />
                       </ListItem>
                     ))}

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -69,6 +69,7 @@ const filterData = (data, columns) => {
 
     row.engage = item;
     row.siteName = item?.statusInfos?.[0].data?.siteName;
+
     if (
       item.rosStatuses &&
       item.rosStatuses.length > 0 &&
@@ -93,7 +94,10 @@ const filterData = (data, columns) => {
         row.status = [item.statusInfos[0].status];
       }
     } else if (item.progressStats) {
-      row.status = ['open', ...Object.keys(item.progressStats).filter((key) => key === 'archived')];
+      row.status = [item.statusInfo, ...Object.keys(item.progressStats).filter((key) => key === 'archived')];
+      if (item.interested === 'withdrawn') {
+        row.status.push(item.interested);
+      }
     } else {
       row.status = ['open'];
     }

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -94,7 +94,10 @@ const filterData = (data, columns) => {
         row.status = [item.statusInfos[0].status];
       }
     } else if (item.progressStats) {
-      row.status = [item.statusInfo, ...Object.keys(item.progressStats).filter((key) => key === 'archived')];
+      row.status = [
+        item.statusInfo,
+        ...Object.keys(item.progressStats).filter((key) => key === 'archived'),
+      ];
       if (item.interested === 'withdrawn') {
         row.status.push(item.interested);
       }

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -47,15 +47,14 @@ const getStatusForMoH = (isInterested, progressStats) => {
     isWithdrawn = true;
   }
 
-  if (progressStats.prospecting) {
-    firstStatus = 'prospecting';
+  if (progressStats.total && !progressStats.hired) {
+    const count =
+      progressStats.offer_made || progressStats.interviewing || progressStats.prospecting;
+    if (count > 0) {
+      firstStatus = `inprogress_${count}`;
+    }
   }
-  if (progressStats.interviewing) {
-    firstStatus = 'interviewing';
-  }
-  if (progressStats.offer_made) {
-    firstStatus = 'offer_made';
-  }
+
   if (progressStats.hired) {
     firstStatus = 'hired';
   }

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -14,10 +14,9 @@ const getParticipantStatus = (isMoH, status) => {
   if (status === 'rejected') return 'Archived';
   if (status === 'ros') return 'Return of Service';
 
-  if (isMoH) {
-    if (status === 'prospecting') return 'In Progress';
-    if (status === 'interviewing') return 'In Progress (2)';
-    if (status === 'offer_made') return 'In Progress (3)';
+  if (isMoH && status.startsWith('inprogress')) {
+    const count = status.split('_');
+    return `In Progress (${count[1]})`;
   }
 
   if (status === 'offer_made') return 'Offer Made';

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -3,6 +3,13 @@ import InfoIcon from '@material-ui/icons/Info';
 import { ComponentTooltip } from '../components/generic/ComponentTooltip';
 import { Button } from '../components/generic';
 
+/**
+ * Returns participant stats message based on the first status provided
+ *
+ * @param {boolean} isMoH - is this view displayed for MoH user
+ * @param {string} status - first status defined in row.status
+ * @returns {string} specific status message based on value / capitalized status
+ */
 const getParticipantStatus = (isMoH, status) => {
   if (status === 'rejected') return 'Archived';
   if (status === 'ros') return 'Return of Service';

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -3,7 +3,10 @@ import InfoIcon from '@material-ui/icons/Info';
 import { ComponentTooltip } from '../components/generic/ComponentTooltip';
 import { Button } from '../components/generic';
 
-const getInProgressStatus = (isMoH, status) => {
+const getParticipantStatus = (isMoH, status) => {
+  if (status === 'rejected') return 'Archived';
+  if (status === 'ros') return 'Return of Service';
+
   if (isMoH) {
     if (status === 'prospecting') return 'In Progress';
     if (status === 'interviewing') return 'In Progress (2)';
@@ -26,20 +29,9 @@ export const prettifyStatus = (
   const statusValue = status[0];
   let firstStatus = statusValue;
   let isWithdrawn = false;
-  if (statusValue === 'available') firstStatus = 'Available';
-  if (statusValue === 'open') firstStatus = 'Open';
 
-  if (
-    statusValue === 'offer_made' ||
-    statusValue === 'interviewing' ||
-    statusValue === 'prospecting'
-  ) {
-    firstStatus = getInProgressStatus(isMoH, statusValue);
-  }
+  firstStatus = getParticipantStatus(isMoH, statusValue);
 
-  if (statusValue === 'rejected') firstStatus = 'Archived';
-  if (statusValue === 'hired') firstStatus = 'Hired';
-  if (statusValue === 'ros') firstStatus = 'Return of Service';
   if (status.includes('withdrawn')) {
     firstStatus = 'Withdrawn';
     isWithdrawn = true;
@@ -49,15 +41,14 @@ export const prettifyStatus = (
   }
   let toolTip = 'This candidate was hired by another employer.';
   if (isWithdrawn) {
-    if (status.includes('pending_acknowledgement')) {
-      toolTip = 'This candidate was archived.';
-    } else {
-      toolTip = 'Participant is no longer available.';
-    }
+    toolTip = status.includes('pending_acknowledgement')
+      ? 'This candidate was archived.'
+      : 'Participant is no longer available.';
   }
 
-  if (status[1] === 'hired_by_peer')
+  if (status[1] === 'hired_by_peer') {
     toolTip = 'This candidate was hired by same site. And available in "Hired Participants" tab.';
+  }
 
   const hideAcknowledgeButton =
     !(tabValue === 'Hired Candidates' && status.includes('pending_acknowledgement')) &&

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -27,10 +27,8 @@ export const prettifyStatus = (
   isMoH = false
 ) => {
   const statusValue = status[0];
-  let firstStatus = statusValue;
+  let firstStatus = getParticipantStatus(isMoH, statusValue);
   let isWithdrawn = false;
-
-  firstStatus = getParticipantStatus(isMoH, statusValue);
 
   if (status.includes('withdrawn')) {
     firstStatus = 'Withdrawn';

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -47,7 +47,7 @@ export const prettifyStatus = (status, id, tabValue, handleEngage, handleAcknowl
         alignItems: 'center',
       }}
     >
-      {firstStatus}{' '}
+      {firstStatus || status[0]}{' '}
       {status[1] && firstStatus !== 'Archived' && (
         <ComponentTooltip
           arrow

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -3,6 +3,18 @@ import InfoIcon from '@material-ui/icons/Info';
 import { ComponentTooltip } from '../components/generic/ComponentTooltip';
 import { Button } from '../components/generic';
 
+const getInProgressStatus = (isMoH, status) => {
+  if (isMoH) {
+    if (status === 'prospecting') return 'In Progress';
+    if (status === 'interviewing') return 'In Progress (2)';
+    if (status === 'offer_made') return 'In Progress (3)';
+  }
+
+  if (status === 'offer_made') return 'Offer Made';
+
+  return status.charAt(0).toUpperCase() + status.slice(1);
+};
+
 export const prettifyStatus = (
   status,
   id,
@@ -11,16 +23,23 @@ export const prettifyStatus = (
   handleAcknowledge,
   isMoH = false
 ) => {
-  let firstStatus = status[0];
+  const statusValue = status[0];
+  let firstStatus = statusValue;
   let isWithdrawn = false;
-  if (status[0] === 'available') firstStatus = 'Available';
-  if (status[0] === 'offer_made') firstStatus = isMoH ? 'In Progress (3)' : 'Offer Made';
-  if (status[0] === 'open') firstStatus = 'Open';
-  if (status[0] === 'prospecting') firstStatus = isMoH ? 'In Progress (2)' : 'Prospecting';
-  if (status[0] === 'interviewing') firstStatus = isMoH ? 'In Progress' : 'Interviewing';
-  if (status[0] === 'rejected') firstStatus = 'Archived';
-  if (status[0] === 'hired') firstStatus = 'Hired';
-  if (status[0] === 'ros') firstStatus = 'Return of Service';
+  if (statusValue === 'available') firstStatus = 'Available';
+  if (statusValue === 'open') firstStatus = 'Open';
+
+  if (
+    statusValue === 'offer_made' ||
+    statusValue === 'interviewing' ||
+    statusValue === 'prospecting'
+  ) {
+    firstStatus = getInProgressStatus(isMoH, statusValue);
+  }
+
+  if (statusValue === 'rejected') firstStatus = 'Archived';
+  if (statusValue === 'hired') firstStatus = 'Hired';
+  if (statusValue === 'ros') firstStatus = 'Return of Service';
   if (status.includes('withdrawn')) {
     firstStatus = 'Withdrawn';
     isWithdrawn = true;
@@ -84,7 +103,7 @@ export const prettifyStatus = (
                     onClick={() => {
                       handleEngage(id, 'rejected', {
                         final_status: isWithdrawn ? 'withdrawn' : 'hired by other',
-                        previous: status[0],
+                        previous: statusValue,
                       });
                     }}
                     size='small'

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -3,13 +3,21 @@ import InfoIcon from '@material-ui/icons/Info';
 import { ComponentTooltip } from '../components/generic/ComponentTooltip';
 import { Button } from '../components/generic';
 
-export const prettifyStatus = (status, id, tabValue, handleEngage, handleAcknowledge) => {
+export const prettifyStatus = (
+  status,
+  id,
+  tabValue,
+  handleEngage,
+  handleAcknowledge,
+  isMoH = false
+) => {
   let firstStatus = status[0];
   let isWithdrawn = false;
-  if (status[0] === 'offer_made') firstStatus = 'Offer Made';
+  if (status[0] === 'available') firstStatus = 'Available';
+  if (status[0] === 'offer_made') firstStatus = isMoH ? 'In Progress (3)' : 'Offer Made';
   if (status[0] === 'open') firstStatus = 'Open';
-  if (status[0] === 'prospecting') firstStatus = 'Prospecting';
-  if (status[0] === 'interviewing') firstStatus = 'Interviewing';
+  if (status[0] === 'prospecting') firstStatus = isMoH ? 'In Progress (2)' : 'Prospecting';
+  if (status[0] === 'interviewing') firstStatus = isMoH ? 'In Progress' : 'Interviewing';
   if (status[0] === 'rejected') firstStatus = 'Archived';
   if (status[0] === 'hired') firstStatus = 'Hired';
   if (status[0] === 'ros') firstStatus = 'Return of Service';
@@ -47,7 +55,7 @@ export const prettifyStatus = (status, id, tabValue, handleEngage, handleAcknowl
         alignItems: 'center',
       }}
     >
-      {firstStatus || status[0]}{' '}
+      {firstStatus}{' '}
       {status[1] && firstStatus !== 'Archived' && (
         <ComponentTooltip
           arrow


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-701

This PR fixes the issue with statuses being displayed as `Open` for MoH. Still, I feel like there're a few more tests needed
I'd appreciate any input at this point 🙌 

I'm adding some refactoring as well 🖌️ 

**My questions:** ❔ 
1. I noticed there's a field we're generating on BE called `statusInfo`. Is it used somewhere?
2. When HA archives a participant, they have an option to select: _Withdrawn at participant request_. If they select this option - should the status change to `rejected` or `withdrawn`?
3. What should be the status for archived participants assuming they're not available to any employers?

<img width="750" alt="Screen Shot 2022-04-29 at 11 00 27 AM" src="https://user-images.githubusercontent.com/64768811/165999450-89e86695-9502-4cc5-b89f-b4a4094feebb.png">
<img width="750" alt="Screen Shot 2022-04-29 at 11 07 10 AM" src="https://user-images.githubusercontent.com/64768811/165999470-05dbd69f-5908-40a2-939c-4f913a73ca62.png">
