### PR TITLE
HCAP-1246 | BugFix | Remove date validation for graduation date

### DIFF
--- a/client/src/components/modal-forms/ManageGraduationForm.js
+++ b/client/src/components/modal-forms/ManageGraduationForm.js
@@ -22,6 +22,7 @@ export const ManageGraduationForm = ({ initialValues, onClose, onSubmit, cohortE
           const handleStatusChange = ({ target }) => {
             const { value } = target;
             setFieldValue('status', value);
+            setFieldValue('continue', '');
             if (value === postHireStatuses.postSecondaryEducationCompleted) {
               setFieldValue('data.date', cohortEndDate);
             } else {

--- a/client/src/constants/validation/schema/schema-participant-post-hire-status.js
+++ b/client/src/constants/validation/schema/schema-participant-post-hire-status.js
@@ -14,10 +14,7 @@ export const ParticipantPostHireStatusSchema = yup
       switch (status) {
         case postHireStatuses.postSecondaryEducationCompleted:
           return schema.noUnknown('Unknown field in data form').shape({
-            date: yup
-              .string()
-              .required('Graduation date is required')
-              .test('is-date', 'Invalid date', validateDateString),
+            date: yup.string().optional(),
           });
 
         case postHireStatuses.cohortUnsuccessful:


### PR DESCRIPTION
The field is pre-populated with `cohort-end-date`. So, no need for UI validation.