### PR TITLE
fix: add a test for getting all site phases

### DIFF
--- a/server/tests/phase.service.test.js
+++ b/server/tests/phase.service.test.js
@@ -169,15 +169,17 @@ describe('Phase Allocation Endpoints', () => {
       },
     ];
 
-    hiredStartDates.map(async (hiredStartDate, i) => {
-      await makeHiredParticipant({
-        emailAddress: `participantemail${i}@test.com`,
-        employerId: 1,
-        siteId: site.siteId,
-        hiredDate: hiredStartDate.hiredDate,
-        startDate: hiredStartDate.startDate,
-      });
-    });
+    await Promise.all(
+      hiredStartDates.map(async (hiredStartDate, i) => {
+        await makeHiredParticipant({
+          emailAddress: `participantemail${i}@test.com`,
+          employerId: 1,
+          siteId: site.siteId,
+          hiredDate: hiredStartDate.hiredDate,
+          startDate: hiredStartDate.startDate,
+        });
+      })
+    );
 
     // Testing get all phases for the site to see how many hires for each phase
     const sitePhases = await getAllSitePhases(site.id);

--- a/server/tests/phase.service.test.js
+++ b/server/tests/phase.service.test.js
@@ -18,19 +18,6 @@ import { makeTestParticipant, makeTestParticipantStatus, makeTestSite } from './
 import { startDB, closeDB } from './util/db';
 import { participantStatus } from '../constants';
 
-
-
-import { dbClient, collections } from '../db';
-import { stringReplace } from 'string-replace-middleware';
-
-
-const {
-  PROSPECTING,
-  INTERVIEWING,
-  OFFER_MADE,
-  HIRED,
-} = participantStatus;
-
 describe('Phase Allocation Endpoints', () => {
   let server;
 
@@ -96,7 +83,7 @@ describe('Phase Allocation Endpoints', () => {
     expect(res.length).not.toEqual(0);
   });
 
-  it.only('getAllSitePhases, returns correct # of hires and remaining hires per phase', async () => {
+  it('getAllSitePhases, returns correct # of hires and remaining hires per phase', async () => {
     const numAllocations = 30;
     const phaseMockYearOne = {
       name: '2015 Phase',


### PR DESCRIPTION
Just adding a test for get site phases, to ensure that participants hired within a certain phase is properly detected.

Do we need to add more cases? Does this make more sense in the e2e suite?