### PR TITLE
HCAP-1363 Separate joins for hired and archived status

### DIFF
--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -140,6 +140,7 @@ const getPSICohorts = async (psiID) => {
         type: 'LEFT OUTER',
         on: {
           cohort_id: 'id',
+          is_current: true,
         },
       },
       participantStatusJoin: {


### PR DESCRIPTION
- Oversight from the last fix was that joining on `hired` would omit `archived` participants, we run into issues when we combine archived and hired participants in the same join so I split them up into two joins
  - When combining hired and archived into `participantStatusJoin` we can't guarantee `siteId` will be populated because some archive statuses don't have `siteId`
  - By splitting them up, we ensure we get all hired and archived participants, and can also be much more confident `siteJoin` will populate by referring to the hired status

https://freshworks.atlassian.net/browse/HCAP-1363