### PR TITLE
HCAP-1324: RoS start date sorting fix for MoH

### DIFF
--- a/server/services/participants-helper.js
+++ b/server/services/participants-helper.js
@@ -575,7 +575,7 @@ class ParticipantsFinder {
     this.siteJoin = 'siteJoin';
     this.siteDistanceJoin = 'siteDistanceJoin';
     // MoH/SU users query a view with ros_infos column
-    this.rosStatuses = user.isHA || user.isEmployer ? 'rosStatuses' : 'ros_infos';
+    this.rosStatuses = user.isHA || user.isEmployer ? 'rosStatuses' : 'ros_infos[0]';
   }
 
   filterRegion(regionFilter) {


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1324

The date wasn't sorted for MoH because it couldn't find `ros_infos.data.date` for MoH. Therefore, it sorted by `id` by default. The reason why it couldn't find `ros_infos.data.date` field was because it's an array - it can only get the actual date by getting a specific item `ros_infos[0]`