### PR TITLE
HCAP-1234 | RoS Start Date Column For MoH (+SU)

### DIFF
--- a/client/src/constants/participantTableConstants.js
+++ b/client/src/constants/participantTableConstants.js
@@ -50,6 +50,7 @@ export const tabs = {
       'archived',
       'rejected',
       'hired',
+      'ros',
     ],
   },
 };
@@ -117,6 +118,7 @@ export const tabStatuses = {
     'rejected',
     'hired',
     'archived',
+    'ros',
   ],
 };
 
@@ -214,6 +216,7 @@ export const columnsByRole = {
       crcClear,
       userUpdatedAt,
       postHireStatuses,
+      rosStartDate,
       edit,
     ],
   },
@@ -231,6 +234,7 @@ export const columnsByRole = {
       crcClear,
       userUpdatedAt,
       postHireStatuses,
+      rosStartDate,
       edit,
     ],
   },

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -111,14 +111,15 @@ const filterData = (data, columns, isMoH = false) => {
     if (
       item.rosStatuses &&
       item.rosStatuses.length > 0 &&
-      item.statusInfos[0].status !== 'archived'
+      item.statusInfos?.[0].status !== 'archived'
     ) {
-      const archivedStatuses = item.statusInfos.filter(
-        (statusInfo) =>
-          statusInfo.status === 'withdrawn' ||
-          statusInfo.status === 'pending_acknowledgement' ||
-          statusInfo.status === 'hired_by_peer'
-      );
+      const archivedStatuses =
+        item.statusInfos?.filter(
+          (statusInfo) =>
+            statusInfo.status === 'withdrawn' ||
+            statusInfo.status === 'pending_acknowledgement' ||
+            statusInfo.status === 'hired_by_peer'
+        ) ?? [];
       const otherStatuses = archivedStatuses.map((statusInfo) => statusInfo.status);
       row.status = ['ros', ...otherStatuses];
     } else if (item.statusInfos && item.statusInfos.length > 0) {
@@ -474,6 +475,8 @@ const ParticipantTable = () => {
         );
       case 'postHireStatuses':
         return getGraduationStatus(row[columnId] || []);
+      case 'rosStartDate':
+        return row[columnId] ?? 'N/A';
       default:
         return row[columnId];
     }

--- a/cypress/fixtures/participantTableTabs.json
+++ b/cypress/fixtures/participantTableTabs.json
@@ -21,7 +21,8 @@
           "Non-HCAP",
           "CRC Clear",
           "Last Updated",
-          "Graduated"
+          "Graduated",
+          "Return of Service Start Date"
         ]
       }
     },
@@ -43,7 +44,8 @@
           "Non-HCAP",
           "CRC Clear",
           "Last Updated",
-          "Graduated"
+          "Graduated",
+          "Return of Service Start Date"
         ]
       }
     },

--- a/server/db/schema.js
+++ b/server/db/schema.js
@@ -24,6 +24,7 @@ const collections = {
 
 const views = {
   PARTICIPANTS_STATUS_INFOS: 'participants_status_infos',
+  TARA_PARTICIPANTS_STATUS_INFOS: 'tara_participants_status_infos',
 };
 
 // Relational tables should contain a `definition` property

--- a/server/db/schema.js
+++ b/server/db/schema.js
@@ -24,7 +24,6 @@ const collections = {
 
 const views = {
   PARTICIPANTS_STATUS_INFOS: 'participants_status_infos',
-  TARA_PARTICIPANTS_STATUS_INFOS: 'tara_participants_status_infos',
 };
 
 // Relational tables should contain a `definition` property

--- a/server/migrations/1660318202044_update_participant_status_infos.js
+++ b/server/migrations/1660318202044_update_participant_status_infos.js
@@ -1,0 +1,20 @@
+/* eslint-disable camelcase */
+const { dbClient, views } = require('../db');
+
+exports.shorthands = 'update-participant-status-infos';
+
+exports.up = async () => {
+  await dbClient.db.query(`CREATE OR REPLACE VIEW ${views.PARTICIPANTS_STATUS_INFOS} AS
+    SELECT p.id,
+     p.body,
+     p.search,
+     p.created_at,
+     p.updated_at,
+     jsonb_agg(ps.*) FILTER (WHERE ps.id IS NOT NULL) AS status_infos,
+     jsonb_agg(DISTINCT jsonb_build_object('id', rosstatus.id, 'data', rosstatus.data, 'status', rosstatus.status, 'site_id', rosstatus.site_id, 'rosSite', ros_site.*)) FILTER (WHERE rosstatus.id IS NOT NULL) AS ros_infos
+    FROM participants p
+      LEFT JOIN return_of_service_status rosstatus ON p.id = rosstatus.participant_id
+      LEFT JOIN participants_status ps ON p.id = ps.participant_id AND ps.current IS TRUE
+      LEFT JOIN employer_sites ros_site ON rosstatus.site_id = ros_site.id
+   GROUP BY p.id, p.body, p.search, p.created_at, p.updated_at`);
+};

--- a/server/migrations/1660318202044_update_participant_status_infos.js
+++ b/server/migrations/1660318202044_update_participant_status_infos.js
@@ -13,7 +13,7 @@ exports.up = async () => {
      jsonb_agg(ps.*) FILTER (WHERE ps.id IS NOT NULL) AS status_infos,
      jsonb_agg(DISTINCT jsonb_build_object('id', rosstatus.id, 'data', rosstatus.data, 'status', rosstatus.status, 'site_id', rosstatus.site_id, 'rosSite', ros_site.*)) FILTER (WHERE rosstatus.id IS NOT NULL) AS ros_infos
     FROM participants p
-      LEFT JOIN return_of_service_status rosstatus ON p.id = rosstatus.participant_id
+      LEFT JOIN return_of_service_status rosstatus ON p.id = rosstatus.participant_id AND rosstatus.is_current IS TRUE
       LEFT JOIN participants_status ps ON p.id = ps.participant_id AND ps.current IS TRUE
       LEFT JOIN employer_sites ros_site ON rosstatus.site_id = ros_site.id
    GROUP BY p.id, p.body, p.search, p.created_at, p.updated_at`);


### PR DESCRIPTION
Ticket: https://freshworks.atlassian.net/browse/HCAP-1234

- server/services/participants-helper.js
   - rosStatuses didn't return _at all_ for MoH/SU, necessitating some logic changes
- server/migrations/1660318202044_update_participant_status_infos.js
   - updated the view used in participants-helper used for MoH/SU. This is the only usage of this view, so I changed the view to return what was missing (rosStatuses namely)
- client/src/constants/participantTableConstants.js
  - added rosStartDate to list of columns. I'm actually not 100% sure on the tabs/tabStatuses though
- client/src/pages/private/ParticipantTable.js
  - got some undefined errors after bringing in rosStatuses for MoH here, basically added null checks in a few places.

![image](https://user-images.githubusercontent.com/102187683/185664174-0b947e0e-5803-4428-bc8a-b5dbbf264266.png)


