### PR TITLE
HCAP-1336: Authenticate user's sites when fetching site phase allocations

### DIFF
--- a/server/keycloak.js
+++ b/server/keycloak.js
@@ -21,6 +21,23 @@ const defaults = {
   'public-client': true,
 };
 
+// NOTE: This type is not actually used in this file yet due to some JSDoc limitations.
+// It is currently just here to be used by external files (such as phase-allocation.js).
+// However, it can be used once we switch to TS.
+/**
+ * @typedef {Object} hcapUserInfo
+ * @property {string} name           Full name of user (e.g. "Tabitha Test")
+ * @property {string} username       Username (e.g. "user@bceid")
+ * @property {string} id             Unique identifier string for the user
+ * @property {any[]} sites TODO: annotate element type
+ * @property {string[]} roles        Roles of the user (such as `region_interior` or `health_authority`)
+ * @property {string[]} regions      Regions the user is assigned to (such as `Interior`)
+ * @property {boolean} isEmployer    True if the user is an employer
+ * @property {boolean} isHA          True if the user is a health authority user
+ * @property {boolean} isSuperUser   True if the user is a superuser
+ * @property {boolean} isMoH         True if the user is an MoH user
+ */
+
 class Keycloak {
   // Wrapper class around keycloak-connect
   constructor() {
@@ -79,6 +96,7 @@ class Keycloak {
         const { content } = req.kauth.grant.access_token;
         const roles = content?.resource_access[this.clientNameFrontend]?.roles || [];
         const user = await getUser(content.sub);
+
         req.hcapUserInfo = {
           name: content.name,
           username: content.preferred_username,

--- a/server/routes/phase-allocation.js
+++ b/server/routes/phase-allocation.js
@@ -34,7 +34,8 @@ router.get(
     const authorized =
       user.isSuperUser ||
       user.isMoH ||
-      (user.isHA && (await getSitesForUser(user)).map((site) => site.id).includes(siteId));
+      ((user.isHA || user.isEmployer) &&
+        (await getSitesForUser(user)).map((site) => site.id).includes(siteId));
     if (!authorized) return res.status(403).send('Unauthorized site ID');
 
     // Get and return data

--- a/server/services/employers.js
+++ b/server/services/employers.js
@@ -2,6 +2,24 @@ const { dbClient, collections } = require('../db');
 const { validate, EmployerSiteBatchSchema } = require('../validation');
 const { userRegionQuery } = require('./user.js');
 
+/**
+ * @typedef {import("../keycloak").hcapUserInfo} hcapUserInfo
+ *
+ * @typedef {Object} employerSite
+ * @property {number} id               Internal ID for site
+ * @property {number} siteId           User-visible ID for site
+ * @property {string} siteName         Name of site
+ * @property {string} operatorName     Name of operator (e.g. 'Interior Health Authority')
+ * @property {string} city             City the site is in
+ * @property {string} healthAuthority  Authority for the site
+ * @property {string} postalCode       Postal code of site
+ * @property {number} allocation
+ */
+
+/**
+ * @param {hcapUserInfo} user
+ * @returns {employerSite[]}
+ */
 const getEmployers = async (user) => {
   const criteria =
     user.isSuperUser || user.isMoH ? {} : userRegionQuery(user.regions, 'healthAuthority');
@@ -90,8 +108,8 @@ const getSitesWithCriteria = async (additionalCriteria, additionalCriteriaParams
 
 /**
  * Get all accessible sites for a user
- * @param {*} user user with roles and sites to filter
- * @returns list of sites which the user has access to
+ * @param {hcapUserInfo} user  User with roles and sites to filter
+ * @returns {employerSite[]}   List of sites which the user has access to
  */
 const getSitesForUser = async (user) => {
   const additionalCriteria = [];
@@ -111,8 +129,8 @@ const getSitesForUser = async (user) => {
 
 /**
  * Get all sites for regions, returning nothing if there's no regions passed in
- * @param {*} regions regions to get sites for
- * @returns list of sites within a region
+ * @param {string[]} regions  Regions to get sites for
+ * @returns {employerSite[]}  List of sites within a region
  */
 const getSitesForRegion = async (regions) => {
   if (regions.length > 0) {


### PR DESCRIPTION
[HCAP-1336](https://eydscanada.atlassian.net/browse/HCAP-1336)

This PR prevents non-MoH users from accessing sites they do not have access to. It also adds a bit of documentation and typing to functions related to the `phase-allocation` endpoint.

It should be noted that this does NOT fix [HCAP-1391](https://eydscanada.atlassian.net/browse/HCAP-1391) (allowing MoH users to get invalid site allocations). That issue should be handled separately.