### PR TITLE
HCAP-1035 | No duplicate site ID error while creating a new site with duplicate site ID

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -29,6 +29,6 @@ const patchObject = (source, patchableFields) =>
     {}
   );
 
-const sanitize = (input) => encodeURIComponent(input.trim());
+const sanitize = (input) => encodeURIComponent(input.toString().trim());
 
 module.exports = { createRows, verifyHeaders, patchObject, sanitize };


### PR DESCRIPTION
- Error is being caused by attempting to do string operation on a number
- Solution: turn the number into a string so that we don't need a separate function for strings and numbers