### PR TITLE
HCAP-1252: splitting Last Engaged By column for sorting

### DIFF
--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -164,7 +164,8 @@ const columns = {
   rosStartDate: { id: 'rosStartDate', name: 'Return of Service Start Date', sortOrder: 22 },
   rosSiteName: { id: 'rosSiteName', name: 'RoS Site Name', sortOrder: 23 },
   employerName: { id: 'employerName', name: 'Hired By', sortOrder: 24 },
-  engagedBy: { id: 'engagedBy', name: 'Last Engaged By', sortOrder: 16 },
+  lastEngagedBy: { id: 'lastEngagedBy', name: 'Last Engaged By', sortOrder: 16 },
+  lastEngagedDate: { id: 'lastEngagedDate', name: 'Last Engaged Date', sortOrder: 17 },
   archiveReason: { id: 'archiveReason', name: 'Archive Reason', sortOrder: 25, sortable: false },
 };
 
@@ -192,7 +193,8 @@ const {
   rosStartDate,
   rosSiteName,
   employerName,
-  engagedBy,
+  lastEngagedBy,
+  lastEngagedDate,
   archiveReason,
 } = columns;
 
@@ -262,7 +264,8 @@ export const columnsByRole = {
       userUpdatedAt,
       engage,
       siteName,
-      engagedBy,
+      lastEngagedBy,
+      lastEngagedDate,
     ],
     'Archived Candidates': [
       id,
@@ -336,7 +339,8 @@ export const columnsByRole = {
       userUpdatedAt,
       engage,
       siteName,
-      engagedBy,
+      lastEngagedBy,
+      lastEngagedDate,
     ],
     'Archived Candidates': [
       id,

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -163,8 +163,8 @@ const filterData = (data, columns, isMoH = false) => {
       const createdAtFormatted = dayUtils(statusWithEmployerDetails[0].createdAt).format(
         'MMM DD, YYYY'
       );
-      row.engagedLast = createdAtFormatted;
-      row.engagedBy = row.employerName;
+      row.lastEngagedDate = createdAtFormatted;
+      row.lastEngagedBy = row.employerName;
     }
 
     row.engage.status = row.status[0];
@@ -206,9 +206,6 @@ const ParticipantTable = () => {
   const isEmployer = roles.includes('health_authority') || roles.includes('employer');
 
   const useStyles = makeStyles((theme) => ({
-    cellTextStrong: {
-      fontWeight: 'bold',
-    },
     cellTextGray: {
       color: theme.palette.gray.dark,
     },
@@ -488,13 +485,6 @@ const ParticipantTable = () => {
         );
       case 'postHireStatuses':
         return getGraduationStatus(row[columnId] || []);
-      case 'engagedBy':
-        return (
-          <>
-            <Box className={classes.cellTextStrong}>{row.engagedBy}</Box>
-            <Box className={classes.cellTextGray}>{row.engagedLast}</Box>
-          </>
-        );
       default:
         return row[columnId];
     }

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -3,7 +3,6 @@ import { useHistory } from 'react-router-dom';
 
 import Grid from '@material-ui/core/Grid';
 import { Box, Menu, MenuItem, Link } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
 
 import {
   ToastStatus,
@@ -204,13 +203,6 @@ const ParticipantTable = () => {
   const isSuperUser = roles.includes('superuser');
   const isAdmin = isMoH || isSuperUser;
   const isEmployer = roles.includes('health_authority') || roles.includes('employer');
-
-  const useStyles = makeStyles((theme) => ({
-    cellTextGray: {
-      color: theme.palette.gray.dark,
-    },
-  }));
-  const classes = useStyles();
 
   const fetchParticipants = async () => {
     if (!columns) return;

--- a/cypress/fixtures/participantTableTabs.json
+++ b/cypress/fixtures/participantTableTabs.json
@@ -92,6 +92,7 @@
           "Site Distance",
           "Last Updated",
           "Last Engaged By",
+          "Last Engaged Date",
           "Site Name"
         ],
         "Archived Candidates": [
@@ -180,6 +181,7 @@
           "Site Distance",
           "Last Updated",
           "Last Engaged By",
+          "Last Engaged Date",
           "Site Name"
         ],
         "Archived Candidates": [

--- a/server/constants/validation-constants.js
+++ b/server/constants/validation-constants.js
@@ -36,7 +36,8 @@ const sortFields = [
   'rosStartDate',
   'rosSiteName',
   'employerName',
-  'engagedBy',
+  'lastEngagedBy',
+  'lastEngagedDate',
 ];
 
 const roles = [

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -194,7 +194,7 @@ class FilteredParticipantsFinder {
       });
 
       // To manage employer name column sorting we need to sort by employer name
-      if (sortField === 'employerName' || sortField === 'engagedBy') {
+      if (sortField === 'employerName' || sortField === 'lastEngagedBy') {
         this.context.options.order.unshift(
           {
             field: `employerInfo.body.userInfo.firstName`,


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1252

Added a new column `Last Engaged Date` to allow sorting by date + renamed `engagedBy` to --> `lastEngagedBy` for clarity

<img width="750" alt="Screen Shot 2022-07-11 at 4 56 11 PM" src="https://user-images.githubusercontent.com/64768811/178377892-62f5af35-bcef-47db-afbe-d42129a0be8c.png">

