### PR TITLE
HCAP-1436

### DIFF
--- a/client/src/components/modal-forms/PhaseDialog.js
+++ b/client/src/components/modal-forms/PhaseDialog.js
@@ -19,8 +19,9 @@ const useStyles = makeStyles(() => ({
     gap: '25px',
   },
   list: {
-    overflow: 'scroll',
+    overflow: 'auto',
     maxHeight: '250px',
+    overflowX: 'hidden',
   },
   listItem: {
     fontSize: '14px',


### PR DESCRIPTION
- Updated css to remove scroll bar when not needed in phase overlap validation error
https://eydscanada.atlassian.net/browse/HCAP-1436