### PR TITLE
fix: ignore ROS if participant is not in my sites

### DIFF
--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -76,7 +76,7 @@ const scrubParticipantData = (raw, joinNames, sites) =>
     let rosStatuses = participant.rosStatuses
       ? participant.rosStatuses.sort((ros1, ros2) => ros2.id - ros1.id)
       : [];
-    rosStatuses = rosStatuses.filter(rosStatus => sites.includes(rosStatus.rosSite.body.siteId));
+    rosStatuses = rosStatuses.filter((rosStatus) => sites.includes(rosStatus.rosSite.body.siteId));
     return {
       ...participant.body,
       id: participant.id,
@@ -126,7 +126,7 @@ const run = async (context) => {
     participants = scrubParticipantData(
       participants,
       (user.isEmployer || user.isHA) && [employerSpecificJoin, hiredGlobalJoin],
-      user.sites,
+      user.sites
     );
     return participants;
   } catch (error) {

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -328,11 +328,12 @@ class FieldsFilteredParticipantsFinder {
           is_current: true,
         },
         rosSite: {
-          type: 'LEFT OUTER',
+          type: 'INNER',
           relation: collections.EMPLOYER_SITES,
           decomposeTo: 'object',
           on: {
             id: `${collections.ROS_STATUS}.site_id`,
+            'body.siteId': user.sites.map((item) => item.toString()),
           },
         },
       },


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1304

Basically, my candidates was showing a user who has already gotten ROS for a site I don't have access to and making them actionable. In talking with Tavy, we've determined that if a user gets hired for a site I don't have access to, there can be no further action on that participant.

In this PR, we're doing an inner join which means the participant no longer gets returned if they were ROS'd for a site I don't have access to. This should be okay for now. (Ideally, the participant will be returned with an empty `rosStatuses` so that they show up and still need to be acknowledged, but I was having some trouble).