### PR TITLE
Updated phase date response

### DIFF
--- a/client/src/pages/private/SiteTableAllocation.js
+++ b/client/src/pages/private/SiteTableAllocation.js
@@ -26,11 +26,15 @@ export const SiteTableAllocation = ({ row }) => {
         <div className={classes.allocation}>
           {row['allocation'] || row['allocation'] === 0 ? row['allocation'] : 'N/A'}
         </div>
-        <FeatureFlaggedComponent featureKey={flagKeys.FEATURE_PHASE_ALLOCATION}>
-          <div className={classes.dates}>
-            {formattedDate('startDate')} - {formattedDate('endDate')}
-          </div>
-        </FeatureFlaggedComponent>
+        {row['startDate'] ? (
+          <FeatureFlaggedComponent featureKey={flagKeys.FEATURE_PHASE_ALLOCATION}>
+            <div className={classes.dates}>
+              {formattedDate('startDate')} - {formattedDate('endDate')}
+            </div>
+          </FeatureFlaggedComponent>
+        ) : (
+          <div />
+        )}
       </Box>
     </>
   );

--- a/server/services/employers.ts
+++ b/server/services/employers.ts
@@ -3,6 +3,7 @@ import { dbClient, collections } from '../db';
 import { validate, EmployerSiteBatchSchema } from '../validation';
 import { userRegionQuery } from './user';
 import type { HcapUserInfo } from '../keycloak';
+import { formatDateSansTimezone } from '../utils';
 
 export interface EmployerSite {
   id: number; // Internal ID for site
@@ -106,8 +107,8 @@ const getSitesWithCriteria = async (additionalCriteria, additionalCriteriaParams
   // Transform and format dates - return data
   return records.map((site) => ({
     ...site,
-    startDate: dayjs.utc(site.startDate).format('YYYY/MM/DD'),
-    endDate: dayjs.utc(site.endDate).format('YYYY/MM/DD'), // strips time/timezone from date and formats it
+    startDate: formatDateSansTimezone(site.startDate),
+    endDate: formatDateSansTimezone(site.endDate), // strips time/timezone from date and formats it
   }));
 };
 

--- a/server/services/phase.ts
+++ b/server/services/phase.ts
@@ -6,6 +6,7 @@ import { dbClient, collections } from '../db';
 import { HcapUserInfo } from '../keycloak';
 import { getSiteByID } from './employers';
 import { Allocation } from './allocations';
+import { formatDateSansTimezone } from '../utils';
 
 dayjs.extend(isBetween);
 
@@ -116,8 +117,8 @@ export const getAllSitePhases = async (siteId: number): Promise<sitePhase[]> => 
     id: phase.id,
     phaseName: phase.name,
     allocationId: phase.allocation_id,
-    startDate: dayjs.utc(phase.start_date).format('YYYY/MM/DD'),
-    endDate: dayjs.utc(phase.end_date).format('YYYY/MM/DD'), // strips time/timezone from date and formats it
+    startDate: formatDateSansTimezone(phase.start_date),
+    endDate: formatDateSansTimezone(phase.end_date),
     allocation: phase.allocation,
     remainingHires: (phase.allocation ?? 0) - Number(phase.hcap_hires),
     hcapHires: Number(phase.hcap_hires),
@@ -151,8 +152,8 @@ export const getAllPhases = async (includeAllocations = null): Promise<phase[]> 
   // Transform dates format and return it
   return phases.map((phase) => ({
     ...phase,
-    start_date: dayjs.utc(phase.start_date).format('YYYY/MM/DD'),
-    end_date: dayjs.utc(phase.end_date).format('YYYY/MM/DD'),
+    start_date: formatDateSansTimezone(phase.start_date),
+    end_date: formatDateSansTimezone(phase.end_date),
   }));
 };
 

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -50,3 +50,6 @@ export const patchObject = (source, patchableFields) =>
   );
 
 export const sanitize = (input) => encodeURIComponent(input.toString().trim());
+
+export const formatDateSansTimezone = (date) =>
+  date ? dayjs.utc(date).format('YYYY/MM/DD') : date; // strips time/timezone from date and formats it in short form


### PR DESCRIPTION
- added formatter on the BE to remove timezone/formate date, (Open to suggestions for a better name)
- updated responses that were using similar logic for phase dates,
- the FE is now returned null/undefined vs Invalid Date. 
- Updated FE site table to check for phase start_date vs displaying string Invalid Date

![Screen Shot 2023-03-08 at 1 05 19 PM](https://user-images.githubusercontent.com/25125247/223835723-2c17c5ec-2207-4e29-bfd5-f782d7855692.png)

vs. 
![Screen Shot 2023-03-08 at 1 06 26 PM](https://user-images.githubusercontent.com/25125247/223836104-d231ff2d-8fc9-4438-a99f-32f92daa2b6b.png)

