### PR TITLE
HCAP-1334: Optimize query for joining hires to site phase allocations

### DIFF
--- a/server/db/db.js
+++ b/server/db/db.js
@@ -54,9 +54,17 @@ class DBClient {
     return this.db.reload();
   }
 
-  async runRawQuery(query) {
-    if (!query) return;
-    await this.db.query(query);
+  /**
+   *
+   * @param {string | massive.Select | massive.Insert | massive.Update | massive.Delete} query  Query to run.
+   * @param {massive.QueryParams} queryParams  Array of parameters to use for the query.
+   *                                           For example, if `query` contains `$1`, this will be replaced with the first element of `queryParams`.
+   * @returns  Query result, or nothing if no query is provided.
+   */
+  async runRawQuery(query, queryParams) {
+    if (!query) return [];
+    const res = await this.db.query(query, queryParams);
+    return res;
   }
 
   async createDocumentTableIfNotExists(table) {

--- a/server/routes/employer-sites.js
+++ b/server/routes/employer-sites.js
@@ -194,7 +194,7 @@ router.get(
       // parseInt will return NaN (a falsey value) if it cannot parse the string
       return res.status(400).json({ error: 'Invalid site id' });
     }
-    const [result] = await getSiteByID(id);
+    const result = await getSiteByID(id);
     logger.info({
       action: 'employer-sites-detail_get',
       performed_by: {

--- a/server/routes/phase-allocation.js
+++ b/server/routes/phase-allocation.js
@@ -39,18 +39,23 @@ router.get(
     if (!authorized) return res.status(403).send('Unauthorized site ID');
 
     // Get and return data
-    const result = await getAllSitePhases(siteId);
-
-    logger.info({
-      action: 'phases_get',
-      performed_by: {
-        username: user.username,
-        id: user.id,
-      },
-      phases_accessed: result.map((phase) => phase.id),
-      for_site: siteId,
-    });
-    return res.json({ data: result });
+    try {
+      const result = await getAllSitePhases(siteId);
+      logger.info({
+        action: 'phases_get',
+        performed_by: {
+          username: user.username,
+          id: user.id,
+        },
+        phases_accessed: result.map((phase) => phase.id),
+        for_site: siteId,
+      });
+      return res.json({ data: result });
+    } catch (error) {
+      return error.message.includes('No site found')
+        ? res.status(400).send('Invalid site ID')
+        : res.status(500).send('Failed to get phases for site');
+    }
   })
 );
 

--- a/server/services/employers.js
+++ b/server/services/employers.js
@@ -152,9 +152,14 @@ const getSiteDetailsById = async (id) => {
   return site;
 };
 
+/**
+ * @param {number} id  ID of requested site
+ * @returns {[employerSite] | [{error: string}]} Requested site
+ */
 const getSiteByID = async (id) => {
   const site = await dbClient.db[collections.EMPLOYER_SITES].findDoc({ id });
   if (site.length === 0) {
+    // This might be better as an actual rejection
     return [{ error: `No site found with id` }];
   }
 

--- a/server/services/employers.js
+++ b/server/services/employers.js
@@ -154,13 +154,12 @@ const getSiteDetailsById = async (id) => {
 
 /**
  * @param {number} id  ID of requested site
- * @returns {[employerSite] | [{error: string}]} Requested site
+ * @returns {Promise<employerSite>} Requested site
  */
 const getSiteByID = async (id) => {
   const site = await dbClient.db[collections.EMPLOYER_SITES].findDoc({ id });
   if (site.length === 0) {
-    // This might be better as an actual rejection
-    return [{ error: `No site found with id` }];
+    throw new Error(`No site found with id ${id}`);
   }
 
   // Counting hire
@@ -195,7 +194,7 @@ const getSiteByID = async (id) => {
     });
   site[0].hcapHires = hcapHires;
   site[0].nonHcapHires = nonHcapHires;
-  return site;
+  return site[0];
 };
 
 module.exports = {

--- a/server/services/phase.js
+++ b/server/services/phase.js
@@ -10,7 +10,7 @@ dayjs.extend(isBetween);
 /**
  * @typedef {import('./employers').employerSite} employerSite
  *
- * @typedef  {Object} phase
+ * @typedef  {Object} sitePhase
  * @property {number} id             Internal ID of the phase
  * @property {string} phaseName      Human readable phase name
  * @property {string} startDate      Date string seperated by slashes, e.g. '2020/01/01'
@@ -22,8 +22,9 @@ dayjs.extend(isBetween);
  */
 
 /**
+ * Gets all phases for a site
  * @param {number} siteId Database ID of the site
- * @returns {Promise<phase[]>} Phases for the site
+ * @returns {Promise<sitePhase[]>} Phases for the site
  */
 const getAllSitePhases = async (siteId) => {
   const site = await getSiteByID(siteId);
@@ -90,7 +91,6 @@ const getAllSitePhases = async (siteId) => {
   }));
 };
 
-// TODO TYPES
 const getAllPhases = async () => {
   // NOTE: this will not allow for full access to the phase list once it hits that 100k limit!
   // If there is any chance of this hitting that number, or if performance starts to suffer,

--- a/server/services/phase.js
+++ b/server/services/phase.js
@@ -26,7 +26,8 @@ dayjs.extend(isBetween);
  * @returns {phase[]}
  */
 const getAllSitePhases = async (siteId) => {
-  const [site] = await getSiteByID(siteId);
+  const site = await getSiteByID(siteId);
+
   // siteDataId is the id in the data attribute, not the table PK
   const siteDataId = site.siteId;
   const sitePhases = await dbClient.db[collections.GLOBAL_PHASE]

--- a/server/services/phase.js
+++ b/server/services/phase.js
@@ -70,7 +70,7 @@ const getAllSitePhases = async (siteId) => {
       phase 
       LEFT JOIN site_phase_allocation spa ON phase.id = spa.phase_id AND spa.site_id = '$1'
       LEFT JOIN participants_status ps ON
-        ps.DATA ->> 'site' = '$1' AND ps."current"
+        ps.DATA ->> 'site' = '$1'
         AND ps."current"
         AND to_date(
           ps.data ->> 'hiredDate', 'YYYY/MM/DD'

--- a/server/services/phase.js
+++ b/server/services/phase.js
@@ -22,99 +22,75 @@ dayjs.extend(isBetween);
  */
 
 /**
- * @param {number} siteId
- * @returns {phase[]}
+ * @param {number} siteId Database ID of the site
+ * @returns {Promise<phase[]>} Phases for the site
  */
 const getAllSitePhases = async (siteId) => {
   const site = await getSiteByID(siteId);
 
-  // siteDataId is the id in the data attribute, not the table PK
-  const siteDataId = site.siteId;
-  const sitePhases = await dbClient.db[collections.GLOBAL_PHASE]
-    .join({
-      [collections.SITE_PHASE_ALLOCATION]: {
-        type: 'LEFT OUTER',
-        relation: collections.SITE_PHASE_ALLOCATION,
-        on: {
-          phase_id: 'id',
-          site_id: siteId,
-        },
-      },
-      // TODO: HCAP-1334 What we actually want is to have it be on: filter so that hired range is between startDate and endDate
-      // could not NULL COALESCE the start/end dates, and could not use comparitive operators (<=, etc turned to =).
-      // so we get all the hires and filter afterwards.
-      hires: {
-        type: 'LEFT OUTER',
-        relation: collections.PARTICIPANTS_STATUS,
-        on: {
-          status: 'hired',
-          'data.site': siteDataId,
-        },
-      },
-      archivedJoin: {
-        type: 'LEFT OUTER',
-        relation: collections.PARTICIPANTS_STATUS,
-        on: {
-          participant_id: 'hires.participant_id',
-          status: 'archived',
-          current: true,
-          'data.type': 'duplicate',
-        },
-      },
-    })
-    .find({ 'archivedJoin.participant_id': null });
+  /**
+   * @typedef {Object} sitePhasesResponse  Internal type for DB response to the `getAllSitePhases` query
+   * @property {number} id                 Internal ID of the phase
+   * @property {string} name               Name of the phase
+   * @property {Date} start_date           Start date of the phase
+   * @property {Date} end_date             End date of the phase
+   * @property {number} allocation         Number of employees allocated for this phase at this site
+   * @property {string} hcap_hires         Number of HCAP employees hired (as a string)
+   * @property {string} non_hcap_hires     Number of non-HCAP employees hired (as a string)
+   */
 
-  // merge the site-specific allocation data into the global phase,
-  // overwriting global properties with specific where named the same (except id)
-  const phaseData = sitePhases.map((phase) => {
-    let sitePhase = phase;
+  /**
+   * @type {sitePhasesResponse[]}
+   */
+  const sitePhases = await dbClient.runRawQuery(
+    `
+    SELECT 
+      phase.id, 
+      phase.name, 
+      phase.start_date, 
+      phase.end_date, 
+      spa.allocation, 
+      count(ps.id) FILTER (
+        WHERE 
+          ps.data ->> 'nonHcapOpportunity' = 'false'
+      ) AS hcap_hires, 
+      count(ps.id) FILTER (
+        WHERE 
+          ps.data ->> 'nonHcapOpportunity' = 'true'
+      ) AS non_hcap_hires 
+    FROM 
+      phase 
+      LEFT JOIN site_phase_allocation spa ON phase.id = spa.phase_id
+      LEFT JOIN participants_status ps ON
+        ps.DATA ->> 'site' = '$1' AND ps."current"
+        AND ps."current"
+        AND to_date(
+          ps.data ->> 'hiredDate', 'YYYY/MM/DD'
+        ) BETWEEN COALESCE(
+          spa.start_date, phase.start_date
+        ) 
+      AND COALESCE(spa.end_date, phase.end_date) 
+    GROUP BY 
+      phase.id, 
+      spa.id
+    `,
+    [site.siteId]
+  );
 
-    if (phase.site_phase_allocation.length > 0) {
-      const sitePhaseAllocation = phase.site_phase_allocation[0];
-      const start_date = sitePhaseAllocation.start_date ?? phase.start_date;
-      const end_date = sitePhaseAllocation.end_date ?? phase.end_date;
-      const allocation = sitePhaseAllocation.allocation ?? 0;
-      const site_phase_allocation_id = sitePhaseAllocation.id;
-
-      sitePhase = {
-        ...sitePhase,
-        start_date,
-        end_date,
-        allocation,
-        site_phase_allocation_id,
-      };
-    }
-
-    const phaseHires = phase.hires.filter((hire) =>
-      dayjs(hire.data.hiredDate).isBetween(sitePhase.start_date, sitePhase.end_date, null, '()')
-    );
-    // count HCAP and non-HCAP hires
-    sitePhase.hcapHires = phaseHires.filter((hire) => !hire.data.nonHcapOpportunity).length;
-    sitePhase.nonHcapHires = phaseHires.filter((hire) => hire.data.nonHcapOpportunity).length;
-
-    // strip time/timezone from date
-    sitePhase.start_date = dayjs.utc(sitePhase.start_date).format('YYYY/MM/DD');
-    sitePhase.end_date = dayjs.utc(sitePhase.end_date).format('YYYY/MM/DD');
-
-    // remove join attributes
-    delete sitePhase.site_phase_allocation;
-    delete sitePhase.archivedJoin;
-    delete sitePhase.hires;
-
-    return {
-      id: sitePhase.id,
-      phaseName: sitePhase.name,
-      startDate: sitePhase.start_date,
-      endDate: sitePhase.end_date,
-      allocation: sitePhase.allocation,
-      remainingHires: (sitePhase.allocation ?? 0) - sitePhase.hcapHires,
-      hcapHires: sitePhase.hcapHires,
-      nonHcapHires: sitePhase.nonHcapHires,
-    };
-  });
-  return phaseData;
+  // Transform data format and return it
+  return sitePhases.map((phase) => ({
+    id: phase.id,
+    phaseName: phase.name,
+    startDate: dayjs.utc(phase.start_date).format('YYYY/MM/DD'),
+    endDate: dayjs.utc(phase.end_date).format('YYYY/MM/DD'), // strips time/timezone from date and formats it
+    allocation: phase.allocation,
+    remainingHires: (phase.allocation ?? 0) - Number(phase.hcap_hires),
+    hcapHires: Number(phase.hcap_hires),
+    nonHcapHires: Number(phase.non_hcap_hires),
+  }));
 };
 
+// TODO TYPES
 const getAllPhases = async () => {
   // NOTE: this will not allow for full access to the phase list once it hits that 100k limit!
   // If there is any chance of this hitting that number, or if performance starts to suffer,

--- a/server/services/phase.js
+++ b/server/services/phase.js
@@ -41,6 +41,13 @@ const getAllSitePhases = async (siteId) => {
    */
 
   /**
+   * Raw result from a custom query.
+   *
+   * This query essentially performs the following actions:
+   * * Grabs all phases
+   * * Finds the phase allocations for each phase at this site
+   * * For each phase, counts the number of currently hired employees within its timespan
+   * * Splits these hires into HCAP and non-HCAP hires
    * @type {sitePhasesResponse[]}
    */
   const sitePhases = await dbClient.runRawQuery(

--- a/server/services/phase.js
+++ b/server/services/phase.js
@@ -68,7 +68,7 @@ const getAllSitePhases = async (siteId) => {
       ) AS non_hcap_hires 
     FROM 
       phase 
-      LEFT JOIN site_phase_allocation spa ON phase.id = spa.phase_id
+      LEFT JOIN site_phase_allocation spa ON phase.id = spa.phase_id AND spa.site_id = '$1'
       LEFT JOIN participants_status ps ON
         ps.DATA ->> 'site' = '$1' AND ps."current"
         AND ps."current"

--- a/server/services/phase.js
+++ b/server/services/phase.js
@@ -7,6 +7,24 @@ const { getSiteByID } = require('./employers');
 
 dayjs.extend(isBetween);
 
+/**
+ * @typedef {import('./employers').employerSite} employerSite
+ *
+ * @typedef  {Object} phase
+ * @property {number} id             Internal ID of the phase
+ * @property {string} phaseName      Human readable phase name
+ * @property {string} startDate      Date string seperated by slashes, e.g. '2020/01/01'
+ * @property {string} endDate        Date string seperated by slashes, e.g. '2020/01/01'
+ * @property {any} allocation
+ * @property {number} remainingHires Number of remaining hires
+ * @property {number} hcapHires      Number of hires from HCAP
+ * @property {number} nonHcapHires   Number of hires from outside HCAP
+ */
+
+/**
+ * @param {number} siteId
+ * @returns {phase[]}
+ */
 const getAllSitePhases = async (siteId) => {
   const [site] = await getSiteByID(siteId);
   // siteDataId is the id in the data attribute, not the table PK

--- a/server/tests/employer.form.test.js
+++ b/server/tests/employer.form.test.js
@@ -244,7 +244,7 @@ describe.skip('Server V1 Form Endpoints', () => {
     const sites = await getSitesForUser({ roles: ['ministry_of_health'] });
     const [siteData] = sites.filter((entry) => entry.siteId === siteResponse.siteId);
 
-    const [res] = await getSiteByID(siteData.id);
+    const res = await getSiteByID(siteData.id);
     await makeParticipant(participant1);
     await makeParticipant(participant2);
     const {

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -154,9 +154,7 @@ describe('Employer Site Endpoints', () => {
     expect(sitePostRes.id).toBeDefined();
 
     const res = await getSiteByID(sitePostRes.id);
-    expect(res).toEqual(
-      expect.arrayContaining([siteBaseFields].map((item) => expect.objectContaining(item)))
-    );
+    expect(res).toEqual(expect.objectContaining(siteBaseFields));
   });
 
   it('gets a site before and after hires have been made', async () => {

--- a/server/tests/employer.site.test.js
+++ b/server/tests/employer.site.test.js
@@ -160,7 +160,7 @@ describe('Employer Site Endpoints', () => {
   });
 
   it('gets a site before and after hires have been made', async () => {
-    const [res] = await getSiteByID(1);
+    const res = await getSiteByID(1);
     expect(res.hcapHires).toEqual('0');
     expect(res.nonHcapHires).toEqual('0');
     await makeParticipant(participant1);
@@ -190,7 +190,7 @@ describe('Employer Site Endpoints', () => {
       hiredDate: new Date(),
       startDate: new Date(),
     });
-    const [res1] = await getSiteByID(1);
+    const res1 = await getSiteByID(1);
     expect(res1.hcapHires).toEqual('1');
     expect(res1.nonHcapHires).toEqual('1');
   });
@@ -229,7 +229,7 @@ describe('Employer Site Endpoints', () => {
     const expectedSite = [{ siteId: 67, status: 'Success' }];
     expect(siteResponse).toEqual(expectedSite);
 
-    const [res] = await getSiteByID(1);
+    const res = await getSiteByID(1);
     await makeParticipant(participant1);
     await makeParticipant(participant2);
     const {
@@ -257,7 +257,7 @@ describe('Employer Site Endpoints', () => {
       hiredDate: new Date(),
       startDate: new Date(),
     });
-    const [site1] = await getSiteByID(1);
+    const site1 = await getSiteByID(1);
     const res2 = await getHiredParticipantsBySite(site1.siteId);
     expect(res2.length).toEqual(2);
   });


### PR DESCRIPTION
[HCAP-1334](https://eydscanada.atlassian.net/browse/HCAP-1334) (blocks [HCAP-1298](https://eydscanada.atlassian.net/browse/HCAP-1298))
Also fixes [HCAP-1391](https://eydscanada.atlassian.net/browse/HCAP-1391)

This PR optimizes the code used to get the phase allocation and hires for a given site. DB impact is now limited to two queries, and only the data needed is sent over the wire.

In addition, this PR:
* Expands the capacity for custom queries in the DB wrapper
* Simplifies the return type of `getSiteByID` (was an array with only one element, now directly returns the element) and updates all dependent code
* Adds typing in a few related places