### PR TITLE
HCAP-1358 HA participant access

### DIFF
--- a/client/src/pages/private/CohortDetails.js
+++ b/client/src/pages/private/CohortDetails.js
@@ -5,9 +5,9 @@ import { Box, Card, Grid, Typography, Link } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 import { Page, CheckPermissions, Table } from '../../components/generic';
-import { Routes, ToastStatus, postHireStatuses } from '../../constants';
+import { Routes, ToastStatus } from '../../constants';
 import { useToast } from '../../hooks';
-import { fetchCohort, fetchCohortParticipants, getPostHireStatusLabel } from '../../services';
+import { fetchCohort, getPostHireStatusLabel } from '../../services';
 import { keyedString } from '../../utils';
 
 const useStyles = makeStyles((theme) => ({
@@ -33,18 +33,6 @@ export default ({ match }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [rows, setRows] = useState([]);
 
-  const cohortSize = cohort?.cohort_size || 0;
-  const assignedParticipants = rows.length || 0;
-  const availableCohortSeats = cohortSize - assignedParticipants;
-  const unsuccessfulParticipants =
-    rows.filter((participant) =>
-      participant.postHireJoin?.find(
-        (postHireStatus) =>
-          postHireStatus.status === postHireStatuses.cohortUnsuccessful &&
-          postHireStatus.is_current === true
-      )
-    )?.length || 0;
-
   const columns = [
     { id: 'lastName', name: 'Last Name', sortable: false },
     { id: 'firstName', name: 'First Name', sortable: false },
@@ -56,9 +44,8 @@ export default ({ match }) => {
     try {
       setIsLoading(true);
       const cohortData = await fetchCohort({ cohortId });
-      setCohort(cohortData);
-      const cohortParticipantsData = (await fetchCohortParticipants({ cohortId })) || [];
-      setRows(cohortParticipantsData);
+      setCohort(cohortData.cohort);
+      setRows(cohortData.participants);
     } catch (err) {
       openToast({
         status: ToastStatus.Error,
@@ -124,17 +111,17 @@ export default ({ match }) => {
 
               <Grid item xs={12} sm={6}>
                 <Typography variant='subtitle2'>Total Seats</Typography>
-                <Typography variant='body1'>{cohortSize}</Typography>
+                <Typography variant='body1'>{cohort?.cohort_size ?? '...'}</Typography>
               </Grid>
 
               <Grid item xs={12} sm={6}>
                 <Typography variant='subtitle2'>Total Available Seats</Typography>
-                <Typography variant='body1'>{availableCohortSeats}</Typography>
+                <Typography variant='body1'>{cohort?.availableCohortSeats ?? '...'}</Typography>
               </Grid>
 
               <Grid item xs={12} sm={6}>
                 <Typography variant='subtitle2'>Number of Unsuccessful Participants</Typography>
-                <Typography variant='body1'>{unsuccessfulParticipants}</Typography>
+                <Typography variant='body1'>{cohort?.unsuccessfulParticipants ?? '...'}</Typography>
               </Grid>
             </Grid>
 

--- a/client/src/pages/private/CohortDetails.js
+++ b/client/src/pages/private/CohortDetails.js
@@ -9,17 +9,18 @@ import { Routes, ToastStatus } from '../../constants';
 import { useToast } from '../../hooks';
 import { fetchCohort, getPostHireStatusLabel } from '../../services';
 import { keyedString } from '../../utils';
+import Alert from '@material-ui/lab/Alert';
 
 const useStyles = makeStyles((theme) => ({
   cardRoot: {
-    minWidth: '1020px',
+    width: '1020px',
   },
   gridRoot: {
     padding: theme.spacing(2),
   },
   notFoundBox: {
     textAlign: 'center',
-    paddingTop: theme.spacing(6),
+    paddingTop: theme.spacing(3),
   },
 }));
 
@@ -122,6 +123,14 @@ export default ({ match }) => {
               <Grid item xs={12} sm={6}>
                 <Typography variant='subtitle2'>Number of Unsuccessful Participants</Typography>
                 <Typography variant='body1'>{cohort?.unsuccessfulParticipants ?? '...'}</Typography>
+              </Grid>
+
+              <Grid item xs={12}>
+                <Alert severity='info'>
+                  <Typography variant='body2' gutterBottom>
+                    Participants hired outside your region will not appear in this list
+                  </Typography>
+                </Alert>
               </Grid>
             </Grid>
 

--- a/client/src/pages/private/ParticipantDetailsView.js
+++ b/client/src/pages/private/ParticipantDetailsView.js
@@ -1,7 +1,7 @@
 // Participant Details Page
 // Dependency
 import React, { useEffect, useState, useMemo } from 'react';
-import { useParams, useHistory, Link as RouterLink } from 'react-router-dom';
+import { useParams, Link as RouterLink } from 'react-router-dom';
 
 import { Box, Card, Grid, Link, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';

--- a/server/routes/cohorts.js
+++ b/server/routes/cohorts.js
@@ -11,6 +11,7 @@ const {
   getCountOfAllocation,
   getCohortParticipants,
   filterCohortParticipantsForUser,
+  getCohortWithCalculatedFields,
 } = require('../services/cohorts.js');
 const { getParticipantByID } = require('../services/participants');
 const { EditCohortSchema, validate } = require('../validation');
@@ -52,6 +53,8 @@ router.get(
 // Get one cohort with its id
 router.get(
   '/:id',
+  [applyMiddleware(keycloak.allowRolesMiddleware('health_authority', 'ministry_of_health'))],
+  keycloak.getUserInfoMiddleware(),
   asyncMiddleware(async (req, res) => {
     const { user_id: userId, sub: localUserId } = req.user;
     const user = userId || localUserId;
@@ -60,6 +63,16 @@ router.get(
     if (cohort === undefined) {
       return res.status(401).send({ message: 'You do not have permission to view this record' });
     }
+
+    const cohortParticipants = await getCohortParticipants(id);
+
+    const cohortWithCalculatedFields = getCohortWithCalculatedFields(cohort, cohortParticipants);
+
+    const filteredCohortParticipants = filterCohortParticipantsForUser(
+      cohortParticipants,
+      req.hcapUserInfo
+    );
+
     logger.info({
       action: 'cohort_get',
       performed_by: {
@@ -68,32 +81,10 @@ router.get(
       id: cohort.id || '',
     });
 
-    return res.status(200).json(cohort);
-  })
-);
-
-// Get cohort participants with their statuses
-router.get(
-  '/:id/participants',
-  [applyMiddleware(keycloak.allowRolesMiddleware('health_authority', 'ministry_of_health'))],
-  keycloak.getUserInfoMiddleware(),
-  asyncMiddleware(async (req, res) => {
-    const { user_id: userId, sub: localUserId } = req.user;
-    const user = userId || localUserId;
-    const cohortId = parseInt(req.params.id, 10);
-    const cohortParticipants = await getCohortParticipants(cohortId);
-    const filteredCohortParticipants = filterCohortParticipantsForUser(
-      cohortParticipants,
-      req.hcapUserInfo
-    );
-    logger.info({
-      action: 'cohort_get',
-      performed_by: {
-        user,
-      },
+    return res.status(200).json({
+      cohort: cohortWithCalculatedFields,
+      participants: filteredCohortParticipants,
     });
-
-    return res.status(200).json(filteredCohortParticipants);
   })
 );
 

--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -111,13 +111,11 @@ const getCohortWithCalculatedFields = (cohort, participants) => {
   // Count cohort participants with unsuccessful statuses
   cohortWithCalculatedFields.unsuccessfulParticipants =
     participants.filter((participant) =>
-      participant.postHireJoin?.find((postHireStatus) => {
-        console.log(postHireStatus.status, postHireStatus.is_current);
-        return (
+      participant.postHireJoin?.find(
+        (postHireStatus) =>
           postHireStatus.status === postHireStatuses.cohortUnsuccessful &&
           postHireStatus.is_current === true
-        );
-      })
+      )
     )?.length || 0;
 
   return cohortWithCalculatedFields;

--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -91,6 +91,36 @@ const filterCohortParticipantsForUser = (cohortParticipants, user) => {
   return [];
 };
 
+/**
+ * Calculates and appends fields to cohort objects based
+ * on cohort data and participants list
+ *
+ * availableCohortSeats: number of seats available in the cohort
+ * unsuccessfulParticipants: total participants with unsuccessful statuses
+ *
+ * @param {*} cohort cohort to calculate fields for
+ * @param {*} participants cohort participant list, used in calculations
+ * @returns
+ */
+const getCohortWithCalculatedFields = (cohort, participants) => {
+  const cohortWithCalculatedFields = { ...cohort };
+
+  // Calculate available cohort seats
+  cohortWithCalculatedFields.availableCohortSeats = cohort.cohort_size - participants.length;
+
+  // Count cohort participants with unsuccessful statuses
+  cohortWithCalculatedFields.unsuccessfulParticipants =
+    participants.filter((participant) =>
+      participant.postHireJoin?.find(
+        (postHireStatus) =>
+          postHireStatus.status === postHireStatuses.cohortUnsuccessful &&
+          postHireStatus.is_current === true
+      )
+    )?.length || 0;
+
+  return cohortWithCalculatedFields;
+};
+
 // Get all Cohorts associated with a specific PSI
 const getPSICohorts = async (psiID) => {
   let psiCohorts = await dbClient.db[collections.COHORTS]
@@ -332,6 +362,7 @@ module.exports = {
   getCohorts,
   getCohortParticipants,
   filterCohortParticipantsForUser,
+  getCohortWithCalculatedFields,
   getPSICohorts,
   getCohort,
   makeCohort,

--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -65,6 +65,32 @@ const getCohortParticipants = async (cohortId) =>
       'participantStatusJoin.status': ['hired', 'archived'],
     });
 
+/**
+ * Filters cohort participants based on given user
+ *
+ * MOH: Don't filter participants
+ * HA: Only return participants hired to requesting HA's region
+ *
+ * @param {*} cohortParticipants list of cohort participants
+ * @param {*} user requesting user
+ * @returns filtered list of participants
+ */
+const filterCohortParticipantsForUser = (cohortParticipants, user) => {
+  if (user.isMoH) {
+    return cohortParticipants;
+  }
+
+  if (user.isHA) {
+    // Remove participants hired outside of HA's region
+    // participant.siteJoin is joined based on hired status' siteId
+    return cohortParticipants.filter((participant) =>
+      user.regions.includes(participant.siteJoin.body.healthAuthority)
+    );
+  }
+
+  return [];
+};
+
 // Get all Cohorts associated with a specific PSI
 const getPSICohorts = async (psiID) => {
   let psiCohorts = await dbClient.db[collections.COHORTS]
@@ -305,6 +331,7 @@ const changeCohortParticipant = async (
 module.exports = {
   getCohorts,
   getCohortParticipants,
+  filterCohortParticipantsForUser,
   getPSICohorts,
   getCohort,
   makeCohort,

--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -111,11 +111,13 @@ const getCohortWithCalculatedFields = (cohort, participants) => {
   // Count cohort participants with unsuccessful statuses
   cohortWithCalculatedFields.unsuccessfulParticipants =
     participants.filter((participant) =>
-      participant.postHireJoin?.find(
-        (postHireStatus) =>
+      participant.postHireJoin?.find((postHireStatus) => {
+        console.log(postHireStatus.status, postHireStatus.is_current);
+        return (
           postHireStatus.status === postHireStatuses.cohortUnsuccessful &&
           postHireStatus.is_current === true
-      )
+        );
+      })
     )?.length || 0;
 
   return cohortWithCalculatedFields;

--- a/server/services/participant-details.js
+++ b/server/services/participant-details.js
@@ -20,7 +20,7 @@ const checkUserHasAccessToParticipant = async (id, user) => {
 
     // Get hired site to determine hired region
     const hiredSite = await dbClient.db[collections.EMPLOYER_SITES].findOne({
-      id: hiredStatus.data.site,
+      'body.siteId': hiredStatus.data.site,
     });
 
     // Allow access if requesting user has access to hired site

--- a/server/services/participant-details.js
+++ b/server/services/participant-details.js
@@ -24,11 +24,9 @@ const checkUserHasAccessToParticipant = async (id, user) => {
     });
 
     // Allow access if requesting user has access to hired site
-    if (user.regions.includes(hiredSite.body.healthAuthority)) {
-      return true;
-    }
+    const participantIsInUserRegion = user.regions.includes(hiredSite.body.healthAuthority);
 
-    return false;
+    return participantIsInUserRegion;
   }
 
   if (user.isEmployer) {

--- a/server/tests/participant-details.e2e.test.js
+++ b/server/tests/participant-details.e2e.test.js
@@ -2,7 +2,7 @@
 const request = require('supertest');
 const app = require('../server');
 const { startDB, closeDB } = require('./util/db');
-const { makeTestParticipant } = require('./util/integrationTestData');
+const { makeTestParticipant, createTestParticipantStatus } = require('./util/integrationTestData');
 const { getKeycloakToken, healthAuthority, superuser } = require('./util/keycloak');
 
 describe('e2e tests for /participant/details route', () => {
@@ -26,12 +26,29 @@ describe('e2e tests for /participant/details route', () => {
     expect(res.status).toEqual(200);
   });
 
-  it('should not return participant for HA if participant is not hired or engaged by HA', async () => {
-    const p = await makeTestParticipant({ emailAddress: 'test.e2e.participant.details.2@hcap.io' });
-    expect(p.id).toBeDefined();
+  it('should not return participant for HA if participant is not in the same region', async () => {
+    const { participant } = await createTestParticipantStatus({
+      participantData: { emailAddress: 'test.e2e.participant.details.2@hcap.io' },
+      siteData: { siteId: 1231, healthAuthority: 'Northern' },
+      status: 'hired',
+    });
+    expect(participant.id).toBeDefined();
 
     const header = await getKeycloakToken(healthAuthority);
-    const res = await request(app).get(`/api/v1/participant/details/${p.id}`).set(header);
+    const res = await request(app).get(`/api/v1/participant/details/${participant.id}`).set(header);
     expect(res.status).toEqual(403);
+  });
+
+  it('should return participant for HA if participant is in the same region', async () => {
+    const { participant } = await createTestParticipantStatus({
+      participantData: { emailAddress: 'test.e2e.participant.details.2@hcap.io' },
+      siteData: { siteId: 1232, healthAuthority: 'Fraser' },
+      status: 'hired',
+    });
+    expect(participant.id).toBeDefined();
+
+    const header = await getKeycloakToken(healthAuthority);
+    const res = await request(app).get(`/api/v1/participant/details/${participant.id}`).set(header);
+    expect(res.status).toEqual(200);
   });
 });


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1358

- Open HA participant access to all participants within their region
- Limit cohort participant query to only participants within HA's region
- Fix available seats count on details page
  - Calculate remaining seats on server
  - Solution is to combine the participants and details queries so we don't make duplicate service requests
