### PR TITLE
HCAP-1341 Remove additional unneeded sorting

### DIFF
--- a/client/src/components/modal-forms/EditRosSiteForm.js
+++ b/client/src/components/modal-forms/EditRosSiteForm.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import _orderBy from 'lodash/orderBy';
 
 import Alert from '@material-ui/lab/Alert';
 import { Box } from '@material-ui/core';

--- a/client/src/components/modal-forms/EditRosSiteForm.js
+++ b/client/src/components/modal-forms/EditRosSiteForm.js
@@ -85,7 +85,7 @@ export const EditRosSiteForm = ({
               component={RenderAutocomplete}
               label='New Site Name'
               boldLabel
-              options={_orderBy(sites, ['siteName']).map((item) => ({
+              options={sites.map((item) => ({
                 value: item.siteId,
                 label: addEllipsisMask(item.siteName, MAX_LABEL_LENGTH),
               }))}

--- a/client/src/components/modal-forms/SelectProspectingSiteForm.js
+++ b/client/src/components/modal-forms/SelectProspectingSiteForm.js
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from 'react';
-import _orderBy from 'lodash/orderBy';
 import { AuthContext } from '../../providers';
 
 import {
@@ -75,7 +74,7 @@ export const SelectProspectingSiteForm = ({
             name='prospectingSite'
             component={RenderSelectField}
             placeholder='Select Site'
-            options={_orderBy(sites, ['siteName']).map((item) => ({
+            options={sites.map((item) => ({
               value: item.siteId,
               label: addEllipsisMask(item.siteName, MAX_LABEL_LENGTH),
             }))}

--- a/client/src/pages/private/UserView.js
+++ b/client/src/pages/private/UserView.js
@@ -237,7 +237,7 @@ export default () => {
                     name='sites'
                     component={RenderMultiSelectField}
                     label='* Employer Sites (allocation number) - select one or more'
-                    options={_orderBy(sites, ['siteName'])
+                    options={sites
                       .filter((item) =>
                         values.role === 'health_authority'
                           ? values.regions.includes(item.healthAuthority)

--- a/client/src/pages/private/UserView.js
+++ b/client/src/pages/private/UserView.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import _orderBy from 'lodash/orderBy';
 import { useHistory } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import { Box, Typography } from '@material-ui/core';


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1341

I guess lodash and postgres treat spaces differently in their sorting algorithms

- removed extra sort on FE for sitenames