### PR TITLE
HCAP-1039: view cohort details page

### DIFF
--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -31,6 +31,7 @@ export default Object.freeze({
   SiteViewDetails: '/site-view/:id',
   PSIView: '/psi-view',
   PSIViewDetails: '/psi-view/:id',
+  CohortDetails: '/cohort/:id',
   ParticipantView: '/participant-view',
   ParticipantUpload: '/participant-upload',
   ParticipantUploadResults: '/participant-upload-results',

--- a/client/src/pages/private/CohortDetails.js
+++ b/client/src/pages/private/CohortDetails.js
@@ -99,7 +99,7 @@ export default ({ match }) => {
         <Card className={classes.cardRoot}>
           <Box py={8} px={10}>
             <Typography variant='body1'>
-              <Link href={Routes.PSIView}>Manage PSI</Link> / Cohort Details
+              <Link href={Routes.PSIView}>PSI</Link> / Cohorts / {cohort?.cohort_name}
             </Typography>
 
             <Box py={2}>

--- a/client/src/pages/private/CohortDetails.js
+++ b/client/src/pages/private/CohortDetails.js
@@ -5,8 +5,8 @@ import { makeStyles } from '@material-ui/core/styles';
 
 import { Page, CheckPermissions } from '../../components/generic';
 import { useToast } from '../../hooks';
-import { fetchCohort } from '../../services';
-import { Routes, ToastStatus } from '../../constants';
+import { fetchCohort, fetchParticipantPostHireStatus } from '../../services';
+import { Routes, ToastStatus, postHireStatuses } from '../../constants';
 
 const useStyles = makeStyles((theme) => ({
   cardRoot: {
@@ -21,13 +21,39 @@ export default ({ match }) => {
   const cohortId = parseInt(match.params.id);
   const classes = useStyles();
   const [cohort, setCohort] = useState(null);
+  const [unsuccessfulParticipantsNumber, setUnsuccessfulParticipantsNumber] = useState(-1);
   const { openToast } = useToast();
+
+  const getTotalParticipantsNumber = () => {
+    return cohort ? cohort.cohort_size : 0;
+  };
+
+  const getAvailableParticipantsNumber = () => {
+    if (!cohort) return 0;
+    const totalNumber = cohort.cohort_size;
+    const assignedParticipantsNumber = cohort.participants?.length;
+    return totalNumber - assignedParticipantsNumber;
+  };
+
+  const fetchUnsuccessfulParticipantsNumber = async () => {
+    if (!cohort) return;
+
+    const cohortParticipantIds = cohort.participants.map(
+      (participant) => participant.participant_id
+    );
+    let participantCount = 0;
+    for (const participantId of cohortParticipantIds) {
+      const postHireData = await fetchParticipantPostHireStatus({ id: participantId });
+      const status = postHireData?.status;
+      if (status === postHireStatuses.cohortUnsuccessful) participantCount++;
+    }
+    setUnsuccessfulParticipantsNumber(participantCount);
+  };
 
   const fetchCohortDetails = async () => {
     try {
       const data = await fetchCohort({ cohortId });
       setCohort(data);
-      console.log(data);
     } catch (err) {
       openToast({
         status: ToastStatus.Error,
@@ -40,8 +66,11 @@ export default ({ match }) => {
     if (cohort === null) {
       fetchCohortDetails();
     }
+    if (unsuccessfulParticipantsNumber === -1) {
+      fetchUnsuccessfulParticipantsNumber();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cohort]);
+  }, [cohort, unsuccessfulParticipantsNumber]);
 
   return (
     <Page>
@@ -76,14 +105,17 @@ export default ({ match }) => {
 
               <Grid item xs={12} sm={6}>
                 <Typography variant='subtitle2'>Total Seats</Typography>
-                <Typography variant='body1'>{cohort?.cohort_size}</Typography>
+                <Typography variant='body1'>{getTotalParticipantsNumber()}</Typography>
               </Grid>
 
               <Grid item xs={12} sm={6}>
                 <Typography variant='subtitle2'>Total Available Seats</Typography>
-                <Typography variant='body1'>
-                  {cohort?.cohort_size - cohort?.participants.length}
-                </Typography>
+                <Typography variant='body1'>{getAvailableParticipantsNumber()}</Typography>
+              </Grid>
+
+              <Grid item xs={12} sm={6}>
+                <Typography variant='subtitle2'>Number of Unsuccessful Participants</Typography>
+                <Typography variant='body1'>{unsuccessfulParticipantsNumber}</Typography>
               </Grid>
             </Grid>
           </Box>

--- a/client/src/pages/private/CohortDetails.js
+++ b/client/src/pages/private/CohortDetails.js
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react';
+import dayjs from 'dayjs';
+import { Box, Card, Grid, Typography, Link } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+import { Page, CheckPermissions } from '../../components/generic';
+import { useToast } from '../../hooks';
+import { fetchCohort } from '../../services';
+import { Routes, ToastStatus } from '../../constants';
+
+const useStyles = makeStyles((theme) => ({
+  cardRoot: {
+    minWidth: '1020px',
+  },
+  gridRoot: {
+    padding: theme.spacing(2),
+  },
+}));
+
+export default ({ match }) => {
+  const cohortId = parseInt(match.params.id);
+  const classes = useStyles();
+  const [cohort, setCohort] = useState(null);
+  const { openToast } = useToast();
+
+  const fetchCohortDetails = async () => {
+    try {
+      const data = await fetchCohort({ cohortId });
+      setCohort(data);
+      console.log(data);
+    } catch (err) {
+      openToast({
+        status: ToastStatus.Error,
+        message: err.message || 'Failed to fetch cohort',
+      });
+    }
+  };
+
+  useEffect(() => {
+    if (cohort === null) {
+      fetchCohortDetails();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cohort]);
+
+  return (
+    <Page>
+      <CheckPermissions
+        permittedRoles={['health_authority', 'ministry_of_health']}
+        renderErrorMessage={true}
+      >
+        <Card className={classes.cardRoot}>
+          <Box py={8} px={10}>
+            <Typography variant='body1'>
+              <Link href={Routes.PSIView}>Manage PSI</Link> / Cohort Details
+            </Typography>
+
+            <Box py={2}>
+              <Typography variant='h2'>{cohort?.cohort_name}</Typography>
+            </Box>
+
+            <Grid container spacing={2} className={classes.gridRoot}>
+              <Grid item xs={12} sm={6}>
+                <Typography variant='subtitle2'>Start Date</Typography>
+                <Typography variant='body1'>
+                  {dayjs(cohort?.start_date).format('MMM DD, YYYY')}
+                </Typography>
+              </Grid>
+
+              <Grid item xs={12} sm={6}>
+                <Typography variant='subtitle2'>End Date</Typography>
+                <Typography variant='body1'>
+                  {dayjs(cohort?.end_date).format('MMM DD, YYYY')}
+                </Typography>
+              </Grid>
+
+              <Grid item xs={12} sm={6}>
+                <Typography variant='subtitle2'>Total Seats</Typography>
+                <Typography variant='body1'>{cohort?.cohort_size}</Typography>
+              </Grid>
+
+              <Grid item xs={12} sm={6}>
+                <Typography variant='subtitle2'>Total Available Seats</Typography>
+                <Typography variant='body1'>
+                  {cohort?.cohort_size - cohort?.participants.length}
+                </Typography>
+              </Grid>
+            </Grid>
+          </Box>
+        </Card>
+      </CheckPermissions>
+    </Page>
+  );
+};

--- a/client/src/pages/private/CohortTable.js
+++ b/client/src/pages/private/CohortTable.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import _orderBy from 'lodash/orderBy';
-import Grid from '@material-ui/core/Grid';
-import { Box } from '@material-ui/core';
+
+import { Box, Grid, Link } from '@material-ui/core';
 import { Table, Button } from '../../components/generic';
-import { formatCohortDate } from '../../utils';
+import { formatCohortDate, keyedString } from '../../utils';
+import { Routes } from '../../constants';
 
 const columns = [
   { id: 'cohort_name', name: 'Cohort Name' },
@@ -15,6 +17,8 @@ const columns = [
 ];
 
 export default ({ cohorts, editCohortAction }) => {
+  const history = useHistory();
+
   // States
   const [order, setOrder] = useState('asc');
   const [rows, setRows] = useState(cohorts);
@@ -33,11 +37,24 @@ export default ({ cohorts, editCohortAction }) => {
   };
 
   // Helpers
-
   const sort = (array) => _orderBy(array, [orderBy, 'operatorName'], [order]);
 
   const renderCell = (columnId, row) => {
     switch (columnId) {
+      case 'cohort_name':
+        return (
+          <Link
+            component='button'
+            variant='body2'
+            onClick={() => {
+              const { id } = row;
+              const cohortDetailsPath = keyedString(Routes.CohortDetails, { id });
+              history.push(cohortDetailsPath);
+            }}
+          >
+            {row[columnId]}
+          </Link>
+        );
       case 'edit':
         return (
           <Button onClick={() => handleEdit(row)} variant='outlined' size='small' text='Edit' />

--- a/client/src/pages/private/CohortTable.js
+++ b/client/src/pages/private/CohortTable.js
@@ -36,6 +36,12 @@ export default ({ cohorts, editCohortAction }) => {
     editCohortAction(cohort);
   };
 
+  const handleCohortNav = (row) => {
+    const { id } = row;
+    const cohortDetailsPath = keyedString(Routes.CohortDetails, { id });
+    history.push(cohortDetailsPath);
+  };
+
   // Helpers
   const sort = (array) => _orderBy(array, [orderBy, 'operatorName'], [order]);
 
@@ -43,15 +49,7 @@ export default ({ cohorts, editCohortAction }) => {
     switch (columnId) {
       case 'cohort_name':
         return (
-          <Link
-            component='button'
-            variant='body2'
-            onClick={() => {
-              const { id } = row;
-              const cohortDetailsPath = keyedString(Routes.CohortDetails, { id });
-              history.push(cohortDetailsPath);
-            }}
-          >
+          <Link component='button' variant='body2' onClick={() => handleCohortNav(row)}>
             {row[columnId]}
           </Link>
         );

--- a/client/src/pages/private/PSIView.js
+++ b/client/src/pages/private/PSIView.js
@@ -1,7 +1,10 @@
 import React, { useState, useEffect, useMemo, lazy } from 'react';
+import { saveAs } from 'file-saver';
+import store from 'store';
+
 import { Box, Typography } from '@material-ui/core';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
-import { saveAs } from 'file-saver';
+import GetAppIcon from '@material-ui/icons/GetApp';
 
 import { Page, CheckPermissions, Button, Dialog } from '../../components/generic';
 import { PSIForm, CohortForm } from '../../components/modal-forms';
@@ -12,7 +15,6 @@ import {
   DOWNLOAD_DEFAULT_SUCCESS_MESSAGE,
   DOWNLOAD_DEFAULT_ERROR_MESSAGE,
 } from '../../constants';
-import store from 'store';
 import { AuthContext } from '../../providers';
 import { useToast } from '../../hooks';
 
@@ -28,8 +30,6 @@ export default () => {
 
   const { auth } = AuthContext.useAuth();
   const roles = useMemo(() => auth.user?.roles || [], [auth.user]);
-  // TODO: add in a dropdown once we have multiple download options
-  // const [isDownloadMenuOpen, setDownloadMenuOpen] = useState(false);
   const [isLoadingPSIParticipantsReport, setLoadingPSIParticipantsReport] = useState(false);
 
   // Functions
@@ -213,35 +213,13 @@ export default () => {
               permittedRoles={['ministry_of_health', 'health_authority']}
             >
               <Box alignSelf='flex-end' py={1}>
-                {/** TODO: add in a dropdown once we have multiple download options
-                  <ClickAwayListener onClickAway={() => setDownloadMenuOpen(false)}> */}
                 <Button
-                  /** TODO: add in a dropdown once we have multiple download options
-                    onClick={() => setDownloadMenuOpen(!isDownloadMenuOpen)}
-                    endIcon={<ExpandMoreIcon />}
-                    text='Download CSV' 
-                  */
-                  text='Download participants attending PSI Report'
+                  startIcon={<GetAppIcon />}
+                  text='Download PSI list (.csv)'
                   onClick={handleDownloadPSIParticipantsReport}
                   variant='outlined'
                   loading={isLoadingPSIParticipantsReport}
                 />
-
-                {/** TODO: add in a dropdown once we have multiple download options
-                  <Grow in={isDownloadMenuOpen}>
-                    <Paper>
-                      <MenuList>
-                        <MenuItem onClick={}>
-                          Download PSI and Cohort Information
-                        </MenuItem>
-
-                        <MenuItem onClick={}>
-                          Download Participants attending PSI
-                        </MenuItem>
-                      </MenuList>
-                    </Paper>
-                  </Grow>
-                */}
               </Box>
             </CheckPermissions>
           </Box>

--- a/client/src/pages/private/PSIView.js
+++ b/client/src/pages/private/PSIView.js
@@ -4,7 +4,6 @@ import store from 'store';
 
 import { Box, Typography } from '@material-ui/core';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
-import GetAppIcon from '@material-ui/icons/GetApp';
 
 import { Page, CheckPermissions, Button, Dialog } from '../../components/generic';
 import { PSIForm, CohortForm } from '../../components/modal-forms';
@@ -214,8 +213,7 @@ export default () => {
             >
               <Box alignSelf='flex-end' py={1}>
                 <Button
-                  startIcon={<GetAppIcon />}
-                  text='Download PSI list (.csv)'
+                  text='Download participants attending PSI Report'
                   onClick={handleDownloadPSIParticipantsReport}
                   variant='outlined'
                   loading={isLoadingPSIParticipantsReport}

--- a/client/src/pages/private/PSIViewDetails.js
+++ b/client/src/pages/private/PSIViewDetails.js
@@ -208,13 +208,11 @@ export default ({ match }) => {
             <Box pb={4} pl={2}>
               <Box pb={2}>
                 <Typography variant='body1'>
-                  <Link href={routes.PSIView}>PSI</Link> / {psi.instituteName}
+                  <Link href={routes.PSIView}>Manage PSI</Link> / PSI Details
                 </Typography>
               </Box>
               <Grid container direction='row'>
-                <Typography variant='h2'>
-                  <b>{psi.instituteName}</b>
-                </Typography>
+                <Typography variant='h2'>{psi.instituteName}</Typography>
                 <CheckPermissions permittedRoles={['ministry_of_health', 'health_authority']}>
                   <Box pl={2} pt={0.5}>
                     <Button

--- a/client/src/pages/private/PSIViewDetails.js
+++ b/client/src/pages/private/PSIViewDetails.js
@@ -208,7 +208,7 @@ export default ({ match }) => {
             <Box pb={4} pl={2}>
               <Box pb={2}>
                 <Typography variant='body1'>
-                  <Link href={routes.PSIView}>Manage PSI</Link> / PSI Details
+                  <Link href={routes.PSIView}>PSI</Link> / {psi.instituteName}
                 </Typography>
               </Box>
               <Grid container direction='row'>

--- a/client/src/routes/index.js
+++ b/client/src/routes/index.js
@@ -15,6 +15,7 @@ const SiteView = lazy(() => import('../pages/private/SiteView'));
 const SiteViewDetails = lazy(() => import('../pages/private/SiteViewDetails'));
 const PSIView = lazy(() => import('../pages/private/PSIView'));
 const PSIViewDetails = lazy(() => import('../pages/private/PSIViewDetails'));
+const CohortDetails = lazy(() => import('../pages/private/CohortDetails'));
 const EOIView = lazy(() => import('../pages/private/EOIView'));
 const EOIViewDetails = lazy(() => import('../pages/private/EOIViewDetails'));
 const ParticipantUpload = lazy(() => import('../pages/private/ParticipantUpload'));
@@ -178,6 +179,7 @@ export default () => {
             <PrivateRoute exact path={Routes.SiteViewDetails} component={SiteViewDetails} />
             <PrivateRoute exact path={Routes.PSIView} component={PSIView} />
             <PrivateRoute exact path={Routes.PSIViewDetails} component={PSIViewDetails} />
+            <PrivateRoute exact path={Routes.CohortDetails} component={CohortDetails} />
             <PrivateRoute exact path={Routes.EOIView} component={EOIView} />
             <PrivateRoute exact path={Routes.EOIViewDetails} component={EOIViewDetails} />
             <PrivateRoute exact path={Routes.ParticipantView} component={ParticipantView} />

--- a/client/src/services/participant.js
+++ b/client/src/services/participant.js
@@ -6,14 +6,14 @@ export const getCohortPsiName = (cohort = {}) =>
     ? `${cohort.cohort_name} / ${cohort.psi?.institute_name}`
     : 'Not Assigned';
 
-const getPostHireStatusLabel = ({ status, data = {} } = {}) => {
+export const getPostHireStatusLabel = ({ status, data = {} } = {}) => {
   switch (status) {
     case postHireStatuses.postSecondaryEducationCompleted:
       return `Graduation Completed on - ${data.graduationDate}`;
     case postHireStatuses.cohortUnsuccessful:
       return `Unsuccessful/incomplete course - ${data.unsuccessfulCohortDate}`;
     default:
-      return `Status not recorded`;
+      return `Not recorded`;
   }
 };
 

--- a/client/src/services/psi-cohort.js
+++ b/client/src/services/psi-cohort.js
@@ -102,7 +102,7 @@ export const fetchCohorts = async ({ psiId }) => {
 };
 
 export const fetchCohort = async ({ cohortId }) => {
-  const response = await fetch(`${API_URL}/api/v1/cohorts/${cohortId}/participants`, {
+  const response = await fetch(`${API_URL}/api/v1/cohorts/${cohortId}`, {
     headers: {
       Authorization: `Bearer ${store.get('TOKEN')}`,
     },
@@ -115,6 +115,22 @@ export const fetchCohort = async ({ cohortId }) => {
   }
 
   throw new Error(response.error || response.statusText || 'Unable to load cohorts details');
+};
+
+export const fetchCohortParticipants = async ({ cohortId }) => {
+  const res = await fetch(`${API_URL}/api/v1/cohorts/${cohortId}/participants`, {
+    headers: {
+      Authorization: `Bearer ${store.get('TOKEN')}`,
+    },
+    method: 'GET',
+  });
+
+  if (res.ok) {
+    const participants = await res.json();
+    return participants;
+  }
+
+  throw new Error(res.error || res.statusText || 'Unable to load cohort participants');
 };
 
 export const addCohort = async ({ psiId, cohort }) => {

--- a/client/src/services/psi-cohort.js
+++ b/client/src/services/psi-cohort.js
@@ -101,6 +101,22 @@ export const fetchCohorts = async ({ psiId }) => {
   throw new Error(response.error || response.statusText || 'Unable to load cohorts details');
 };
 
+export const fetchCohort = async ({ cohortId }) => {
+  const response = await fetch(`${API_URL}/api/v1/cohorts/${cohortId}/participants`, {
+    headers: {
+      Authorization: `Bearer ${store.get('TOKEN')}`,
+    },
+    method: 'GET',
+  });
+
+  if (response.ok) {
+    const cohort = await response.json();
+    return cohort;
+  }
+
+  throw new Error(response.error || response.statusText || 'Unable to load cohorts details');
+};
+
 export const addCohort = async ({ psiId, cohort }) => {
   const response = await fetch(`${API_URL}/api/v1/psi/${psiId}/cohorts/`, {
     method: 'POST',

--- a/server/routes/cohorts.js
+++ b/server/routes/cohorts.js
@@ -80,9 +80,6 @@ router.get(
     const user = userId || localUserId;
     const cohortId = parseInt(req.params.id, 10);
     const cohortParticipants = await getCohortParticipants(cohortId);
-    if (cohortParticipants === undefined) {
-      return res.status(404).send({ message: 'No participants found for this cohort' });
-    }
     logger.info({
       action: 'cohort_get',
       performed_by: {

--- a/server/routes/cohorts.js
+++ b/server/routes/cohorts.js
@@ -9,6 +9,7 @@ const {
   getAssignCohort,
   updateCohort,
   getCountOfAllocation,
+  getCohortWithParticipants,
 } = require('../services/cohorts.js');
 const { getParticipantByID } = require('../services/participants');
 const { EditCohortSchema, validate } = require('../validation');
@@ -55,6 +56,28 @@ router.get(
     const user = userId || localUserId;
     const id = parseInt(req.params.id, 10);
     const [cohort] = await getCohort(id);
+    if (cohort === undefined) {
+      return res.status(401).send({ message: 'You do not have permission to view this record' });
+    }
+    logger.info({
+      action: 'cohort_get',
+      performed_by: {
+        user,
+      },
+      id: cohort.id || '',
+    });
+
+    return res.status(200).json(cohort);
+  })
+);
+
+router.get(
+  '/:id/participants',
+  asyncMiddleware(async (req, res) => {
+    const { user_id: userId, sub: localUserId } = req.user;
+    const user = userId || localUserId;
+    const id = parseInt(req.params.id, 10);
+    const [cohort] = await getCohortWithParticipants(id);
     if (cohort === undefined) {
       return res.status(401).send({ message: 'You do not have permission to view this record' });
     }

--- a/server/routes/cohorts.js
+++ b/server/routes/cohorts.js
@@ -9,7 +9,7 @@ const {
   getAssignCohort,
   updateCohort,
   getCountOfAllocation,
-  getCohortWithParticipants,
+  getCohortParticipants,
 } = require('../services/cohorts.js');
 const { getParticipantByID } = require('../services/participants');
 const { EditCohortSchema, validate } = require('../validation');
@@ -71,25 +71,26 @@ router.get(
   })
 );
 
+// Get cohort participants with their statuses
 router.get(
   '/:id/participants',
+  [applyMiddleware(keycloak.allowRolesMiddleware('health_authority', 'ministry_of_health'))],
   asyncMiddleware(async (req, res) => {
     const { user_id: userId, sub: localUserId } = req.user;
     const user = userId || localUserId;
-    const id = parseInt(req.params.id, 10);
-    const [cohort] = await getCohortWithParticipants(id);
-    if (cohort === undefined) {
-      return res.status(401).send({ message: 'You do not have permission to view this record' });
+    const cohortId = parseInt(req.params.id, 10);
+    const cohortParticipants = await getCohortParticipants(cohortId);
+    if (cohortParticipants === undefined) {
+      return res.status(404).send({ message: 'No participants found for this cohort' });
     }
     logger.info({
       action: 'cohort_get',
       performed_by: {
         user,
       },
-      id: cohort.id || '',
     });
 
-    return res.status(200).json(cohort);
+    return res.status(200).json(cohortParticipants);
   })
 );
 

--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -28,6 +28,21 @@ const getCohort = async (id) =>
     id,
   });
 
+const getCohortWithParticipants = async (id) =>
+  dbClient.db[collections.COHORTS]
+    .join({
+      participants: {
+        relation: collections.COHORT_PARTICIPANTS,
+        type: 'LEFT OUTER',
+        on: {
+          cohort_id: 'id',
+        },
+      },
+    })
+    .find({
+      id,
+    });
+
 // Get all Cohorts associated with a specific PSI
 const getPSICohorts = async (psiID) =>
   dbClient.db[collections.COHORTS]
@@ -243,6 +258,7 @@ const changeCohortParticipant = async (
 
 module.exports = {
   getCohorts,
+  getCohortWithParticipants,
   getPSICohorts,
   getCohort,
   makeCohort,

--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -41,6 +41,7 @@ const getCohortWithParticipants = async (id) =>
     })
     .find({
       id,
+      'participants.is_current': true,
     });
 
 // Get all Cohorts associated with a specific PSI


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1039

Creating a new `CohortDetails` page to show
- Start date
- End date
- Capacity
- Availability
- Number of unsuccessful participants

<img width="650" alt="Screen Shot 2022-09-07 at 4 06 06 PM" src="https://user-images.githubusercontent.com/64768811/188998649-eddef89a-fcdf-4678-91a7-70c4835cc4d2.png">


There's a separate ticket to display a list of participants attached to this cohort --> https://freshworks.atlassian.net/browse/HCAP-1056

https://www.figma.com/proto/35c5C0DyTEOxJ4N4DIaADL/HCAP-Design?node-id=2441%3A37315&viewport=241%2C48%2C0.37&scaling=min-zoom&starting-point-node-id=2441%3A37147