### PR TITLE
fix: rename breadcrumbs to view sites

### DIFF
--- a/client/src/pages/private/PhaseView.js
+++ b/client/src/pages/private/PhaseView.js
@@ -15,7 +15,7 @@ export default () => {
         <Box textAlign={0} width={1}>
           <Box py={4} px={2}>
             <Typography variant='body1'>
-              <Link href={Routes.SiteView}>Sites</Link> / <b>Phase list</b>
+              <Link href={Routes.SiteView}>View Sites</Link> / <b>Phase list</b>
             </Typography>
             <Box paddingTop={2}>
               <Typography variant='h2' py={2}>

--- a/client/src/pages/private/SiteViewDetails.js
+++ b/client/src/pages/private/SiteViewDetails.js
@@ -5,7 +5,7 @@ import { Box, Chip, Grid, Link, Typography } from '@material-ui/core';
 import { Button, Card, Dialog, Page, CheckPermissions } from '../../components/generic';
 import { scrollUp } from '../../utils';
 import store from 'store';
-import routes from '../../constants/routes';
+import { Routes } from '../../constants';
 import { EditSiteForm } from '../../components/modal-forms';
 import { useToast } from '../../hooks';
 import { ToastStatus, EditSiteSchema, API_URL } from '../../constants';
@@ -150,7 +150,7 @@ export default ({ match }) => {
                 <Box pb={4} pl={2}>
                   <Box pb={2}>
                     <Typography variant='body1'>
-                      <Link href={routes.SiteView}>View Sites</Link> / {site.siteName}
+                      <Link href={Routes.SiteView}>View Sites</Link> / {site.siteName}
                     </Typography>
                   </Box>
                   <Grid container>

--- a/client/src/pages/private/SiteViewDetails.js
+++ b/client/src/pages/private/SiteViewDetails.js
@@ -150,7 +150,7 @@ export default ({ match }) => {
                 <Box pb={4} pl={2}>
                   <Box pb={2}>
                     <Typography variant='body1'>
-                      <Link href={routes.SiteView}>Sites</Link> / {site.siteName}
+                      <Link href={routes.SiteView}>View Sites</Link> / {site.siteName}
                     </Typography>
                   </Box>
                   <Grid container>


### PR DESCRIPTION
HCAP-1392

A quick renaming of the breadcrumbs to match design