### PR TITLE
fix: using current hired status when archiving

### DIFF
--- a/client/src/components/participant-details/track-graduation.js
+++ b/client/src/components/participant-details/track-graduation.js
@@ -13,8 +13,16 @@ import { postHireStatuses } from '../../constants';
 import { AuthContext } from '../../providers';
 import { useToast } from '../../hooks';
 import { formatCohortDate } from '../../utils';
+import { participantStatus } from '../../constants';
 // Helper function to call archive participant service
-const handleArchive = async (participantId, openToast, dispatchFunction, additional = {}) => {
+const handleArchive = async (
+  participantId,
+  openToast,
+  dispatchFunction,
+  additional = {},
+  siteId = null,
+  currentStatusId = null
+) => {
   const response = await fetch(`${API_URL}/api/v1/employer-actions`, {
     method: 'POST',
     headers: {
@@ -22,7 +30,13 @@ const handleArchive = async (participantId, openToast, dispatchFunction, additio
       Accept: 'application/json',
       'Content-type': 'application/json',
     },
-    body: JSON.stringify({ participantId, status: 'archived', data: additional }),
+    body: JSON.stringify({
+      participantId,
+      status: 'archived',
+      data: additional,
+      site: siteId,
+      currentStatusId,
+    }),
   });
   if (response.ok) {
     fetchUserNotifications(dispatchFunction);
@@ -179,7 +193,17 @@ export const TrackGraduation = (props) => {
                 }}
                 onSubmit={async (values) => {
                   setShowArchiveModal(false);
-                  await handleArchive(props?.participant?.id, openToast, dispatchFunction, values);
+                  const hiredStatus = props?.participant?.latestStatuses?.find(
+                    (status) => status.status === participantStatus.HIRED
+                  );
+                  await handleArchive(
+                    props?.participant?.id,
+                    openToast,
+                    dispatchFunction,
+                    values,
+                    hiredStatus?.siteId,
+                    hiredStatus?.id
+                  );
                   fetchData();
                 }}
                 participant={props?.participant}

--- a/server/routes/participant.js
+++ b/server/routes/participant.js
@@ -48,6 +48,11 @@ const participantsRouter = express.Router();
 const newHiredParticipantRouter = express.Router();
 const employerActionsRouter = express.Router();
 
+const { participantStatus } = require('../constants');
+
+const { ALREADY_HIRED, INVALID_STATUS, INVALID_STATUS_TRANSITION, INVALID_ARCHIVE } =
+  participantStatus;
+
 // Get details of a participant by ID
 participantRouter.get(
   '/details/:id',
@@ -453,7 +458,15 @@ employerActionsRouter.post(
       participant_id: participantId,
       status,
     });
-    return res.status(201).json({ data: result });
+    let returnStatus = 201;
+    if (
+      [ALREADY_HIRED, INVALID_ARCHIVE, INVALID_STATUS, INVALID_STATUS_TRANSITION].includes(
+        result.status
+      )
+    ) {
+      returnStatus = 400;
+    }
+    return res.status(returnStatus).json({ data: result });
   })
 );
 

--- a/server/services/participant-details.js
+++ b/server/services/participant-details.js
@@ -62,6 +62,17 @@ const participantDetails = async (id) => {
         is_current: true,
       });
 
+    const latestStatuses = await dbClient.db[collections.PARTICIPANTS_STATUS].find({
+      participant_id: id,
+      current: true,
+    });
+    participant.latestStatuses = latestStatuses.map((status) => ({
+      id: status.id,
+      employerId: status.employer_id,
+      siteId: status.data.site,
+      status: status.status,
+    }));
+
     const { body: rosSiteDetails } = rosStatusDbObj?.rosSite || { body: {} };
     return {
       ...participant,

--- a/server/services/participant-status.js
+++ b/server/services/participant-status.js
@@ -102,7 +102,7 @@ const setParticipantStatus = async (
       : await tx[collections.PARTICIPANTS_STATUS].findOne({
           participant_id: participantId,
           current: true,
-          or: [{ employer_id: employerId }, { 'data.site IN': user.sites || [] }],
+          employer_id: employerId,
         });
 
     // If existing status if not current, then invalid status transition


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1308

Some consistency for Archiving.
In short, archiving from the table view in Hired Candidates passes in `site` and `currentStatusId`, both of which aren't passed in from the Participant Details view archiving. Akhil confirmed to me that for non-MoH users, Participant Details screen is only available for hired participants, so we can assume that they were hired here.

As such, we make the backend participant details endpoint return all current statuses, which in this case should really just be hired or archive. We then use those values to make it consistent with the table archive. We expect that there should only be one `hired` status, if at all. If there isn't a `hired` status, this endpoint should fail.

Why? There is a query in in the `employer-actions` endpoint for that gets the current status of the user and makes some important decisions from that. We aren't able to properly get this status unless its passed in. So at the very least, this should make archiving more consistent.