### PR TITLE
Update to FK reference on site_phase_allocation to employer_site

### DIFF
--- a/server/services/phase.js
+++ b/server/services/phase.js
@@ -82,7 +82,7 @@ const getAllSitePhases = async (siteId) => {
       phase.id, 
       spa.id
     `,
-    [site.siteId]
+    [site.id]
   );
 
   // Transform data format and return it


### PR DESCRIPTION
The `getAllSitePhases` was referencing the incorrect FK id between allocations and sites, updated to use the `id` column, not the form input column `siteId`

id = 8
Updated UI
![Screen Shot 2023-02-10 at 4 49 51 PM](https://user-images.githubusercontent.com/25125247/218223253-57ea73c6-7318-4513-ad9b-22158476dd6b.png)
site_phase_allocation in the db matching site_id = 8 
![Screen Shot 2023-02-10 at 4 50 33 PM](https://user-images.githubusercontent.com/25125247/218223316-048ced25-a564-4269-9113-0142dbb7e021.png)

