### PR TITLE
HCAP-1323 | RoS Start Date Column Sorting

### DIFF
--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -574,7 +574,7 @@ class ParticipantsFinder {
     this.hiredGlobalJoin = 'hiredGlobalJoin';
     this.siteJoin = 'siteJoin';
     this.siteDistanceJoin = 'siteDistanceJoin';
-    this.rosStatuses = 'rosStatuses';
+    this.rosStatuses = user.isHA || user.isEmployer ? 'rosStatuses' : 'ros_infos';
   }
 
   filterRegion(regionFilter) {

--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -574,6 +574,7 @@ class ParticipantsFinder {
     this.hiredGlobalJoin = 'hiredGlobalJoin';
     this.siteJoin = 'siteJoin';
     this.siteDistanceJoin = 'siteDistanceJoin';
+    // MoH/SU users query a view with ros_infos column
     this.rosStatuses = user.isHA || user.isEmployer ? 'rosStatuses' : 'ros_infos';
   }
 


### PR DESCRIPTION
Ticket: https://freshworks.atlassian.net/browse/HCAP-1323

Source of bug was that it was trying to sort on the column rosStatuses, but for Moh/SU, the query is different, it uses a view that had to have a different column name because it can only be lowercase name. First I changed it to just look at the right column in the code block that deals specifically with the sorting, but then I decided to move it up into the context/variable definition as that should also avoid future bugs and be less complex.