### PR TITLE
HCAP-1210 | resetting selected participants on change selected tab

### DIFF
--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -376,6 +376,7 @@ const ParticipantTable = () => {
   }, [isMoH, isSuperUser, roles]);
 
   useEffect(() => {
+    setSelectedParticipants([]);
     fetchParticipants();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filter, pagination.page, order, selectedTabStatuses, siteSelector]);


### PR DESCRIPTION
Ticket: https://freshworks.atlassian.net/browse/HCAP-1210
Found the useEffect that gets called when tab changed, setting selected participants there to empty array.