### PR TITLE
HCAP-1319: HAs can see participants in the reports after MoH makes changes

### DIFF
--- a/server/routes/milestone-report.js
+++ b/server/routes/milestone-report.js
@@ -12,7 +12,8 @@ const {
   checkUserRegion,
   getReport,
   getHiredParticipantsReport,
-  getRosParticipantsReport,
+  getHARosMilestonesReport,
+  getMohRosMilestonesReport,
 } = require('../services/reporting');
 const { reportType, DEFAULT_REGION_NAME } = require('../constants');
 
@@ -55,7 +56,10 @@ const generateHiredReport = async (csvStream, region = DEFAULT_REGION_NAME) => {
  * @param csvStream output stream
  */
 const generateRosReport = async (csvStream, region) => {
-  const results = await getRosParticipantsReport(region);
+  const results =
+    region === DEFAULT_REGION_NAME
+      ? await getMohRosMilestonesReport()
+      : await getHARosMilestonesReport(region);
   results.forEach((result) => {
     csvStream.write({
       'Participant ID': result.participantId,

--- a/server/services/reporting.js
+++ b/server/services/reporting.js
@@ -26,6 +26,19 @@ const mapIntendToReturn = (value) => {
   }
 };
 
+const mapRosEntries = (rosEntries) =>
+  rosEntries.map((entry) => ({
+    participantId: entry.participant_id,
+    firstName: entry.participantJoin?.[0]?.body?.firstName,
+    lastName: entry.participantJoin?.[0]?.body?.lastName,
+    isHCA: true,
+    startDate: dayjs(entry.data?.date).format('YYYY-MM-DD'),
+    endDate: addYearToDate(entry.data?.date).format('YYYY-MM-DD'),
+    siteStartDate: dayjs(entry.data?.startDate || entry.data?.date).format('YYYY-MM-DD'),
+    site: entry.siteJoin?.body?.siteName,
+    healthRegion: entry.siteJoin?.body?.healthAuthority,
+  }));
+
 const getPostHireStatusForParticipant = (postHireStatuses) => {
   const graduationStatus = {
     isReturning: DEFAULT_STATUS,
@@ -356,19 +369,6 @@ const getNoOfferParticipantsReport = async () => {
     ...participant.body,
   }));
 };
-
-const mapRosEntries = (rosEntries) =>
-  rosEntries.map((entry) => ({
-    participantId: entry.participant_id,
-    firstName: entry.participantJoin?.[0]?.body?.firstName,
-    lastName: entry.participantJoin?.[0]?.body?.lastName,
-    isHCA: true,
-    startDate: dayjs(entry.data?.date).format('YYYY-MM-DD'),
-    endDate: addYearToDate(entry.data?.date).format('YYYY-MM-DD'),
-    siteStartDate: dayjs(entry.data?.startDate || entry.data?.date).format('YYYY-MM-DD'),
-    site: entry.siteJoin?.body?.siteName,
-    healthRegion: entry.siteJoin?.body?.healthAuthority,
-  }));
 
 const getMohRosMilestonesReport = async () => {
   const entries = await dbClient.db[collections.ROS_STATUS]

--- a/server/services/reporting.js
+++ b/server/services/reporting.js
@@ -458,6 +458,7 @@ const getHARosMilestonesReport = async (region) => {
     })
     .find({
       participant_id: sameSiteRosEntries.map((entry) => entry.participant_id),
+      // data.user <> NULL - indicated that the entry was modified by another user at some point
       'data.user <>': 'NULL',
     });
 


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1319

**Cause of this bug:**
`additionalEntries` are responsible for including participants outside of HAs region in the reports; this can happen due to RoS site change, for example
The issue was that it only included entries with `status = 'assigned-new-site'` - this status is valid when assigning a new site as HA; yet when MoH makes an edit, this status is not being assigned

**Proposed fix:**
Include all edited entries in the report, if they apply to the same health region as HA at any point.
This can be done y identifying updated entries: `'data.user <>': 'NULL'` and checking if HA is allowed to see them based on region

**What else included?**
Splitting `getRosReport` into `getMohRosMilestonesReport` and `getHARosMilestonesReport` 
