### PR TITLE
Add github-provider-map for GH -> Slack link

### DIFF
--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
           provider: slack
+          github-provider-map: 'fw-noel:UUWMCRU4Q,taraepp:U0373NCPMPH,arranfw:U01ADH9FUET,alva-fresh:U012X7BJV0T'


### PR DESCRIPTION
I like this feature of this action, it helps to parse the list of PR reminders for which ones require your attention