### PR TITLE
HCAP-1314 Consolidate getSites methods

### DIFF
--- a/client/src/services/return-of-service.js
+++ b/client/src/services/return-of-service.js
@@ -32,7 +32,7 @@ export const createReturnOfServiceStatus = async ({ participantId, data, siteId 
 };
 
 export const getAllSites = async () => {
-  const url = `${API_URL}/api/v1/employer-sites?all=true`;
+  const url = `${API_URL}/api/v1/employer-sites`;
   const response = await fetch(url, {
     method: 'GET',
     headers: {

--- a/server/routes/employer-sites.js
+++ b/server/routes/employer-sites.js
@@ -4,13 +4,7 @@ const logger = require('../logger.js');
 const { asyncMiddleware } = require('../error-handler.js');
 const { CreateSiteSchema, EditSiteSchema } = require('../validation');
 const { expressRequestBodyValidator, routeRedirect } = require('../middleware');
-const {
-  saveSingleSite,
-  updateSite,
-  getSites,
-  getSiteByID,
-  getAllSites,
-} = require('../services/employers');
+const { saveSingleSite, updateSite, getSites, getSiteByID } = require('../services/employers');
 const {
   getHiredParticipantsBySite,
   getWithdrawnParticipantsBySite,
@@ -87,17 +81,9 @@ router.get(
     routeRedirect({ redirect: '/api/v1/employer-sites/details', match: 'employer-sites-detail' }),
   ],
   asyncMiddleware(async (req, res) => {
-    const { hcapUserInfo: user, query } = req;
-    const { all } = query;
-    let result;
-    if (all === 'true') {
-      result = await getAllSites();
-    } else {
-      result = await getSites();
-      if (user.isHA) {
-        result = result.filter((site) => user.regions.includes(site.healthAuthority));
-      }
-    }
+    const { hcapUserInfo: user } = req;
+
+    const result = await getSites(user);
 
     logger.info({
       action: 'employer-sites_get',

--- a/server/routes/employer-sites.js
+++ b/server/routes/employer-sites.js
@@ -4,7 +4,12 @@ const logger = require('../logger.js');
 const { asyncMiddleware } = require('../error-handler.js');
 const { CreateSiteSchema, EditSiteSchema } = require('../validation');
 const { expressRequestBodyValidator, routeRedirect } = require('../middleware');
-const { saveSingleSite, updateSite, getSites, getSiteByID } = require('../services/employers');
+const {
+  saveSingleSite,
+  updateSite,
+  getSitesForUser,
+  getSiteByID,
+} = require('../services/employers');
 const {
   getHiredParticipantsBySite,
   getWithdrawnParticipantsBySite,
@@ -83,7 +88,7 @@ router.get(
   asyncMiddleware(async (req, res) => {
     const { hcapUserInfo: user } = req;
 
-    const result = await getSites(user);
+    const result = await getSitesForUser(user);
 
     logger.info({
       action: 'employer-sites_get',

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -151,8 +151,8 @@ apiRouter.get(
   keycloak.allowRolesMiddleware('*'),
   keycloak.getUserInfoMiddleware(),
   asyncMiddleware(async (req, res) => {
-    let sites = await getSites();
-    sites = sites.filter((i) => req.hcapUserInfo.sites.includes(i.siteId));
+    const { hcapUserInfo: user } = req;
+    const sites = await getSites(user);
     const notifications = await getUserNotifications(req.hcapUserInfo);
     return res.json({
       roles: req.hcapUserInfo.roles,

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,7 +1,7 @@
 // Index route for /api/v1
 const dayjs = require('dayjs');
 const express = require('express');
-const { getSites } = require('../services/employers.js');
+const { getSitesForUser } = require('../services/employers.js');
 const { getUserNotifications } = require('../services/user.js');
 const { validate, AccessRequestApproval } = require('../validation.js');
 const logger = require('../logger.js');
@@ -152,7 +152,7 @@ apiRouter.get(
   keycloak.getUserInfoMiddleware(),
   asyncMiddleware(async (req, res) => {
     const { hcapUserInfo: user } = req;
-    const sites = await getSites(user);
+    const sites = await getSitesForUser(user);
     const notifications = await getUserNotifications(req.hcapUserInfo);
     return res.json({
       roles: req.hcapUserInfo.roles,

--- a/server/services/employers.js
+++ b/server/services/employers.js
@@ -56,7 +56,7 @@ const updateSite = async (id, site) => {
  * @returns list of sites which the user has access to
  */
 
-const getSites = async (user) => {
+const getSitesForUser = async (user) => {
   const criteria = {};
 
   if (user.isHA) {
@@ -129,7 +129,7 @@ module.exports = {
   saveSingleSite,
   saveSites,
   updateSite,
-  getSites,
+  getSitesForUser,
   getSiteByID,
   getSiteDetailsById,
 };

--- a/server/tests/employer.form.test.js
+++ b/server/tests/employer.form.test.js
@@ -4,7 +4,7 @@ const app = require('../server');
 const {
   getEmployers,
   getEmployerByID,
-  getSites,
+  getSitesForUser,
   getSiteByID,
   saveSites,
 } = require('../services/employers.js');
@@ -241,7 +241,7 @@ describe.skip('Server V1 Form Endpoints', () => {
     const expectedResponse = { siteId: 67, status: 'Success' };
     expect(siteResponse).toEqual(expectedResponse);
 
-    const sites = await getSites({ roles: ['ministry_of_health'] });
+    const sites = await getSitesForUser({ roles: ['ministry_of_health'] });
     const [siteData] = sites.filter((entry) => entry.siteId === siteResponse.siteId);
 
     const [res] = await getSiteByID(siteData.id);

--- a/server/tests/employer.form.test.js
+++ b/server/tests/employer.form.test.js
@@ -241,7 +241,7 @@ describe.skip('Server V1 Form Endpoints', () => {
     const expectedResponse = { siteId: 67, status: 'Success' };
     expect(siteResponse).toEqual(expectedResponse);
 
-    const sites = await getSites();
+    const sites = await getSites({ roles: ['ministry_of_health'] });
     const [siteData] = sites.filter((entry) => entry.siteId === siteResponse.siteId);
 
     const [res] = await getSiteByID(siteData.id);

--- a/server/tests/employer.site.e2e.test.js
+++ b/server/tests/employer.site.e2e.test.js
@@ -128,9 +128,9 @@ describe('api-e2e tests for /employer-sites route', () => {
     expect(res.body.data.length).toEqual(3);
     expect(res.body.data).toEqual(
       expect.arrayContaining(
-        sites.map((site, index) =>
+        sites.map((site) =>
           // using objectContaining because the API returns an ID after saving to the database
-          expect.objectContaining(getAllSitesExpectedFields(site, index + 1))
+          expect.objectContaining(getAllSitesExpectedFields(site))
         )
       )
     );

--- a/server/tests/employer.site.e2e.test.js
+++ b/server/tests/employer.site.e2e.test.js
@@ -33,13 +33,19 @@ describe('api-e2e tests for /employer-sites route', () => {
   let server;
 
   beforeAll(async () => {
-    await startDB();
     server = app.listen();
   });
 
   afterAll(async () => {
-    await closeDB();
     await server.close();
+  });
+
+  beforeEach(async () => {
+    await startDB();
+  });
+
+  afterEach(async () => {
+    await closeDB();
   });
 
   it('should save site', async () => {

--- a/server/tests/employer.site.e2e.test.js
+++ b/server/tests/employer.site.e2e.test.js
@@ -78,7 +78,7 @@ describe('api-e2e tests for /employer-sites route', () => {
     expect(res.status).toEqual(200);
   });
 
-  it.only('should get sites', async () => {
+  it('should get sites', async () => {
     const site = siteObject({ id: 105, name: 'FW Test Site' });
     await saveSingleSite(site);
     const header = await getKeycloakToken(superuser);

--- a/server/tests/employer.site.e2e.test.js
+++ b/server/tests/employer.site.e2e.test.js
@@ -129,6 +129,7 @@ describe('api-e2e tests for /employer-sites route', () => {
     expect(res.body.data).toEqual(
       expect.arrayContaining(
         sites.map((site, index) =>
+          // using objectContaining because the API returns an ID after saving to the database
           expect.objectContaining(getAllSitesExpectedFields(site, index + 1))
         )
       )

--- a/server/tests/employer.site.e2e.test.js
+++ b/server/tests/employer.site.e2e.test.js
@@ -25,8 +25,8 @@ const siteObject = ({ id, name }) => ({
   operatorPhone: '2219909090',
   siteContactFirstName: 'NNN',
   siteContactLastName: 'PCP',
-  siteContactPhone: '2219909091',
-  siteContactEmail: 'test.site@hcpa.fresh',
+  siteContactPhoneNumber: '2219909091',
+  siteContactEmailAddress: 'test.site@hcpa.fresh',
 });
 
 describe('api-e2e tests for /employer-sites route', () => {

--- a/server/tests/employer.site.e2e.test.js
+++ b/server/tests/employer.site.e2e.test.js
@@ -78,16 +78,24 @@ describe('api-e2e tests for /employer-sites route', () => {
     expect(res.status).toEqual(200);
   });
 
-  it('should get sites', async () => {
+  it.only('should get sites', async () => {
     const site = siteObject({ id: 105, name: 'FW Test Site' });
     await saveSingleSite(site);
     const header = await getKeycloakToken(superuser);
     const res = await request(app).get('/api/v1/employer-sites').set(header);
     expect(res.status).toEqual(200);
-    expect(res.body.data.length).toBeGreaterThan(0);
-    expect(
-      res.body.data.filter((siteObj) => site.siteId === siteObj.siteId).length
-    ).toBeGreaterThan(0);
+    expect(res.body.data.length).toEqual(1);
+    expect(res.body.data).toEqual([
+      {
+        id: 1,
+        allocation: site.allocation.toString(),
+        healthAuthority: site.healthAuthority,
+        postalCode: site.postalCode,
+        siteId: site.siteId.toString(),
+        siteName: site.siteName,
+        operatorName: site.operatorName,
+      },
+    ]);
   });
 
   it('should get site by id', async () => {

--- a/server/tests/employer.site.e2e.test.js
+++ b/server/tests/employer.site.e2e.test.js
@@ -25,9 +25,29 @@ const siteObject = ({ id, name }) => ({
   operatorPhone: '2219909090',
   siteContactFirstName: 'NNN',
   siteContactLastName: 'PCP',
-  siteContactPhoneNumber: '2219909091',
-  siteContactEmailAddress: 'test.site@hcpa.fresh',
+  siteContactPhone: '2219909091',
+  siteContactEmail: 'test.site@hcpa.fresh',
 });
+
+/**
+ * This method is required because different endpoints for creating/editing
+ * sites have different names for similar fields (ie: siteContactPhone vs siteContactPhoneNumber)
+ *
+ * This method wraps siteObject() and renames those fields to pass validation
+ *
+ * @param {*} object containing an id and name used to create a test site
+ * @returns an object containing the given id and name and the rest of the required fields for batch saving
+ */
+const batchSiteObject = ({ id, name }) => {
+  const batchObject = {
+    ...siteObject({ id, name }),
+    siteContactPhoneNumber: siteObject.siteContactPhone,
+    siteContactEmailAddress: siteObject.siteContactEmail,
+  };
+  delete batchObject.siteContactPhone;
+  delete batchObject.siteContactEmail;
+  return batchObject;
+};
 
 const getAllSitesExpectedFields = (site) => ({
   allocation: site.allocation.toString(),
@@ -93,11 +113,11 @@ describe('api-e2e tests for /employer-sites route', () => {
     expect(res.status).toEqual(200);
   });
 
-  it.only('should get sites', async () => {
+  it('should get sites', async () => {
     const sites = [
-      siteObject({ id: 105, name: 'Test Site 1' }),
-      siteObject({ id: 106, name: 'Test Site 2' }),
-      siteObject({ id: 107, name: 'Test Site 3' }),
+      batchSiteObject({ id: 105, name: 'Test Site 1' }),
+      batchSiteObject({ id: 106, name: 'Test Site 2' }),
+      batchSiteObject({ id: 107, name: 'Test Site 3' }),
     ];
 
     await saveSites(sites);

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -4,7 +4,7 @@ const app = require('../server');
 const {
   saveSingleSite,
   saveSites,
-  getSites,
+  getSitesForUser,
   getSiteByID,
   updateSite,
 } = require('../services/employers.js');
@@ -132,7 +132,7 @@ describe('Employer Site Endpoints', () => {
   });
 
   it('Get sites, receive all successfully', async () => {
-    const res = await getSites({ roles: ['ministry_of_health'] });
+    const res = await getSitesForUser({ roles: ['ministry_of_health'] });
     expect(res.length).toEqual(3); // dependent on previous tests
     expect(res).toEqual(
       expect.arrayContaining([

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -132,7 +132,7 @@ describe('Employer Site Endpoints', () => {
   });
 
   it('Get sites, receive all successfully', async () => {
-    const res = await getSites();
+    const res = await getSites({ roles: ['ministry_of_health'] });
     expect(res).toEqual(
       expect.arrayContaining([site].map((item) => expect.objectContaining(item)))
     );

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -133,8 +133,17 @@ describe('Employer Site Endpoints', () => {
 
   it('Get sites, receive all successfully', async () => {
     const res = await getSites({ roles: ['ministry_of_health'] });
+    expect(res.length).toEqual(3); // dependent on previous tests
     expect(res).toEqual(
-      expect.arrayContaining([site].map((item) => expect.objectContaining(item)))
+      expect.arrayContaining([
+        expect.objectContaining({
+          allocation: site.allocation.toString(),
+          healthAuthority: site.healthAuthority,
+          postalCode: site.postalCode,
+          siteId: site.siteId.toString(),
+          siteName: site.siteName,
+        }),
+      ])
     );
   });
 


### PR DESCRIPTION
Notes: 
- Many places in the app refer to `user.sites` to list sites
- `GET /user` retrieved all sites then filtered by site ID, this wasn't sorted

Attn:
- In order to properly define test cases in isolation I needed to close and open the db between test cases which adds >10s to this test suite. This is because of some strange behaviour from Massive when attempting to clear the employer_sites table.
- When switching to use `saveSites` I noticed a difference in the validation schemas for the various site editing/creation endpoints which led me to create `batchSiteObject`. I think this isn't great and I'd love feedback on fixing this. Should we make large scale changes to validation/controllers/client to address these inconsistencies?

Changes:
- I consolidated the two getSites methods and handled the access for different roles in that function
- Limit fields on getSites to all that's currently needed on FE
