### PR TITLE
fix: remove hirecount to fix performance issues

### DIFF
--- a/client/src/pages/private/SiteTable.js
+++ b/client/src/pages/private/SiteTable.js
@@ -58,7 +58,6 @@ const columns = [
   { id: 'city', name: 'City' },
   { id: 'postalCode', name: 'Postal Code' },
   { id: 'allocation', name: 'Allocation' },
-  { id: 'hireCount', name: 'Hires' },
   { id: 'details' },
 ];
 

--- a/server/services/employers.js
+++ b/server/services/employers.js
@@ -75,20 +75,6 @@ const getSitesWithCriteria = async (additionalCriteria, additionalCriteriaParams
         employer_sites.body -> 'healthAuthority' as "healthAuthority",
         employer_sites.body -> 'postalCode' as "postalCode",
         employer_sites.body -> 'allocation' as "allocation",
-        (
-          SELECT
-              count(*)
-          FROM
-              participants_status ps
-              LEFT outer JOIN participants_status ps_da on ps.participant_id = ps_da.participant_id
-              AND ps_da.status = 'archived'
-              AND ps_da.current = 'true'
-              AND ps_da.data ->> 'type' = 'duplicate'
-          WHERE
-              ps.data ->> 'site' = employer_sites.body ->> 'siteId'
-              and ps.data ->> 'nonHcapOpportunity' = 'false'
-              and ps_da.data ->> 'type' is null
-        ) as "hireCount"
       FROM
         employer_sites
       ${additionalCriteria.length > 0 ? 'WHERE' : ''}

--- a/server/services/employers.js
+++ b/server/services/employers.js
@@ -74,7 +74,7 @@ const getSitesWithCriteria = async (additionalCriteria, additionalCriteriaParams
         employer_sites.body -> 'city' as "city",
         employer_sites.body -> 'healthAuthority' as "healthAuthority",
         employer_sites.body -> 'postalCode' as "postalCode",
-        employer_sites.body -> 'allocation' as "allocation",
+        employer_sites.body -> 'allocation' as "allocation"
       FROM
         employer_sites
       ${additionalCriteria.length > 0 ? 'WHERE' : ''}


### PR DESCRIPTION
This subquery is causing performance issues on prod, we'll need to disable it for now and work on a more performant solution in the future