### PR TITLE
HCAP-1332 | Deployment alerts for MS Teams

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,4 +138,4 @@ jobs:
           timezone: America/Vancouver
           show-on-start: false
           show-on-exit: true
-          show-on-failure: true
+          show-on-failure: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,14 +108,18 @@ jobs:
           make server-build
           make server-deploy
 
-      - name: Set Notification Title
-        run: echo "SLACK_TITLE=$(git tag -l --format='%(contents:subject)' dev)" >> $GITHUB_ENV
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: 'Dev | Deployment Completed :rocket:'
+      - name: Microsoft Teams Deploy Card
+        uses: toko-bifrost/ms-teams-deploy-card@master
+        if: always()
+        with:
+          github-token: ${{ github.token }}
+          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          environment: development
+          card-layout-exit: complete
+          timezone: America/Vancouver
+          show-on-start: false
+          show-on-exit: true
+          show-on-failure: true
 
       - name: Health Check app
         uses: jtalk/url-health-check-action@v1.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,18 @@ jobs:
         with:
           node-version: '15'
 
+      - uses: toko-bifrost/ms-teams-deploy-card@master
+        if: always()
+        with:
+          github-token: ${{ github.token }}
+          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          environment: development
+          card-layout-exit: complete
+          timezone: America/Vancouver
+          show-on-start: false
+          show-on-exit: true
+          show-on-failure: true
+
       - name: NPM Audit
         run: |
           cd "$GITHUB_WORKSPACE/client" && npm audit --production
@@ -107,19 +119,6 @@ jobs:
           make print-status
           make server-build
           make server-deploy
-
-      - name: Microsoft Teams Deploy Card
-        uses: toko-bifrost/ms-teams-deploy-card@master
-        if: always()
-        with:
-          github-token: ${{ github.token }}
-          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          environment: development
-          card-layout-exit: complete
-          timezone: America/Vancouver
-          show-on-start: false
-          show-on-exit: true
-          show-on-failure: true
 
       - name: Health Check app
         uses: jtalk/url-health-check-action@v1.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,18 +30,6 @@ jobs:
         with:
           node-version: '15'
 
-      - uses: toko-bifrost/ms-teams-deploy-card@master
-        if: always()
-        with:
-          github-token: ${{ github.token }}
-          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          environment: development
-          card-layout-exit: complete
-          timezone: America/Vancouver
-          show-on-start: false
-          show-on-exit: true
-          show-on-failure: true
-
       - name: NPM Audit
         run: |
           cd "$GITHUB_WORKSPACE/client" && npm audit --production
@@ -138,3 +126,16 @@ jobs:
         with:
           target: ${{ env.DEV_URL }}
           cmd_options: '-I'
+
+      - name: Microsoft Teams Deploy Card
+        uses: toko-bifrost/ms-teams-deploy-card@master
+        if: always()
+        with:
+          github-token: ${{ github.token }}
+          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          environment: development
+          card-layout-exit: complete
+          timezone: America/Vancouver
+          show-on-start: false
+          show-on-exit: true
+          show-on-failure: true

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -73,12 +73,15 @@ jobs:
           oc login --token="$AUTH_TOKEN" --server="$CLUSTER"
           export OS_NAMESPACE_SUFFIX=${{ env.OS_NAMESPACE_SUFFIX }}
           make server-deploy
-
-      - name: Set Notification Title
-        run: echo "SLACK_TITLE=$(git tag -l --format='%(contents:subject)' prod)" >> $GITHUB_ENV
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: 'Prod Deployment Completed :rocket:'
+      - name: Microsoft Teams Deploy Card
+        uses: toko-bifrost/ms-teams-deploy-card@master
+        if: always()
+        with:
+          github-token: ${{ github.token }}
+          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          environment: production
+          card-layout-exit: complete
+          timezone: America/Vancouver
+          show-on-start: false
+          show-on-exit: true
+          show-on-failure: true

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -73,6 +73,7 @@ jobs:
           oc login --token="$AUTH_TOKEN" --server="$CLUSTER"
           export OS_NAMESPACE_SUFFIX=${{ env.OS_NAMESPACE_SUFFIX }}
           make server-deploy
+
       - name: Microsoft Teams Deploy Card
         uses: toko-bifrost/ms-teams-deploy-card@master
         if: always()
@@ -84,4 +85,4 @@ jobs:
           timezone: America/Vancouver
           show-on-start: false
           show-on-exit: true
-          show-on-failure: true
+          show-on-failure: false

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -28,6 +28,18 @@ jobs:
             src:
               - 'openshift/**'
           base: 'refs/tags/test'
+      - name: Microsoft Teams Deploy Card
+        uses: toko-bifrost/ms-teams-deploy-card@master
+        if: always()
+        with:
+          github-token: ${{ github.token }}
+          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          environment: ${{ env.OS_NAMESPACE_SUFFIX }}
+          card-layout-exit: complete
+          timezone: America/Vancouver
+          show-on-start: false
+          show-on-exit: true
+          show-on-failure: true
       - name: Dry run - Test
         env:
           OS_NAMESPACE_SUFFIX: test
@@ -105,16 +117,3 @@ jobs:
           oc login --token="$AUTH_TOKEN" --server="$CLUSTER"
           export OS_NAMESPACE_SUFFIX=${{ env.OS_NAMESPACE_SUFFIX }}
           make server-deploy
-
-      - name: Microsoft Teams Deploy Card
-        uses: toko-bifrost/ms-teams-deploy-card@master
-        if: always()
-        with:
-          github-token: ${{ github.token }}
-          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          environment: ${{ env.OS_NAMESPACE_SUFFIX }}
-          card-layout-exit: complete
-          timezone: America/Vancouver
-          show-on-start: false
-          show-on-exit: true
-          show-on-failure: true

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -21,8 +21,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Microsoft Teams Deploy Card
-        uses: toko-bifrost/ms-teams-deploy-card@master
+      - uses: toko-bifrost/ms-teams-deploy-card@master
         if: always()
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -114,3 +114,66 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_MESSAGE: 'Test Deployment Completed :rocket:'
+
+      - name: Microsoft Teams Deploy Card
+      - uses: toko-bifrost/ms-teams-deploy-card@master
+        if: always()
+        with:
+          github-token: ${{ github.token }}
+          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          environment: name of env
+          timezone: America/Vancouver
+          custom-actions: '|
+            - text: View PR
+            url: "https://www.google.ca"'
+          custom-facts: '|
+            - name: GitHub Run ID
+            value: ${{ github.run_id}}'
+
+      - name: Microsoft Teams Notification (Generic)
+        uses: aliencube/microsoft-teams-actions@v0.8.0
+        with:
+          webhook_uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          title: 'Test Deployment Completed 🚀'
+          summary: 'PR x Promoted to env'
+          theme_color: 'FFE600'
+          sections: '[
+            {
+            "activityTitle": "Tara Epp",
+            "activitySubtitle": "9/13/2016, 11:46am",
+            "activityImage": "https://connectorsdemo.azurewebsites.net/images/MSC12_Oscar_002.jpg",
+            "facts": [
+            {
+            "name": "Ref:",
+            "value": "refs/tags/test"
+            },
+            {
+            "name": "Event:",
+            "value": "push"
+            }
+            ],
+            "text": "HCAP-1234 | Add details to page for user roles (#1234)"
+            }
+            ]'
+          actions: '[
+            {
+            "@type": "OpenUri",
+            "name": "OpenShift Deploy/Promotion To Test",
+            "targets": [
+            {
+            "os": "default",
+            "uri": "http://google.ca"
+            }
+            ]
+            },
+            {
+            "@type": "OpenUri",
+            "name": "Commit",
+            "targets": [
+            {
+            "os": "default",
+            "uri": "http://google.ca"
+            }
+            ]
+            }
+            ]'

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          environment: ${{ OS_NAMESPACE_SUFFIX }}
+          environment: test
           card-layout-exit: complete
           timezone: America/Vancouver
           show-on-start: false

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -116,7 +116,7 @@ jobs:
           SLACK_MESSAGE: 'Test Deployment Completed :rocket:'
 
       - name: Microsoft Teams Deploy Card
-      - uses: toko-bifrost/ms-teams-deploy-card@master
+        uses: toko-bifrost/ms-teams-deploy-card@master
         if: always()
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -21,13 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          filters: |
-            src:
-              - 'openshift/**'
-          base: 'refs/tags/test'
       - name: Microsoft Teams Deploy Card
         uses: toko-bifrost/ms-teams-deploy-card@master
         if: always()
@@ -40,6 +33,14 @@ jobs:
           show-on-start: false
           show-on-exit: true
           show-on-failure: true
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'openshift/**'
+          base: 'refs/tags/test'
+
       - name: Dry run - Test
         env:
           OS_NAMESPACE_SUFFIX: test

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -106,74 +106,15 @@ jobs:
           export OS_NAMESPACE_SUFFIX=${{ env.OS_NAMESPACE_SUFFIX }}
           make server-deploy
 
-      - name: Set Notification Title
-        run: echo "SLACK_TITLE=$(git tag -l --format='%(contents:subject)' test)" >> $GITHUB_ENV
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: 'Test Deployment Completed :rocket:'
-
       - name: Microsoft Teams Deploy Card
         uses: toko-bifrost/ms-teams-deploy-card@master
         if: always()
         with:
           github-token: ${{ github.token }}
           webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          environment: name of env
+          environment: ${{ env.OS_NAMESPACE_SUFFIX }}
+          card-layout-exit: complete
           timezone: America/Vancouver
-          custom-actions: '|
-            - text: View PR
-            url: "https://www.google.ca"'
-          custom-facts: '|
-            - name: GitHub Run ID
-            value: ${{ github.run_id}}'
-
-      - name: Microsoft Teams Notification (Generic)
-        uses: aliencube/microsoft-teams-actions@v0.8.0
-        with:
-          webhook_uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          title: 'Test Deployment Completed 🚀'
-          summary: 'PR x Promoted to env'
-          theme_color: 'FFE600'
-          sections: '[
-            {
-            "activityTitle": "Tara Epp",
-            "activitySubtitle": "9/13/2016, 11:46am",
-            "activityImage": "https://connectorsdemo.azurewebsites.net/images/MSC12_Oscar_002.jpg",
-            "facts": [
-            {
-            "name": "Ref:",
-            "value": "refs/tags/test"
-            },
-            {
-            "name": "Event:",
-            "value": "push"
-            }
-            ],
-            "text": "HCAP-1234 | Add details to page for user roles (#1234)"
-            }
-            ]'
-          actions: '[
-            {
-            "@type": "OpenUri",
-            "name": "OpenShift Deploy/Promotion To Test",
-            "targets": [
-            {
-            "os": "default",
-            "uri": "http://google.ca"
-            }
-            ]
-            },
-            {
-            "@type": "OpenUri",
-            "name": "Commit",
-            "targets": [
-            {
-            "os": "default",
-            "uri": "http://google.ca"
-            }
-            ]
-            }
-            ]'
+          show-on-start: false
+          show-on-exit: true
+          show-on-failure: true

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -106,6 +106,7 @@ jobs:
           oc login --token="$AUTH_TOKEN" --server="$CLUSTER"
           export OS_NAMESPACE_SUFFIX=${{ env.OS_NAMESPACE_SUFFIX }}
           make server-deploy
+
       - name: Microsoft Teams Deploy Card
         uses: toko-bifrost/ms-teams-deploy-card@master
         if: always()
@@ -117,4 +118,4 @@ jobs:
           timezone: America/Vancouver
           show-on-start: false
           show-on-exit: true
-          show-on-failure: true
+          show-on-failure: false

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -21,17 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: toko-bifrost/ms-teams-deploy-card@master
-        if: always()
-        with:
-          github-token: ${{ github.token }}
-          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          environment: ${{ env.OS_NAMESPACE_SUFFIX }}
-          card-layout-exit: complete
-          timezone: America/Vancouver
-          show-on-start: false
-          show-on-exit: true
-          show-on-failure: true
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -117,3 +106,15 @@ jobs:
           oc login --token="$AUTH_TOKEN" --server="$CLUSTER"
           export OS_NAMESPACE_SUFFIX=${{ env.OS_NAMESPACE_SUFFIX }}
           make server-deploy
+      - name: Microsoft Teams Deploy Card
+        uses: toko-bifrost/ms-teams-deploy-card@master
+        if: always()
+        with:
+          github-token: ${{ github.token }}
+          webhook-uri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          environment: ${{ OS_NAMESPACE_SUFFIX }}
+          card-layout-exit: complete
+          timezone: America/Vancouver
+          show-on-start: false
+          show-on-exit: true
+          show-on-failure: true

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
           provider: msteams
-          github-provider-map: 'fw-noel:Noel Feliciano,taraepp:Tara Epp,arranfw:Arran Woodruff,alva-fresh:8:Alva Kostrova'
+          github-provider-map: 'fw-noel:Noel Feliciano,taraepp:Tara Epp,arranfw:Arran Woodruff,alva-fresh:Alva Kostrova'

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -13,6 +13,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          provider: slack
+          webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          provider: msteams
           github-provider-map: 'fw-noel:UUWMCRU4Q,taraepp:U0373NCPMPH,arranfw:U01ADH9FUET,alva-fresh:U012X7BJV0T'

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -1,9 +1,7 @@
 name: PRs reviews reminder
 
 on:
-  schedule:
-    # Every weekday every 4 hours during working hours, send notification
-    - cron: '0 15,22 * * 1-5' # Github actions works only on UTC, cannot explicitly set the TZ as PST, so we add 7 hours. Reminders at 8AM and 3PM PST
+  push:
 
 jobs:
   pr-reviews-reminder:

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
           provider: msteams
-          github-provider-map: 'fw-noel:Noel Feliciano,taraepp:Tara Epparranfw:Arran Woodruff,alva-fresh:Olena Kostrova'
+          github-provider-map: 'fw-noel:ae6e3292-d502-4ee5-ad2d-75acf146a4eb,taraepp:5a85e7c2-c4ea-49b9-99c3-ac4348f69337,arranfw:orgid:537deeb2-827c-48cd-8564-0e02492d4ab7,alva-fresh:8:orgid:a3fe8d0f-c975-43f3-9aa1-71c5d8787c17'

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -1,7 +1,9 @@
 name: PRs reviews reminder
 
 on:
-  push:
+  schedule:
+    # Every weekday every 4 hours during working hours, send notification
+    - cron: '0 15,22 * * 1-5' # Github actions works only on UTC, cannot explicitly set the TZ as PST, so we add 7 hours. Reminders at 8AM and 3PM PST
 
 jobs:
   pr-reviews-reminder:

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
           provider: msteams
-          github-provider-map: 'fw-noel:UUWMCRU4Q,taraepp:U0373NCPMPH,arranfw:U01ADH9FUET,alva-fresh:U012X7BJV0T'
+          github-provider-map: 'fw-noel:noel.feliciano@ca.ey.com,taraepp:tara.epp@ca.ey.com,arranfw:arran.woodruff@ca.ey.com,alva-fresh:alva.kostrova@ca.ey.com'

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
           provider: msteams
-          github-provider-map: 'fw-noel:ae6e3292-d502-4ee5-ad2d-75acf146a4eb,taraepp:5a85e7c2-c4ea-49b9-99c3-ac4348f69337,arranfw:orgid:537deeb2-827c-48cd-8564-0e02492d4ab7,alva-fresh:8:orgid:a3fe8d0f-c975-43f3-9aa1-71c5d8787c17'
+          github-provider-map: 'fw-noel:Noel Feliciano,taraepp:Tara Epp,arranfw:Arran Woodruff,alva-fresh:8:Alva Kostrova'

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
           provider: msteams
-          github-provider-map: 'fw-noel:noel.feliciano@ca.ey.com,taraepp:tara.epp@ca.ey.com,arranfw:arran.woodruff@ca.ey.com,alva-fresh:alva.kostrova@ca.ey.com'
+          github-provider-map: 'fw-noel:Noel Feliciano,taraepp:Tara Epparranfw:Arran Woodruff,alva-fresh:Olena Kostrova'


### PR DESCRIPTION
Ticket: https://freshworks.atlassian.net/browse/HCAP-1332

- Uptime Robot alert 
   - 
    - tested and verified
    - I did also subscribe the HCAP alerts channel to the FW keycloak monitor (which it was not before)
-  PR Reminders:
    - 
    - kept same action (https://github.com/DavideViolante/pr-reviews-reminder-action)
    - updated to use Teams
    - not any examples of the user IDs for teams, so I assumed email
    - have not actually confirmed that this will work as desired
    - uses GH secret MS_TEAMS_WEBHOOK_URI to connect to a channel- modify secret to change channel
-  Deploy Alert:
    - 
    - using action https://github.com/toko-bifrost/ms-teams-deploy-card (see for config documentation)
    - also uses GH secret MS_TEAMS_WEBHOOK_URI
    - I have it set to send a notification on exit, and not show on start (ie: will not notify when it starts deploying, only when finished)
    - I've tried putting the action in a few different places, but it always shows "IN PROGRESS" as the status on the alert. 
    - Docs suggested moving the action right below `- uses: actions/checkout@v2` because the jobs.jobid.name being set prevents the tool from distinguishing when the job is complete. I did not try removing the name from Checkout or higher up in the steps (clarity was more important in the workflow run than the teams notification)
    - in the end I put the alert at the end of the workflow, because it was being sent prematurely before I moved it there. Set it to not send a notification on deployment failure to avoid ambiguity- if a notification was sent it was a success.