### PR TITLE
HCAP-1190: updating SelectProspectingSite to single select

### DIFF
--- a/client/src/components/modal-forms/SelectProspectingSiteForm.js
+++ b/client/src/components/modal-forms/SelectProspectingSiteForm.js
@@ -15,7 +15,7 @@ import {
 import { makeStyles } from '@material-ui/core/styles';
 import { FastField, Formik, Form as FormikForm } from 'formik';
 
-import { RenderMultiSelectField } from '../fields';
+import { RenderSelectField } from '../fields';
 import { Button } from '../generic';
 import { addEllipsisMask } from '../../utils';
 
@@ -72,8 +72,8 @@ export const SelectProspectingSiteForm = ({
             }`}
           </Typography>
           <FastField
-            name='prospectingSites'
-            component={RenderMultiSelectField}
+            name='prospectingSite'
+            component={RenderSelectField}
             placeholder='Select Site'
             options={_orderBy(sites, ['siteName']).map((item) => ({
               value: item.id,

--- a/client/src/constants/validation/schema/schema-select-prospecting-sites.js
+++ b/client/src/constants/validation/schema/schema-select-prospecting-sites.js
@@ -3,3 +3,13 @@ import * as yup from 'yup';
 export const ProspectingSitesSchema = yup.object().shape({
   prospectingSites: yup.array().required('This field is required: please select at least 1 site'),
 });
+
+export const ProspectingSiteSchema = yup
+  .object()
+  .noUnknown('Unknown field')
+  .shape({
+    prospectingSite: yup
+      .number()
+      .required('This field is required: please select a prospecting site')
+      .min(0, 'This field is required: please select a valid prospecting site'),
+  });

--- a/client/src/pages/private/ParticipantTableDialogues.js
+++ b/client/src/pages/private/ParticipantTableDialogues.js
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import {
   InterviewingFormSchema,
   RejectedFormSchema,
-  ProspectingSitesSchema,
+  ProspectingSiteSchema,
   participantStatus,
 } from '../../constants';
 import { Dialog } from '../../components/generic';
@@ -35,14 +35,14 @@ export const ParticipantTableDialogues = ({
 
   const handleSingleSelectProspectingSites = (values) => {
     handleEngage(actionMenuParticipant.id, participantStatus.PROSPECTING, {
-      sites: values.prospectingSites.map((value) => ({ id: value })),
+      sites: [values.prospectingSite],
     });
   };
 
   const handleMultiSelectProspectingSites = (values) => {
     bulkParticipants.forEach((participant) => {
       handleEngage(participant?.id, participantStatus.PROSPECTING, {
-        sites: values.prospectingSites.map((value) => ({ id: value })),
+        sites: [values.prospectingSite],
       });
     });
   };
@@ -56,8 +56,8 @@ export const ParticipantTableDialogues = ({
     >
       {activeModalForm === 'single-select-site' && (
         <SelectProspectingSiteForm
-          initialValues={{ prospectingSites: [] }}
-          validationSchema={ProspectingSitesSchema}
+          initialValues={{ prospectingSite: undefined }}
+          validationSchema={ProspectingSiteSchema}
           onSubmit={(values) => {
             handleSingleSelectProspectingSites(values);
           }}
@@ -69,8 +69,8 @@ export const ParticipantTableDialogues = ({
         <SelectProspectingSiteForm
           isMultiSelect
           selected={bulkParticipants}
-          initialValues={{ prospectingSites: [] }}
-          validationSchema={ProspectingSitesSchema}
+          initialValues={{ prospectingSite: undefined }}
+          validationSchema={ProspectingSiteSchema}
           onSubmit={(values) => {
             handleMultiSelectProspectingSites(values);
           }}

--- a/client/src/services/feature-flag.js
+++ b/client/src/services/feature-flag.js
@@ -1,4 +1,4 @@
 import store from 'store';
 
 export const FEATURE_MULTI_ORG_PROSPECTING = 'FEATURE_MULTI_ORG_PROSPECTING';
-export const featureFlag = (key) => store.get(key) || false;
+export const featureFlag = (key) => true;

--- a/client/src/services/feature-flag.js
+++ b/client/src/services/feature-flag.js
@@ -1,4 +1,4 @@
 import store from 'store';
 
 export const FEATURE_MULTI_ORG_PROSPECTING = 'FEATURE_MULTI_ORG_PROSPECTING';
-export const featureFlag = (key) => true;
+export const featureFlag = (key) => store.get(key) || false;


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1190

Changing `SelectProspectingSite` form to allow pick only 1 site during prospecting for both `Engage` and `Bulk Engage`

<img width="600" alt="Screen Shot 2022-05-04 at 4 11 06 PM" src="https://user-images.githubusercontent.com/64768811/166840089-888d975e-4d24-40b1-a4ff-83d8dfbd8792.png">
<img width="750" alt="Screen Shot 2022-05-04 at 4 10 44 PM" src="https://user-images.githubusercontent.com/64768811/166840080-5a5bb1ea-a9a0-46f8-88cd-40c8cf8bd2af.png">
<img width="750" alt="Screen Shot 2022-05-04 at 4 11 00 PM" src="https://user-images.githubusercontent.com/64768811/166840084-8c902814-a0cb-4d80-b7cf-51d58671e116.png">
<img width="600" alt="Screen Shot 2022-05-04 at 4 10 29 PM" src="https://user-images.githubusercontent.com/64768811/166840073-4ae086b1-cefc-4c96-937c-c66f55e052e9.png">

