### PR TITLE
fix: apply phase allocation database changes

### DIFF
--- a/server/migrations/1661284647061_add-phase-tables.js
+++ b/server/migrations/1661284647061_add-phase-tables.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
-const { dbClient, schema } = require('../../db');
+const { dbClient, schema } = require('../db');
 
 exports.shorthands = 'add-phase-tables';
 

--- a/server/migrations/1661465391816_allocation_migration.js
+++ b/server/migrations/1661465391816_allocation_migration.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
-const { dbClient, collections } = require('../../db');
+const { dbClient, collections } = require('../db');
 
 exports.shorthands = 'migrate-phase-data';
 


### PR DESCRIPTION
[HCAP-1296](https://eydscanada.atlassian.net/browse/HCAP-1296)

This PR moves the migrations for Phase Allocation tables to the right folder, so that it will actually apply on dev. In [this ticket](https://eydscanada.atlassian.net/browse/HCAP-1276) we identified that this is the way to do it. To see what the tables look like in general, please see [this ticket](https://eydscanada.atlassian.net/browse/HCAP-1296) and [PR#818](https://github.com/bcgov/hcap/pull/818/files).