### PR TITLE
HCAP-1282 - Bulk Allocation part one

### DIFF
--- a/client/src/components/modal-forms/BulkAllocationForm.js
+++ b/client/src/components/modal-forms/BulkAllocationForm.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Button, Dialog } from '../generic';
+import { Box } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { RenderTextField } from '../fields';
+import { Field, Formik, Form as FormikForm } from 'formik';
+
+const useStyles = makeStyles(() => ({
+  formButton: {
+    maxWidth: '200px',
+  },
+  formRow: {
+    gap: '25px',
+  },
+}));
+
+export const BulkAllocationForm = ({ onClose, open, sites }) => {
+  const classes = useStyles();
+  const initialValues = {
+    allocation: '',
+  };
+
+  const handleSubmit = async () => {
+    console.log('selected sites', sites);
+  };
+  return (
+    <Dialog title='Set Allocation' open={open} onClose={onClose}>
+      <Formik initialValues={initialValues} onSubmit={handleSubmit}>
+        {({ submitForm }) => (
+          <FormikForm>
+            <Box>
+              <Field
+                name='allocation'
+                component={RenderTextField}
+                type='number'
+                label='* Number of allocation'
+                placeholder='Type or select'
+              />
+            </Box>
+
+            <Box display='flex' justifyContent='space-between' my={3}>
+              <Button
+                className={classes.formButton}
+                onClick={onClose}
+                color='default'
+                text='Cancel'
+              />
+              <Button
+                className={classes.formButton}
+                onClick={submitForm}
+                variant='contained'
+                color='primary'
+                text='Set'
+              />
+            </Box>
+          </FormikForm>
+        )}
+      </Formik>
+    </Dialog>
+  );
+};

--- a/client/src/components/modal-forms/index.js
+++ b/client/src/components/modal-forms/index.js
@@ -16,3 +16,4 @@ export * from './EditRosDateForm';
 export * from './EditRosStartDateForm';
 export * from './EditRosSiteForm';
 export * from './PhaseDialog';
+export * from './BulkAllocationForm';

--- a/client/src/pages/private/SetBulkAllocation.js
+++ b/client/src/pages/private/SetBulkAllocation.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { Button } from '../../components/generic';
+import { Box } from '@material-ui/core';
+
+import { BulkAllocationForm } from '../../components/modal-forms/BulkAllocationForm';
+
+export const SetBulkAllocation = ({ sites }) => {
+  const [activeModalForm, setActiveModalForm] = useState(null);
+  const closeDialog = () => {
+    setActiveModalForm(null);
+  };
+
+  const openBulkAllocationModal = () => {
+    setActiveModalForm('bulk-allocation');
+  };
+
+  return (
+    <>
+      <BulkAllocationForm
+        open={activeModalForm === 'bulk-allocation'}
+        onClose={closeDialog}
+        sites={sites}
+      />
+      <Box>
+        <Button
+          onClick={openBulkAllocationModal}
+          text='Set Allocation'
+          variant='outlined'
+          fullWidth={false}
+          disabled={sites.length === 0}
+        />
+      </Box>
+    </>
+  );
+};

--- a/client/src/pages/private/SiteTable.js
+++ b/client/src/pages/private/SiteTable.js
@@ -7,7 +7,7 @@ import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 import { Table, Button, CheckPermissions } from '../../components/generic';
-import { NewSiteDialog, PhaseDialog, BulkAllocationForm } from '../../components/modal-forms';
+import { NewSiteDialog, PhaseDialog } from '../../components/modal-forms';
 
 import {
   Routes,
@@ -24,6 +24,7 @@ import { FeatureFlaggedComponent, flagKeys, featureFlag } from '../../services';
 import { fetchRegionSiteRows, fetchSiteRows } from '../../services/site';
 import { useTableStyles } from '../../components/tables/DataTable';
 import { SiteTableAllocation } from './SiteTableAllocation';
+import { SetBulkAllocation } from './SetBulkAllocation';
 
 const columns = [
   { id: 'siteId', name: 'Site ID' },
@@ -164,10 +165,6 @@ export default ({ sites, viewOnly }) => {
     setActionMenuAnchorEl(event.currentTarget);
   };
 
-  const openBulkAllocationModal = () => {
-    setActiveModalForm('bulk-allocation');
-  };
-
   const closeActionMenu = () => {
     setActionMenuAnchorEl(null);
   };
@@ -203,12 +200,6 @@ export default ({ sites, viewOnly }) => {
         isNew={true}
       />
 
-      <BulkAllocationForm
-        open={activeModalForm === 'bulk-allocation'}
-        onClose={closeDialog}
-        sites={selectedSites}
-      />
-
       <Grid
         container
         alignContent='flex-start'
@@ -234,13 +225,7 @@ export default ({ sites, viewOnly }) => {
           <Grid className={classes.rootItem} item xs={3}>
             <Box px={2} display='flex' justifyContent='space-evenly'>
               <FeatureFlaggedComponent featureKey={flagKeys.FEATURE_PHASE_ALLOCATION}>
-                <Button
-                  onClick={openBulkAllocationModal}
-                  text='Set Allocation'
-                  variant='outlined'
-                  fullWidth={false}
-                  disabled={selectedSites.length === 0}
-                />
+                <SetBulkAllocation sites={selectedSites} />
               </FeatureFlaggedComponent>
               <Button
                 onClick={openActionMenu}


### PR DESCRIPTION
## Work completed
- MOH has the ability to multi-select sites, when selected the 'Set Allocation' button is clickable, and when clicked a modal opens to a form. 
- This is the first PR addressing the AC in [HCAP-1282](https://eydscanada.atlassian.net/jira/software/c/projects/HCAP/boards/206?modal=detail&selectedIssue=HCAP-1282) (The form is a placeholder for logic to come later)

# UI 
![Screen Shot 2023-03-01 at 4 17 14 PM](https://user-images.githubusercontent.com/25125247/222288642-fe2df05a-0fc9-40d4-84e6-06a1fcef27ae.png)
![Screen Shot 2023-03-01 at 4 17 32 PM](https://user-images.githubusercontent.com/25125247/222288682-be6e8f91-718f-49b7-837c-5a7bf926c2a6.png)
WIP form
![Screen Shot 2023-03-01 at 4 18 33 PM](https://user-images.githubusercontent.com/25125247/222288801-7d986886-a4d0-4170-878c-9be1db482c42.png)


Not visible to HA
![Screen Shot 2023-03-01 at 4 18 00 PM](https://user-images.githubusercontent.com/25125247/222288735-c67db147-c670-42eb-ac3a-c9a9b46e78f6.png)

