### PR TITLE
fix: broken deploy pipeline, update k8s apiVersion

### DIFF
--- a/openshift/backup-mongo.dc.yml
+++ b/openshift/backup-mongo.dc.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: ${NAME}

--- a/openshift/backup.dc.yml
+++ b/openshift/backup.dc.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: ${NAME}

--- a/openshift/server.dc.yml
+++ b/openshift/server.dc.yml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 labels:
   app: ${APP_NAME}
 parameters:


### PR DESCRIPTION
Update template to match what's seen in openshift docs: https://docs.openshift.com/container-platform/4.7/openshift_images/using-templates.html#templates-writing_using-templates

Successful run: https://github.com/bcgov/hcap/actions/runs/2916207111

Weirdly [patroni's deployment config](https://github.com/bcgov/hcap/blob/dev/openshift/patroni.dc.yml#L2) was the only one with this apiVersion