### PR TITLE
HCAP-1364 Cohort participant count

### DIFF
--- a/server/services/cohorts.js
+++ b/server/services/cohorts.js
@@ -140,6 +140,7 @@ const getPSICohorts = async (psiID) => {
         type: 'LEFT OUTER',
         on: {
           cohort_id: 'id',
+          is_current: true,
         },
       },
       participantStatusJoin: {


### PR DESCRIPTION
Only counting current participants should stop us counting duplicate assignees to a single cohort

https://freshworks.atlassian.net/browse/HCAP-1364