### PR TITLE
fix: infinite loop when database has no sites

### DIFF
--- a/client/src/pages/private/ParticipantTableDialogues.js
+++ b/client/src/pages/private/ParticipantTableDialogues.js
@@ -102,7 +102,8 @@ export const ParticipantTableDialogues = ({
     if (allSites.length === 0) {
       fetchAllSites();
     }
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Dialog


### PR DESCRIPTION
This causes an infinite loop if you run the app without sites in the database