### PR TITLE
Updated global phases GET permissions

### DIFF
--- a/client/src/pages/private/SiteTable.js
+++ b/client/src/pages/private/SiteTable.js
@@ -304,12 +304,17 @@ export default ({ sites, viewOnly }) => {
                 if (columnObj(columnId).isHidden) return;
                 if (columnId === 'details')
                   return (
-                    <Button
-                      onClick={() => history.push(Routes.SiteView + `/${row.id}`)}
-                      variant='outlined'
-                      size='small'
-                      text='details'
-                    />
+                    <CheckPermissions
+                      roles={roles}
+                      permittedRoles={['health_authority', 'ministry_of_health']}
+                    >
+                      <Button
+                        onClick={() => history.push(Routes.SiteView + `/${row.id}`)}
+                        variant='outlined'
+                        size='small'
+                        text='details'
+                      />
+                    </CheckPermissions>
                   );
                 return row[columnId];
               }}

--- a/server/routes/phase-allocation.js
+++ b/server/routes/phase-allocation.js
@@ -34,8 +34,8 @@ router.get(
     const authorized =
       user.isSuperUser ||
       user.isMoH ||
-      ((user.isHA || user.isEmployer) &&
-        (await getSitesForUser(user)).map((site) => site.id).includes(siteId));
+      user.isHA ||
+      (user.isEmployer && (await getSitesForUser(user)).map((site) => site.id).includes(siteId));
     if (!authorized) return res.status(403).send('Unauthorized site ID');
 
     // Get and return data
@@ -62,7 +62,10 @@ router.get(
 // Read: Get global phases
 router.get(
   '/',
-  [keycloak.allowRolesMiddleware('ministry_of_health'), keycloak.getUserInfoMiddleware()],
+  [
+    keycloak.allowRolesMiddleware('ministry_of_health', 'health_authority'),
+    keycloak.getUserInfoMiddleware(),
+  ],
   asyncMiddleware(async (req, res) => {
     const { hcapUserInfo: user } = req;
     const result = await getAllPhases();


### PR DESCRIPTION
# BUG FIX
- Fixes 403 Forbidden error when fetching Global Phases on Allocation tab
- HA users have access to view Global Phases
- MOH users have access to view Global Phases
- Employers do not have access to view Global Phases
- Removed the 'details' button on the Employer Sites table as employers do not have access to view the details page. 

- Previous view for employers after clicking 'details'
![Screen Shot 2023-02-14 at 4 34 42 PM](https://user-images.githubusercontent.com/25125247/218886983-aaf2da07-f502-463f-aa73-bb9852ee7d6f.png)
- 'Details' button removed
![Screen Shot 2023-02-14 at 4 38 21 PM](https://user-images.githubusercontent.com/25125247/218887432-b4a958f0-9670-4c87-a49c-6674f9d7a086.png)

