### PR TITLE
HCAP | End of ROS Notification

### DIFF
--- a/client/src/components/generic/Notifications.js
+++ b/client/src/components/generic/Notifications.js
@@ -2,30 +2,46 @@ import React from 'react';
 import { Box } from '@material-ui/core';
 import MuiAlert from '@material-ui/lab/Alert';
 import { makeStyles } from '@material-ui/core/styles';
+import { capitalizedString } from '../../utils';
 
-const useStyles = makeStyles(() => ({
-  alertWarning: {
+// style guide: https://developer.gov.bc.ca/Design-System/Alert-Banners
+const useStyles = makeStyles((theme) => ({
+  alert: {
     fontSize: '16px',
-    color: '#6c4a00',
-    backgroundColor: '#f9f1c6',
-    border: '1px solid #faebcc',
+    border: '1px solid',
+    fontWeight: 'bold',
+  },
+  alertWarning: {
+    color: theme.palette.warning.main,
+    backgroundColor: theme.palette.warning.light,
+    borderColor: theme.palette.warning.border,
   },
 }));
+
+const severityPriority = { error: 0, warning: 1, info: 2, success: 3 };
 
 export const Notifications = ({ notifications }) => {
   const classes = useStyles();
 
+  if (!notifications.length > 0) {
+    return null;
+  }
+
+  // isolate a notification with the highest priority available to display
+  const displayedNotification = notifications.sort((a, b) => {
+    return severityPriority[a.severity] - severityPriority[b.severity];
+  })[0];
+
+  const alertSeverityClass = `alert${capitalizedString(displayedNotification.severity)}`;
+
   return (
-    Object.keys(notifications).length > 0 && (
-      <Box m={1}>
-        {notifications.rosEndedNotifications && (
-          <MuiAlert className={classes.alertWarning} severity='warning'>
-            You have a pending action: <strong>{notifications.rosEndedNotifications.length}</strong>{' '}
-            of your Return of Service Participants have finished their term. Please mark their
-            outcomes.
-          </MuiAlert>
-        )}
-      </Box>
-    )
+    <Box m={1}>
+      <MuiAlert
+        className={`${classes.alert} ${classes[alertSeverityClass]}`}
+        severity={displayedNotification.severity}
+      >
+        {displayedNotification.message}
+      </MuiAlert>
+    </Box>
   );
 };

--- a/client/src/components/generic/Notifications.js
+++ b/client/src/components/generic/Notifications.js
@@ -14,40 +14,18 @@ const useStyles = makeStyles(() => ({
 
 export const Notifications = ({ notifications }) => {
   const classes = useStyles();
-  const formatNotifications = (notifications) => {
-    return Object.entries(notifications).map(([type, contents]) => {
-      switch (type) {
-        case 'rosEndedNotifications':
-          return {
-            severity: 'warning',
-            type: type,
-            className: classes.alertWarning,
-            message: (
-              <>
-                You have a pending action: <strong>{contents.length}</strong> of your Return of
-                Service Participants have finished their term. Please mark their outcomes.
-              </>
-            ),
-          };
-        default:
-          return { message: <></>, severity: '' };
-      }
-    });
-  };
 
   return (
-    <Box m={1}>
-      {formatNotifications(notifications).map((notification) => {
-        return (
-          <MuiAlert
-            className={notification.className}
-            severity={notification.severity}
-            key={notification.type}
-          >
-            {notification.message}
+    Object.keys(notifications).length > 0 && (
+      <Box m={1}>
+        {notifications.rosEndedNotifications && (
+          <MuiAlert className={classes.alertWarning} severity='warning'>
+            You have a pending action: <strong>{notifications.rosEndedNotifications.length}</strong>{' '}
+            of your Return of Service Participants have finished their term. Please mark their
+            outcomes.
           </MuiAlert>
-        );
-      })}
-    </Box>
+        )}
+      </Box>
+    )
   );
 };

--- a/client/src/components/generic/Notifications.js
+++ b/client/src/components/generic/Notifications.js
@@ -1,34 +1,51 @@
 import React from 'react';
 import { Box } from '@material-ui/core';
+import MuiAlert from '@material-ui/lab/Alert';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  alertWarning: {
+    fontSize: '16px',
+    color: '#6c4a00',
+    backgroundColor: '#f9f1c6',
+    border: '1px solid #faebcc',
+  },
+}));
 
 export const Notifications = ({ notifications }) => {
+  const classes = useStyles();
   const formatNotifications = (notifications) => {
     return Object.entries(notifications).map(([type, contents]) => {
       switch (type) {
         case 'rosEndedNotifications':
           return {
-            icon: 'warning',
-            className: 'warning',
+            severity: 'warning',
+            type: type,
+            className: classes.alertWarning,
             message: (
               <>
-                You have a pending action: <b>{contents.length}</b> of your Return of Service
-                Participants have finished their term. Please mark their outcomes.
+                You have a pending action: <strong>{contents.length}</strong> of your Return of
+                Service Participants have finished their term. Please mark their outcomes.
               </>
             ),
           };
         default:
-          return { message: <></>, className: '' };
+          return { message: <></>, severity: '' };
       }
     });
   };
 
   return (
-    <Box>
+    <Box m={1}>
       {formatNotifications(notifications).map((notification) => {
         return (
-          <div key={notification.icon}>
-            <div className={notification.className}>{notification.message}</div>
-          </div>
+          <MuiAlert
+            className={notification.className}
+            severity={notification.severity}
+            key={notification.type}
+          >
+            {notification.message}
+          </MuiAlert>
         );
       })}
     </Box>

--- a/client/src/components/generic/Notifications.js
+++ b/client/src/components/generic/Notifications.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Box } from '@material-ui/core';
+
+export const Notifications = ({ notifications }) => {
+  const formatNotifications = (notifications) => {
+    return Object.entries(notifications).map(([type, contents]) => {
+      switch (type) {
+        case 'rosEndedNotifications':
+          return {
+            icon: 'warning',
+            className: 'warning',
+            message: (
+              <>
+                You have a pending action: <b>{contents.length}</b> of your Return of Service
+                Participants have finished their term. Please mark their outcomes.
+              </>
+            ),
+          };
+        default:
+          return { message: <></>, className: '' };
+      }
+    });
+  };
+
+  return (
+    <Box>
+      {formatNotifications(notifications).map((notification) => {
+        return (
+          <div key={notification.icon}>
+            <div className={notification.className}>{notification.message}</div>
+          </div>
+        );
+      })}
+    </Box>
+  );
+};

--- a/client/src/components/generic/Page.js
+++ b/client/src/components/generic/Page.js
@@ -3,6 +3,7 @@ import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
 import { AuthContext } from '../../providers';
 import { Header } from './Header';
+import { Notifications } from './Notifications';
 
 const useStyles = makeStyles(() => ({
   root: (props) => ({
@@ -20,11 +21,11 @@ export const Page = ({ children, hideEmployers = false, centered, isAutoHeight =
 
   const { auth } = AuthContext.useAuth();
   const notifications = useMemo(() => auth.user?.notifications || [], [auth.user?.notifications]);
-  console.log(notifications);
 
   return (
     <Fragment>
       <Header hideEmployers={hideEmployers} />
+      <Notifications notifications={notifications} />
       <Grid className={classes.root} container>
         {children}
       </Grid>

--- a/client/src/components/generic/Page.js
+++ b/client/src/components/generic/Page.js
@@ -20,7 +20,7 @@ export const Page = ({ children, hideEmployers = false, centered, isAutoHeight =
   const classes = useStyles({ centered, isAutoHeight });
 
   const { auth } = AuthContext.useAuth();
-  const notifications = useMemo(() => auth.notifications || {}, [auth.notifications]);
+  const notifications = useMemo(() => auth.notifications || [], [auth.notifications]);
 
   return (
     <Fragment>

--- a/client/src/components/generic/Page.js
+++ b/client/src/components/generic/Page.js
@@ -20,7 +20,7 @@ export const Page = ({ children, hideEmployers = false, centered, isAutoHeight =
   const classes = useStyles({ centered, isAutoHeight });
 
   const { auth } = AuthContext.useAuth();
-  const notifications = useMemo(() => auth.user?.notifications || {}, [auth.user?.notifications]);
+  const notifications = useMemo(() => auth.notifications || {}, [auth.notifications]);
 
   return (
     <Fragment>

--- a/client/src/components/generic/Page.js
+++ b/client/src/components/generic/Page.js
@@ -20,7 +20,7 @@ export const Page = ({ children, hideEmployers = false, centered, isAutoHeight =
   const classes = useStyles({ centered, isAutoHeight });
 
   const { auth } = AuthContext.useAuth();
-  const notifications = useMemo(() => auth.user?.notifications || [], [auth.user?.notifications]);
+  const notifications = useMemo(() => auth.user?.notifications || {}, [auth.user?.notifications]);
 
   return (
     <Fragment>

--- a/client/src/components/generic/Page.js
+++ b/client/src/components/generic/Page.js
@@ -1,7 +1,7 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import Grid from '@material-ui/core/Grid';
 import { makeStyles } from '@material-ui/core/styles';
-
+import { AuthContext } from '../../providers';
 import { Header } from './Header';
 
 const useStyles = makeStyles(() => ({
@@ -17,6 +17,11 @@ const useStyles = makeStyles(() => ({
 // hideEmployers set to true for participant-facing pages
 export const Page = ({ children, hideEmployers = false, centered, isAutoHeight = false }) => {
   const classes = useStyles({ centered, isAutoHeight });
+
+  const { auth } = AuthContext.useAuth();
+  const notifications = useMemo(() => auth.user?.notifications || [], [auth.user?.notifications]);
+  console.log(notifications);
+
   return (
     <Fragment>
       <Header hideEmployers={hideEmployers} />

--- a/client/src/components/generic/ParticipantStatus.js
+++ b/client/src/components/generic/ParticipantStatus.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import InfoIcon from '@material-ui/icons/Info';
+import { ComponentTooltip } from './ComponentTooltip';
+import { Button } from './Button';
+import { getParticipantStatusData } from '../../utils/prettifyStatus';
+
+export const ParticipantStatus = ({
+  status,
+  id,
+  tabValue,
+  handleEngage,
+  handleAcknowledge,
+  isMoH = false,
+  participantInfo = { statusInfos: [] },
+}) => {
+  const { toolTipText, statusText, buttonData } = getParticipantStatusData(
+    status,
+    tabValue,
+    isMoH,
+    participantInfo
+  );
+
+  const { showAcknowledgeButton, showArchiveButton, additional } = buttonData;
+
+  const showToolTip = toolTipText !== '' && statusText !== 'Archived';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+      }}
+    >
+      {statusText}{' '}
+      {showToolTip && (
+        <ComponentTooltip
+          arrow
+          title={
+            <div style={{ margin: 10 }}>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  marginBottom: 10,
+                }}
+              >
+                <InfoIcon color='secondary' style={{ marginRight: 10 }} fontSize='small' />
+                {toolTipText}
+              </div>
+              {showArchiveButton && (
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'flex-end',
+                  }}
+                >
+                  <Button
+                    onClick={() => {
+                      handleEngage(id, 'rejected', additional, participantInfo);
+                    }}
+                    size='small'
+                    fullWidth={false}
+                    text='Move to Archived Candidates'
+                  />
+                </div>
+              )}
+              {showAcknowledgeButton && (
+                <Button
+                  onClick={async () => {
+                    handleAcknowledge(id, status.includes('hired_by_peer'), participantInfo);
+                  }}
+                  size='small'
+                  fullWidth={false}
+                  text='Acknowledge'
+                />
+              )}
+            </div>
+          }
+        >
+          <InfoIcon style={{ marginLeft: 5 }} color='secondary' />
+        </ComponentTooltip>
+      )}
+    </div>
+  );
+};

--- a/client/src/components/participant-details/track-graduation.js
+++ b/client/src/components/participant-details/track-graduation.js
@@ -7,13 +7,14 @@ import { AssignCohortForm } from '../modal-forms/AssignCohort';
 import React, { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import { createPostHireStatus } from '../../services/participant';
+import { fetchUserNotifications } from '../../services';
 import { ToastStatus, API_URL, ArchiveHiredParticipantSchema } from '../../constants';
 import { postHireStatuses } from '../../constants';
-
+import { AuthContext } from '../../providers';
 import { useToast } from '../../hooks';
 import { formatCohortDate } from '../../utils';
 // Helper function to call archive participant service
-const handleArchive = async (participantId, additional = {}, openToast) => {
+const handleArchive = async (participantId, additional = {}, openToast, dispatchFunction) => {
   const response = await fetch(`${API_URL}/api/v1/employer-actions`, {
     method: 'POST',
     headers: {
@@ -24,6 +25,8 @@ const handleArchive = async (participantId, additional = {}, openToast) => {
     body: JSON.stringify({ participantId, status: 'archived', data: additional }),
   });
   if (response.ok) {
+    fetchUserNotifications(dispatchFunction);
+
     openToast({
       status: ToastStatus.Info,
       message: 'Participant Archived',
@@ -37,6 +40,7 @@ const handleArchive = async (participantId, additional = {}, openToast) => {
 };
 
 export const TrackGraduation = (props) => {
+  const { dispatch } = AuthContext.useAuth();
   const [cohort, setCohort] = useState(null);
   const { fetchData } = props;
   const [showEditModel, setShowEditModal] = useState(false);
@@ -48,6 +52,9 @@ export const TrackGraduation = (props) => {
   const cohortEndDate = props.participant?.cohort
     ? formatCohortDate(props.participant.cohort.end_date, { isForm: true })
     : null;
+
+  const dispatchFunction = (notifications) =>
+    dispatch({ type: AuthContext.USER_NOTIFICATIONS_UPDATED, payload: notifications });
 
   useEffect(() => {
     setCohort(props.participant?.cohort);
@@ -169,7 +176,7 @@ export const TrackGraduation = (props) => {
                 }}
                 onSubmit={async (values) => {
                   setShowArchiveModal(false);
-                  await handleArchive(props?.participant?.id, values, openToast);
+                  await handleArchive(props?.participant?.id, values, openToast, dispatchFunction);
                   fetchData();
                 }}
                 participant={props?.participant}

--- a/client/src/components/participant-details/track-graduation.js
+++ b/client/src/components/participant-details/track-graduation.js
@@ -14,7 +14,7 @@ import { AuthContext } from '../../providers';
 import { useToast } from '../../hooks';
 import { formatCohortDate } from '../../utils';
 // Helper function to call archive participant service
-const handleArchive = async (participantId, additional = {}, openToast, dispatchFunction) => {
+const handleArchive = async (participantId, openToast, dispatchFunction, additional = {}) => {
   const response = await fetch(`${API_URL}/api/v1/employer-actions`, {
     method: 'POST',
     headers: {
@@ -176,7 +176,7 @@ export const TrackGraduation = (props) => {
                 }}
                 onSubmit={async (values) => {
                   setShowArchiveModal(false);
-                  await handleArchive(props?.participant?.id, values, openToast, dispatchFunction);
+                  await handleArchive(props?.participant?.id, openToast, dispatchFunction, values);
                   fetchData();
                 }}
                 participant={props?.participant}

--- a/client/src/constants/theme.js
+++ b/client/src/constants/theme.js
@@ -40,6 +40,7 @@ export default createMuiTheme({
     warning: {
       main: '#6c4a00',
       light: '#f9f1c6',
+      border: '#faebcc',
     },
     background: {
       default: '#FFFFFF',

--- a/client/src/constants/theme.js
+++ b/client/src/constants/theme.js
@@ -38,10 +38,11 @@ export default createMuiTheme({
       secondary: '#1890FF',
     },
     warning: {
-      main: '#F5A623',
+      main: '#6c4a00',
+      light: '#f9f1c6',
     },
     background: {
-      default: '#F5F6FA',
+      default: '#FFFFFF',
       light: '#F2F2F2',
     },
     text: {

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -434,7 +434,7 @@ const ParticipantTable = () => {
           'withdrawn',
           'archived',
           'reject_ack',
-        ].find((s) => row.status.includes(s));
+        ].find((participantStatus) => row.status.includes(participantStatus));
 
         return (
           engage && (

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -16,13 +16,7 @@ import {
 } from '../../constants';
 import { Table, CheckPermissions, Button, CustomTab, CustomTabs } from '../../components/generic';
 import { useToast } from '../../hooks';
-import {
-  dayUtils,
-  addEllipsisMask,
-  prettifyStatus,
-  keyedString,
-  capitalizedString,
-} from '../../utils';
+import { dayUtils, addEllipsisMask, keyedString, capitalizedString } from '../../utils';
 import { AuthContext, ParticipantsContext } from '../../providers';
 import { ParticipantTableFilters } from './ParticipantTableFilters';
 import { ParticipantTableDialogues } from './ParticipantTableDialogues';
@@ -36,6 +30,7 @@ import {
   FEATURE_MULTI_ORG_PROSPECTING,
   fetchUserNotifications,
 } from '../../services';
+import { ParticipantStatus } from '../../components/generic/ParticipantStatus';
 
 const mapRosData = (data) => ({
   rosSiteName: data?.rosStatuses?.[0]?.rosSite?.body.siteName,
@@ -414,14 +409,17 @@ const ParticipantTable = () => {
         return row[columnId] ? 'Primed' : 'Available';
       case 'status':
       case 'mohStatus':
-        return prettifyStatus(
-          row[columnId] || row['status'],
-          row.id,
-          selectedTab,
-          handleEngage,
-          handleAcknowledge,
-          isMoH,
-          row.engage || null
+        const status = row[columnId] || row['status'];
+        return (
+          <ParticipantStatus
+            status={status}
+            id={row.id}
+            tabValue={selectedTab}
+            handleEngage={handleEngage}
+            handleAcknowledge={handleAcknowledge}
+            isMoH={isMoH}
+            participantInfo={row.engage || null}
+          />
         );
       case 'distance':
         if (row[columnId] !== null && row[columnId] !== undefined) {

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -434,7 +434,7 @@ const ParticipantTable = () => {
           'withdrawn',
           'archived',
           'reject_ack',
-        ].find((status) => row.status.includes(status));
+        ].find((s) => row.status.includes(s));
 
         return (
           engage && (

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -34,6 +34,7 @@ import {
   getGraduationStatus,
   featureFlag,
   FEATURE_MULTI_ORG_PROSPECTING,
+  fetchUserNotifications,
 } from '../../services';
 
 const mapRosData = (data) => ({
@@ -201,7 +202,7 @@ const ParticipantTable = () => {
     },
     dispatch: participantsDispatch,
   } = ParticipantsContext.useParticipantsContext();
-  const { auth } = AuthContext.useAuth();
+  const { auth, dispatch } = AuthContext.useAuth();
   const roles = useMemo(() => auth.user?.roles || [], [auth.user?.roles]);
 
   const isMoH = roles.includes('ministry_of_health');
@@ -276,6 +277,9 @@ const ParticipantTable = () => {
         status,
         additional: additionalParma,
       });
+      const dispatchFunction = (notifications) =>
+        dispatch({ type: AuthContext.USER_NOTIFICATIONS_UPDATED, payload: notifications });
+      fetchUserNotifications(dispatchFunction);
       setLoadingData(false);
       if (status === participantStatus.PROSPECTING) {
         // Modal appears after submitting

--- a/client/src/pages/private/ParticipantTableDialogues.js
+++ b/client/src/pages/private/ParticipantTableDialogues.js
@@ -17,6 +17,7 @@ import {
   ReturnOfServiceForm,
   SelectProspectingSiteForm,
 } from '../../components/modal-forms';
+import { fetchUserNotifications } from '../../services';
 import { getDialogTitle } from '../../utils';
 import { AuthContext, ParticipantsContext } from '../../providers';
 
@@ -30,7 +31,7 @@ export const ParticipantTableDialogues = ({
   handleRosUpdate,
 }) => {
   const { dispatch: participantsDispatch } = ParticipantsContext.useParticipantsContext();
-  const { auth } = AuthContext.useAuth();
+  const { auth, dispatch } = AuthContext.useAuth();
   const sites = useMemo(() => auth.user?.sites || [], [auth.user?.sites]);
 
   const getParticipantName = (participant) => {
@@ -163,6 +164,10 @@ export const ParticipantTableDialogues = ({
         <ArchiveHiredParticipantForm
           onSubmit={(values) => {
             handleEngage(actionMenuParticipant.id, 'archived', values);
+
+            const dispatchFunction = (notifications) =>
+              dispatch({ type: AuthContext.USER_NOTIFICATIONS_UPDATED, payload: notifications });
+            fetchUserNotifications(dispatchFunction);
           }}
           onClose={onClose}
           participant={actionMenuParticipant}

--- a/client/src/pages/private/ParticipantTableDialogues.js
+++ b/client/src/pages/private/ParticipantTableDialogues.js
@@ -17,7 +17,6 @@ import {
   ReturnOfServiceForm,
   SelectProspectingSiteForm,
 } from '../../components/modal-forms';
-import { fetchUserNotifications } from '../../services';
 import { getDialogTitle } from '../../utils';
 import { AuthContext, ParticipantsContext } from '../../providers';
 
@@ -31,7 +30,7 @@ export const ParticipantTableDialogues = ({
   handleRosUpdate,
 }) => {
   const { dispatch: participantsDispatch } = ParticipantsContext.useParticipantsContext();
-  const { auth, dispatch } = AuthContext.useAuth();
+  const { auth } = AuthContext.useAuth();
   const sites = useMemo(() => auth.user?.sites || [], [auth.user?.sites]);
 
   const getParticipantName = (participant) => {
@@ -164,10 +163,6 @@ export const ParticipantTableDialogues = ({
         <ArchiveHiredParticipantForm
           onSubmit={(values) => {
             handleEngage(actionMenuParticipant.id, 'archived', values);
-
-            const dispatchFunction = (notifications) =>
-              dispatch({ type: AuthContext.USER_NOTIFICATIONS_UPDATED, payload: notifications });
-            fetchUserNotifications(dispatchFunction);
           }}
           onClose={onClose}
           participant={actionMenuParticipant}

--- a/client/src/pages/private/SiteParticipantsTable.js
+++ b/client/src/pages/private/SiteParticipantsTable.js
@@ -7,6 +7,7 @@ import store from 'store';
 import { Table, Button, Dialog, CustomTab, CustomTabs } from '../../components/generic';
 import { getDialogTitle } from '../../utils';
 import { AuthContext, SiteDetailTabContext } from '../../providers';
+import { fetchUserNotifications } from '../../services';
 import { fieldsLabelMap } from '../../constants';
 import {
   ToastStatus,
@@ -216,6 +217,10 @@ export default ({ id, siteId }) => {
     });
 
     if (response.ok) {
+      const dispatchFunction = (notifications) =>
+        dispatch({ type: AuthContext.USER_NOTIFICATIONS_UPDATED, payload: notifications });
+      fetchUserNotifications(dispatchFunction);
+
       const index = rows.findIndex((row) => row.participantId === participantId);
       const { participantName } = rows[index];
       const toasts = makeToasts(participantName, '');

--- a/client/src/pages/private/SiteParticipantsTable.js
+++ b/client/src/pages/private/SiteParticipantsTable.js
@@ -109,7 +109,7 @@ export default ({ id, siteId }) => {
   const [rows, setRows] = useState([]);
   const [fetchedHiredRows, setFetchedHiredRows] = useState([]);
   const [fetchedWithdrawnRows, setFetchedWithdrawnRows] = useState([]);
-  const { auth } = AuthContext.useAuth();
+  const { auth, dispatch: authDispatch } = AuthContext.useAuth();
   const { openToast } = useToast();
   const roles = useMemo(() => auth.user?.roles || [], [auth.user]);
   const defaultOnClose = () => {
@@ -218,7 +218,7 @@ export default ({ id, siteId }) => {
 
     if (response.ok) {
       const dispatchFunction = (notifications) =>
-        dispatch({ type: AuthContext.USER_NOTIFICATIONS_UPDATED, payload: notifications });
+        authDispatch({ type: AuthContext.USER_NOTIFICATIONS_UPDATED, payload: notifications });
       fetchUserNotifications(dispatchFunction);
 
       const index = rows.findIndex((row) => row.participantId === participantId);

--- a/client/src/providers/AuthContext.js
+++ b/client/src/providers/AuthContext.js
@@ -6,6 +6,7 @@ const AuthContext = React.createContext();
 
 const USER_LOADING = 'USER_LOADING';
 const USER_LOADED = 'USER_LOADED';
+const USER_NOTIFICATIONS_UPDATED = 'USER_NOTIFICATIONS_UPDATED';
 
 const authReducer = (state, action) => {
   switch (action.type) {
@@ -19,9 +20,16 @@ const authReducer = (state, action) => {
       return {
         ...state,
         user: action.payload,
+        notifications: action.payload.notifications ?? state.notifications,
         isLoading: false,
         // find first role in above array that is included in the user object (highest permission role)
         permissionRole: rolePriority.find((role) => action.payload?.roles.includes(role)),
+      };
+
+    case USER_NOTIFICATIONS_UPDATED:
+      return {
+        ...state,
+        notifications: action.payload.notifications,
       };
     default:
       return state;
@@ -35,6 +43,7 @@ const authReducer = (state, action) => {
 const AuthProvider = ({ children }) => {
   const [auth, dispatch] = useReducer(authReducer, {
     user: null,
+    notifications: null,
     isLoading: true,
     permissionRole: null,
   });
@@ -52,4 +61,4 @@ function useAuth() {
   return context;
 }
 
-export { AuthProvider, useAuth, USER_LOADING, USER_LOADED };
+export { AuthProvider, useAuth, USER_LOADING, USER_LOADED, USER_NOTIFICATIONS_UPDATED };

--- a/client/src/services/index.js
+++ b/client/src/services/index.js
@@ -2,3 +2,4 @@ export * from './participant';
 export * from './psi-cohort';
 export * from './return-of-service';
 export * from './feature-flag';
+export * from './notifications';

--- a/client/src/services/notifications.js
+++ b/client/src/services/notifications.js
@@ -1,0 +1,17 @@
+import store from 'store';
+import { API_URL } from '../constants';
+
+export const fetchUserNotifications = async (dispatchFunction) => {
+  const response = await fetch(`${API_URL}/api/v1/user-notifications`, {
+    headers: {
+      Authorization: `Bearer ${store.get('TOKEN')}`,
+    },
+    method: 'GET',
+  });
+
+  if (response.ok) {
+    const notifications = await response.json();
+    dispatchFunction(notifications);
+  }
+  return response;
+};

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -3,6 +3,7 @@ import InfoIcon from '@material-ui/icons/Info';
 import { ComponentTooltip } from '../components/generic/ComponentTooltip';
 import { Button } from '../components/generic';
 import { capitalizedString } from './gen-util';
+import { addYearToDate } from './date';
 
 /**
  * Returns participant stats message based on the first status provided
@@ -45,6 +46,17 @@ export const prettifyStatus = (
   let isWithdrawn = false;
   const isHiredByPeer = status[1] === 'hired_by_peer';
   const isRejectedByPeer = statusValue === 'reject_ack';
+  const isROS = statusValue === 'ros';
+
+  //show if participant needs to be archived
+  if (isROS && !status.includes('archived')) {
+    const rosStartDate = participantInfo.rosStatuses[0].data.date;
+    const isTimeToArchive = addYearToDate(rosStartDate).isBefore(new Date());
+    if (isTimeToArchive) {
+      toolTip =
+        'Please action and archive this participant to record their outcomes as they have met their one year mark of Return of Service';
+    }
+  }
 
   if (status.includes('withdrawn')) {
     firstStatus = 'Withdrawn';
@@ -83,6 +95,11 @@ export const prettifyStatus = (
     ['Archived Candidates', 'Participants'].includes(tabValue) ||
     !hideAcknowledgeButton ||
     isHiredByPeer;
+
+  if (status[1] || isRejectedByPeer) {
+    toolTip = 'This candidate was hired by another site.';
+  }
+  const showToolTip = toolTip !== '' && firstStatus !== 'Archived';
   return (
     <div
       style={{
@@ -92,7 +109,7 @@ export const prettifyStatus = (
       }}
     >
       {firstStatus}{' '}
-      {(status[1] || isRejectedByPeer) && firstStatus !== 'Archived' && (
+      {showToolTip && (
         <ComponentTooltip
           arrow
           title={

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -28,7 +28,7 @@ export const getParticipantStatusData = (status, tabValue, isMoH, participantInf
   const rosStartDate = isROS ? participantInfo.rosStatuses[0].data.date : null;
   const finalStatus = statusInfo.data?.final_status ?? null;
 
-  const toolTipText = getToolTipText(
+  const toolTipText = getToolTipText({
     isWithdrawn,
     isRejectedByPeer,
     isHiredByPeer,
@@ -36,8 +36,8 @@ export const getParticipantStatusData = (status, tabValue, isMoH, participantInf
     isArchived,
     isPendingAcknowledgement,
     rosStartDate,
-    finalStatus
-  );
+    finalStatus,
+  });
 
   const statusText = getStatusText(
     isMoH,
@@ -120,7 +120,7 @@ const getStatusText = (
  * @param {string} finalStatus
  * @returns {string}
  */
-const getToolTipText = (
+const getToolTipText = ({
   isWithdrawn,
   isRejectedByPeer,
   isHiredByPeer,
@@ -128,8 +128,8 @@ const getToolTipText = (
   isArchived,
   isPendingAcknowledgement,
   rosStartDate,
-  finalStatus
-) => {
+  finalStatus,
+}) => {
   if (rosStartDate && !isArchived) {
     const isTimeToArchive = addYearToDate(rosStartDate).isBefore(new Date());
     if (isTimeToArchive) {

--- a/client/src/utils/prettifyStatus.js
+++ b/client/src/utils/prettifyStatus.js
@@ -98,7 +98,15 @@ const getButtonData = () => {};
 
 // returns all of the combined data used to generate the status component
 // (basically replacing prettifyStatus() with this to get the front-end out of the back-end)
-const getStatusData = (status, tabValue, isMoH = false, participantInfo) => {
+const getStatusData = (
+  status,
+  id,
+  tabValue,
+  handleEngage,
+  handleAcknowledge,
+  isMoH,
+  participantInfo
+) => {
   //TODO: this is not going to fly
   if (!status) return;
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -161,6 +161,18 @@ apiRouter.get(
   })
 );
 
+apiRouter.get(
+  `/user-notifications`,
+  keycloak.allowRolesMiddleware('*'),
+  keycloak.getUserInfoMiddleware(),
+  asyncMiddleware(async (req, res) => {
+    const notifications = await getUserNotifications(req.hcapUserInfo);
+    return res.json({
+      notifications,
+    });
+  })
+);
+
 // Version number
 apiRouter.get(`/version`, (req, res) => res.json({ version: process.env.VERSION }));
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,6 +2,7 @@
 const dayjs = require('dayjs');
 const express = require('express');
 const { getSites } = require('../services/employers.js');
+const { getUserNotifications } = require('../services/user.js');
 const { validate, AccessRequestApproval } = require('../validation.js');
 const logger = require('../logger.js');
 const { dbClient, collections } = require('../db');
@@ -150,10 +151,12 @@ apiRouter.get(
   asyncMiddleware(async (req, res) => {
     let sites = await getSites();
     sites = sites.filter((i) => req.hcapUserInfo.sites.includes(i.siteId));
+    const notifications = await getUserNotifications(req.hcapUserInfo);
     return res.json({
       roles: req.hcapUserInfo.roles,
       name: req.hcapUserInfo.name,
       sites,
+      notifications,
     });
   })
 );

--- a/server/services/user.js
+++ b/server/services/user.js
@@ -13,6 +13,25 @@ const getUser = async (id) => {
   return dbClient.db[collections.USERS].findDoc(query, options);
 };
 
+/**
+ *
+ * @param {*} hcapUserInfo
+ * @returns
+ */
+const getUserNotifications = async (hcapUserInfo) => {
+  const notifications = [];
+  if (hcapUserInfo.isEmployer || hcapUserInfo.isHA) {
+    const rosEndedNotifications = [
+      {
+        type: 'rosEnded',
+        message: '2 of your Return of Service Participants have finished their term.',
+      },
+    ];
+    notifications.push(rosEndedNotifications);
+  }
+  return notifications;
+};
+
 const getUserSites = async (id) => {
   const user = await getUser(id);
   if (!user || !user.sites) return [];
@@ -39,4 +58,5 @@ module.exports = {
   userRegionQuery,
   makeUser,
   getUserSiteIds,
+  getUserNotifications,
 };

--- a/server/services/user.js
+++ b/server/services/user.js
@@ -32,27 +32,31 @@ const getROSEndedNotifications = async (sites) => {
       },
     })
     .find({
-      and: [
-        { 'data.date::timestamp <': todayDate },
-        { 'participantStatus.current': true },
-        { 'participantStatus.status': 'hired' },
-        { 'participantStatus.data.site': sites },
-      ],
+      'data.date::timestamp <': todayDate,
+      'participantStatus.current': true,
+      'participantStatus.status': 'hired',
+      'participantStatus.data.site': sites,
     });
 };
 
 /**
- * Returns an object of user notifications with keys being the type of notification
- * Empty object for no notifications, keys correspond to notification type they have
+ * Returns an array of user notification objects
+ * Where each notification has a message, severity, and type
+ * Empty array for no notifications
  * @param {*} hcapUserInfo
- * @returns {}
+ * @returns {[]}
  */
 const getUserNotifications = async (hcapUserInfo) => {
-  const notifications = {};
+  const notifications = [];
   if (hcapUserInfo.isEmployer || hcapUserInfo.isHA) {
     const rosEndedNotifications = await getROSEndedNotifications(hcapUserInfo.sites);
     if (rosEndedNotifications.length > 0) {
-      notifications.rosEndedNotifications = rosEndedNotifications;
+      notifications.push({
+        message: `You have a pending action: ${rosEndedNotifications.length} of your Return
+        of Service Participants have finished their term. Please mark their outcomes.`,
+        severity: 'warning',
+        type: 'rosEnded',
+      });
     }
   }
   return notifications;

--- a/server/services/user.js
+++ b/server/services/user.js
@@ -43,13 +43,17 @@ const getROSEndedNotifications = async (sites) => {
 
 /**
  * Returns an object of user notifications with keys being the type of notification
+ * Empty object for no notifications, keys correspond to notification type they have
  * @param {*} hcapUserInfo
- * @returns
+ * @returns {}
  */
 const getUserNotifications = async (hcapUserInfo) => {
   const notifications = {};
   if (hcapUserInfo.isEmployer || hcapUserInfo.isHA) {
-    notifications.rosEndedNotifications = await getROSEndedNotifications(hcapUserInfo.sites);
+    const rosEndedNotifications = await getROSEndedNotifications(hcapUserInfo.sites);
+    if (rosEndedNotifications.length > 0) {
+      notifications.rosEndedNotifications = rosEndedNotifications;
+    }
   }
   return notifications;
 };

--- a/server/services/user.js
+++ b/server/services/user.js
@@ -33,10 +33,10 @@ const getROSEndedNotifications = async (sites) => {
     })
     .find({
       and: [
-        { site_id: sites },
         { 'data.date::timestamp <': todayDate },
         { 'participantStatus.current': true },
         { 'participantStatus.status': 'hired' },
+        { 'participantStatus.data.site': sites },
       ],
     });
 };


### PR DESCRIPTION
Ticket: https://freshworks.atlassian.net/browse/HCAP-1189

For sure some room for improvement in prettifyStatus, particularly interested in feedback on:
- change the name of the file? Took all the front-end stuff out of here, name no longer reflects purpose
- similarly, put ParticipantStatus in components/generic. _Is it_ generic? Didn't see any better fits, does it justify its own new directory?
- I sacrificed brevity for clarity and made lots of variables. Looking for opportunities to simplify this where possible while maintaining readability.
- I have a boolean `isHiredByPeer = status[1] === 'hired_by_peer'`, in another place the logic was looking for `status.includes('hired_by_peer')`- will these **always** be the same? If so I'd like to simplify it. Probably other variables/expressions that are redundant.
