### PR TITLE
HCAP-1106 | Add date to last engaged by column

### DIFF
--- a/client/src/constants/theme.js
+++ b/client/src/constants/theme.js
@@ -55,6 +55,7 @@ export default createMuiTheme({
     gray: {
       primary: '#F0F0F0',
       secondary: '#E8E8E8',
+      dark: '#606060',
     },
   },
 

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router-dom';
 
 import Grid from '@material-ui/core/Grid';
 import { Box, Menu, MenuItem, Link } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 import {
   ToastStatus,
@@ -149,6 +150,11 @@ const filterData = (data, columns, isMoH = false) => {
         statusWithEmployerDetails[0].employerInfo.firstName,
         maxStrLen
       )} ${addEllipsisMask(statusWithEmployerDetails[0].employerInfo.lastName, maxStrLen)}`;
+
+      const createdAtFormatted = dayUtils(statusWithEmployerDetails[0].createdAt).format(
+        'MMM DD, YYYY'
+      );
+      row.engagedLast = createdAtFormatted;
       row.engagedBy = row.employerName;
     }
 
@@ -189,6 +195,16 @@ const ParticipantTable = () => {
   const isSuperUser = roles.includes('superuser');
   const isAdmin = isMoH || isSuperUser;
   const isEmployer = roles.includes('health_authority') || roles.includes('employer');
+
+  const useStyles = makeStyles((theme) => ({
+    cellTextStrong: {
+      fontWeight: 'bold',
+    },
+    cellTextWeak: {
+      color: theme.palette.gray.dark,
+    },
+  }));
+  const classes = useStyles();
 
   const fetchParticipants = async () => {
     if (!columns) return;
@@ -401,6 +417,13 @@ const ParticipantTable = () => {
         );
       case 'postHireStatuses':
         return getGraduationStatus(row[columnId] || []);
+      case 'engagedBy':
+        return (
+          <>
+            <div className={classes.cellTextStrong}>{row.engagedBy}</div>
+            <div className={classes.cellTextWeak}>{row.engagedLast}</div>
+          </>
+        );
       default:
         return row[columnId];
     }

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -200,7 +200,7 @@ const ParticipantTable = () => {
     cellTextStrong: {
       fontWeight: 'bold',
     },
-    cellTextWeak: {
+    cellTextGray: {
       color: theme.palette.gray.dark,
     },
   }));
@@ -420,8 +420,8 @@ const ParticipantTable = () => {
       case 'engagedBy':
         return (
           <>
-            <div className={classes.cellTextStrong}>{row.engagedBy}</div>
-            <div className={classes.cellTextWeak}>{row.engagedLast}</div>
+            <Box className={classes.cellTextStrong}>{row.engagedBy}</Box>
+            <Box className={classes.cellTextGray}>{row.engagedLast}</Box>
           </>
         );
       default:


### PR DESCRIPTION
- date added
- format according to MMM DD, YYYY
- made classes for the cell text in participant table
- added that darker grey colour to theme palette
- did not change the sorting (sorting by date not desired, already sorting by name)

Could have instead used Typography instead of classes? Not sure if we like div but it gets the job done.

Updated:
- investigated using Typography instead: v4 of MUI does not support custom variants, the feature was added in v5. None of our existing variants matched the design (all bold variants were much larger or the button variant has a text-transform). Did not want to modify variants used elsewhere.
- changed div to Box
- renamed that class to Alva's suggestion
- did not follow the design _exactly_ as it had the staff name text larger than the date. The design also had other larger, bold text (column headers) that the implementation currently lacks. It looked out of place.
