### PR TITLE
HCAP-1309 | Graduation date error message

### DIFF
--- a/client/src/components/modal-forms/ManageGraduationForm.js
+++ b/client/src/components/modal-forms/ManageGraduationForm.js
@@ -21,12 +21,13 @@ export const ManageGraduationForm = ({ initialValues, onClose, onSubmit, cohortE
         onSubmit={onSubmit}
         validationSchema={ParticipantPostHireStatusSchema}
       >
-        {({ submitForm, values, setFieldValue }) => {
+        {({ submitForm, values, setFieldValue, setFieldTouched }) => {
           const handleStatusChange = ({ target }) => {
             const { value } = target;
             setFieldValue('status', value);
             if (value === postHireStatuses.postSecondaryEducationCompleted) {
               setFieldValue('data.date', cohortEndDate);
+              setFieldTouched('data.date', false);
               setFieldValue('continue', 'continue_yes');
             } else {
               setFieldValue('data.date', '');


### PR DESCRIPTION
Ticket: https://freshworks.atlassian.net/browse/HCAP-1309

- After changing the purpose of the date field, I made it so that it was "untouched" to not trigger the error message. 
- Bonus: now when going Unsuccessful-> attempt submit-> Graduated-> Unsuccessful, the error message from the first unsuccessful submit does not appear again when status changed to unsuccessful again