### PR TITLE
HCAP-1361 Get Cohort ISE

### DIFF
--- a/server/routes/cohorts.js
+++ b/server/routes/cohorts.js
@@ -64,27 +64,35 @@ router.get(
       return res.status(401).send({ message: 'You do not have permission to view this record' });
     }
 
-    const cohortParticipants = await getCohortParticipants(id);
+    try {
+      const cohortParticipants = await getCohortParticipants(id);
 
-    const cohortWithCalculatedFields = getCohortWithCalculatedFields(cohort, cohortParticipants);
+      const cohortWithCalculatedFields = getCohortWithCalculatedFields(cohort, cohortParticipants);
 
-    const filteredCohortParticipants = filterCohortParticipantsForUser(
-      cohortParticipants,
-      req.hcapUserInfo
-    );
+      const filteredCohortParticipants = filterCohortParticipantsForUser(
+        cohortParticipants,
+        req.hcapUserInfo
+      );
 
-    logger.info({
-      action: 'cohort_get',
-      performed_by: {
-        user,
-      },
-      id: cohort.id || '',
-    });
+      logger.info({
+        action: 'cohort_get',
+        performed_by: {
+          user,
+        },
+        id: cohort.id || '',
+      });
 
-    return res.status(200).json({
-      cohort: cohortWithCalculatedFields,
-      participants: filteredCohortParticipants,
-    });
+      return res.status(200).json({
+        cohort: cohortWithCalculatedFields,
+        participants: filteredCohortParticipants,
+      });
+    } catch (err) {
+      logger.error(`Cohort retrieval failed ${err.message}`, {
+        context: 'cohort-controller',
+        error: err,
+      });
+      throw err;
+    }
   })
 );
 

--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -50,6 +50,7 @@ const getCohortParticipants = async (cohortId) =>
         relation: collections.PARTICIPANTS_STATUS,
         on: {
           participant_id: 'id',
+          status: 'hired',
         },
       },
       siteJoin: {


### PR DESCRIPTION
https://freshworks.atlassian.net/browse/HCAP-1361

Notes:
- Previous join was joining any participants statuses which made it indeterminate which status would be retrieved
- This would often join statuses that don't contain `data.site` which means the siteJoin would be null
- Null site join caused issues with the new HA region access code

Solution:
- Additional logs on get cohort failure
- Only join hired statuses so we are more confident it will populate the siteJoin
  - We have seen hired statuses without 'site' but these are very invalid and we should delete them as we see them, they will cause the same crash when stumbled upon though