### PR TITLE
HCAP-1209: fixing bulk-engage bug

### DIFF
--- a/client/src/components/generic/Table.js
+++ b/client/src/components/generic/Table.js
@@ -187,7 +187,7 @@ const MultiSelectAction = (props) => {
         size='small'
         variant='outlined'
         text='Bulk Engage'
-        disabled={selected.length === 0}
+        disabled={selected.length <= 1}
         onClick={multiSelectAction}
       />
     </Box>

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -295,7 +295,6 @@ const ParticipantTable = () => {
       setActionMenuParticipant(null);
       setActiveModalForm(null);
     }
-    setSelectedParticipants([]);
     fetchParticipants();
   };
 


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1209

Very small fix for multi-select

**What's included:**
- removed `setSelectedParticipants([]);` from `handleEngage()`
🗒️ _Note_: this action is already captured in `handleClose()` 
- updating condition for _Bulk Engage_ button; it's enabled only if >= 1 rows selected

<img width="400" alt="Screen Shot 2022-05-18 at 5 21 21 PM" src="https://user-images.githubusercontent.com/64768811/169177019-51c177d3-db5f-4065-9ef1-d5cfb8ff71b6.png">
