### PR TITLE
HCAP-1349: modification to cohort participants query

### DIFF
--- a/client/src/pages/private/CohortDetails.js
+++ b/client/src/pages/private/CohortDetails.js
@@ -69,7 +69,16 @@ export default ({ match }) => {
     }
   };
 
-  const getParticipantGraduationStatus = (participantStatuses) => {
+  const getParticipantGraduationStatus = (participantStatuses, participantId, participants) => {
+    // check if any of the participants were re-assigned to the same cohort
+    if (
+      participants.filter((participant) => participant.participant_id === participantId).length > 1
+    ) {
+      // extra validation for the edge case
+      if (!participantStatuses.find((postHireStatus) => postHireStatus.is_current === true)) {
+        return getPostHireStatusLabel(participantStatuses[participantStatuses.length - 1]);
+      }
+    }
     if (!participantStatuses || participantStatuses.length === 0) return 'Not recorded';
     const graduationStatus = participantStatuses.find(
       (postHireStatus) => postHireStatus.is_current === true
@@ -146,21 +155,25 @@ export default ({ match }) => {
                   renderCell={(columnId, row) => {
                     switch (columnId) {
                       case 'firstName':
-                        return row.body[columnId];
+                        return row.participantsJoin?.[0].body[columnId];
                       case 'lastName':
                         return (
                           <Link
                             component='button'
                             variant='body2'
-                            onClick={() => handleOpenParticipantDetails(row.id)}
+                            onClick={() => handleOpenParticipantDetails(row.participant_id)}
                           >
-                            {row.body[columnId]}
+                            {row.participantsJoin?.[0].body[columnId]}
                           </Link>
                         );
                       case 'siteName':
-                        return row.siteJoin?.body[columnId];
+                        return row.siteJoin?.body?.[columnId];
                       case 'graduationStatus':
-                        return getParticipantGraduationStatus(row.postHireJoin);
+                        return getParticipantGraduationStatus(
+                          row.postHireJoin,
+                          row.participant_id,
+                          rows
+                        );
                       default:
                         return row[columnId];
                     }

--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -97,10 +97,21 @@ const getPSICohorts = async (psiID) => {
     });
 
   // calculate remaining cohort seats
-  psiCohorts = psiCohorts.map((cohort) => ({
-    ...cohort,
-    remaining_seats: cohort.cohort_size - cohort.participants.length,
-  }));
+  psiCohorts = psiCohorts.map((cohort) => {
+    const uniqueCohortParticipants = [];
+    // filter out duplicates
+    cohort.participants.forEach((participant) => {
+      if (
+        !uniqueCohortParticipants.find((item) => item.participant_id === participant.participant_id)
+      ) {
+        uniqueCohortParticipants.push(participant);
+      }
+    });
+    return {
+      ...cohort,
+      remaining_seats: cohort.cohort_size - uniqueCohortParticipants.length,
+    };
+  });
 
   return psiCohorts;
 };


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1349

In test db the query was selecting multiple entries for the same participant possibly due to `JOIN`. After setting `SELECT COUNT(DISTINCT "participants"."id")"` the number of available seats became correct for both queries.
This request is for filtering out duplicates which causing incorrect count. Yet I don't like this solution, so happy to hear thoughts on this 

Including 2 possible solutions here as separate commits based on further findings: https://teams.microsoft.com/l/message/19:IUaAmNEwTGmcqt3CjlNCrc_j7pTI3rB5QRpVrTFxNHQ1@thread.tacv2/1663206188323?tenantId=5b973f99-77df-4beb-b27d-aa0c70b8482c&groupId=3f22a178-b2af-4d1a-99cd-bc1781c11210&parentMessageId=1663204501914&teamName=HCAP&channelName=General&createdTime=1663206188323&allowXTenantAccess=false

<img width="600" alt="Screen Shot 2022-09-14 at 7 10 45 PM" src="https://user-images.githubusercontent.com/64768811/190297149-b043d0a1-fda7-48cb-b079-8860908a9977.png">

