### PR TITLE
HCAP-1461 - Site name too long

### DIFF
--- a/client/src/components/modal-forms/BulkAllocationForm.js
+++ b/client/src/components/modal-forms/BulkAllocationForm.js
@@ -7,7 +7,7 @@ import { BulkAllocationSchema, ToastStatus } from '../../constants';
 import { RenderTextField, RenderSelectField, RenderCheckbox } from '../fields';
 import { Field, Formik, Form as FormikForm } from 'formik';
 import { formatLongDate } from '../../utils/date';
-import { truncateString } from '../../utils/gen-util';
+import { addEllipsisMask } from '../../utils';
 import { bulkAllocation } from '../../services/allocations';
 import { useToast } from '../../hooks';
 
@@ -33,7 +33,7 @@ export const createPhaseDropdown = (phases) => {
     .sort((a, b) => new Date(b.end_date) - new Date(a.end_date))
     .map((phase) => ({
       value: phase.id,
-      label: `${truncateString(phase.name, 40)} - ${formatLongDate(phase.start_date)} -
+      label: `${addEllipsisMask(phase.name, 40)} - ${formatLongDate(phase.start_date)} -
     ${formatLongDate(phase.end_date)}`,
     }));
 };

--- a/client/src/constants/validation/schema/schema-create-site.js
+++ b/client/src/constants/validation/schema/schema-create-site.js
@@ -4,7 +4,10 @@ import { errorMessage } from '../functions';
 
 export const CreateSiteSchema = yup.object().shape({
   siteId: yup.number().required('Site ID is required'),
-  siteName: yup.string().required(errorMessage),
+  siteName: yup
+    .string()
+    .required(errorMessage)
+    .max(255, 'Site name should be no longer than 255 characters'),
   address: yup.string().nullable(),
   city: yup.string().nullable(),
   isRHO: yup.boolean().nullable().required(errorMessage),

--- a/client/src/constants/validation/schema/schema-edit-site.js
+++ b/client/src/constants/validation/schema/schema-edit-site.js
@@ -9,7 +9,10 @@ export const EditSiteSchema = yup.object().shape({
     .required(errorMessage)
     .matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
   siteContactEmail: yup.string().required(errorMessage).email('Invalid email address'),
-  siteName: yup.string().required(errorMessage),
+  siteName: yup
+    .string()
+    .required(errorMessage)
+    .max(255, 'Site name should be no longer than 255 characters'),
   registeredBusinessName: yup.string().required(errorMessage),
   address: yup.string().required(errorMessage),
   city: yup.string().required(errorMessage),

--- a/client/src/constants/validation/schema/schema-employer-form.js
+++ b/client/src/constants/validation/schema/schema-employer-form.js
@@ -24,7 +24,10 @@ export const EmployerFormSchema = yup
       .matches(/^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/, 'Format as A1A 1A1'),
 
     // Site contact info
-    siteName: yup.string().nullable(errorMessage),
+    siteName: yup
+      .string()
+      .nullable(errorMessage)
+      .max(255, 'Site name should be no longer than 255 characters'),
     address: yup.string().nullable(errorMessage),
     healthAuthority: yup
       .string()

--- a/client/src/pages/private/SiteViewDetails.js
+++ b/client/src/pages/private/SiteViewDetails.js
@@ -4,7 +4,7 @@ import { Box, Chip, Grid, Link, Typography } from '@material-ui/core';
 
 import { Button, Card, Dialog, Page, CheckPermissions } from '../../components/generic';
 import { scrollUp } from '../../utils';
-import { Routes } from '../../constants';
+import { Routes, MAX_LABEL_LENGTH } from '../../constants';
 import { EditSiteForm } from '../../components/modal-forms';
 import { useToast } from '../../hooks';
 import { flagKeys, featureFlag } from '../../services';
@@ -12,6 +12,7 @@ import { ToastStatus, EditSiteSchema } from '../../constants';
 import { SiteDetailTabContext } from '../../providers';
 import { fetchSitePhases } from '../../services/phases';
 import { fetchSiteParticipants, updateSite, fetchSite } from '../../services/site';
+import { addEllipsisMask } from '../../utils';
 
 const SiteViewDetailsTabs = lazy(() => import('./SiteViewDetailsTabs'));
 
@@ -131,7 +132,7 @@ export default ({ match }) => {
   return (
     <>
       <Dialog
-        title={`Edit Site (${site.siteName})`}
+        title={`Edit Site (${addEllipsisMask(site.siteName, MAX_LABEL_LENGTH)})`}
         open={activeModalForm != null}
         onClose={defaultOnClose}
       >
@@ -205,7 +206,8 @@ export default ({ match }) => {
                 <Box pb={4} pl={2}>
                   <Box pb={2}>
                     <Typography variant='body1'>
-                      <Link href={Routes.SiteView}>View Sites</Link> / {site.siteName}
+                      <Link href={Routes.SiteView}>View Sites</Link> /{' '}
+                      {addEllipsisMask(site.siteName, MAX_LABEL_LENGTH)}
                     </Typography>
                   </Box>
                   <Grid container>

--- a/client/src/pages/private/SiteViewDetails.js
+++ b/client/src/pages/private/SiteViewDetails.js
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Box, Chip, Grid, Link, Typography } from '@material-ui/core';
 
 import { Button, Card, Dialog, Page, CheckPermissions } from '../../components/generic';
-import { scrollUp } from '../../utils';
+import { scrollUp, addEllipsisMask } from '../../utils';
 import { Routes, MAX_LABEL_LENGTH } from '../../constants';
 import { EditSiteForm } from '../../components/modal-forms';
 import { useToast } from '../../hooks';
@@ -12,7 +12,6 @@ import { ToastStatus, EditSiteSchema } from '../../constants';
 import { SiteDetailTabContext } from '../../providers';
 import { fetchSitePhases } from '../../services/phases';
 import { fetchSiteParticipants, updateSite, fetchSite } from '../../services/site';
-import { addEllipsisMask } from '../../utils';
 
 const SiteViewDetailsTabs = lazy(() => import('./SiteViewDetailsTabs'));
 

--- a/client/src/utils/gen-util.js
+++ b/client/src/utils/gen-util.js
@@ -5,13 +5,6 @@ export const keyedString = (str, keyValues) =>
   );
 export const capitalizedString = (str) => str.charAt(0).toUpperCase() + str.slice(1);
 
-export const truncateString = (str, length) => {
-  if (str.length <= length) {
-    return str;
-  }
-  return str.slice(0, length) + '...';
-};
-
 /**
  * Sorts a list of objects based on the values of a given key
  *

--- a/cypress/integration/siteViewDetails.spec.js
+++ b/cypress/integration/siteViewDetails.spec.js
@@ -25,6 +25,23 @@ describe('Tests the Site Details View', () => {
     cy.get('button.Mui-selected').should('have.text', 'Site Details');
   });
 
+  it('creates a new site as MoH, gets error site name is too long', () => {
+    const longSiteName =
+      'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.';
+    cy.kcLogin('test-moh');
+    cy.visit('/site-view');
+    cy.get('span.MuiButton-label', { timeout: 10000 }).should('include.text', 'Action');
+    cy.get('span.MuiButton-label').contains('Action').click();
+    cy.get('li.MuiListItem-button', { timeout: 10000 }).should('include.text', 'Create new site');
+    cy.get('li.MuiListItem-button').contains('Create new site').click();
+    cy.get('input#siteId').focus().type('1111');
+    cy.get('input#siteName').focus().type(longSiteName);
+
+    cy.get('span.MuiButton-label').contains('Submit').click();
+    // show have error
+    cy.contains('p.Mui-error', 'Site name should be no longer than 255 characters');
+  });
+
   it('edits a site and confirms the new data is rendered', () => {
     cy.kcLogin('test-moh');
     cy.visit('/site-view');

--- a/server/tests/employer.site.e2e.test.js
+++ b/server/tests/employer.site.e2e.test.js
@@ -80,6 +80,17 @@ describe('api-e2e tests for /employer-sites route', () => {
     expect(res.status).toEqual(201);
   });
 
+  it('should error when saving site due to validation', async () => {
+    const longSiteName =
+      'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.';
+    // Used for batch site POST
+    const site = siteObject({ id: 61, name: longSiteName });
+    const header = await getKeycloakToken(superuser);
+    const res = await request(app).post('/api/v1/employer-sites').set(header).send(site);
+
+    expect(res.status).toEqual(400);
+  });
+
   it('should update site', async () => {
     const site = siteObject({ id: 91, name: 'Test Site 1' });
 

--- a/server/validators/employer.ts
+++ b/server/validators/employer.ts
@@ -23,7 +23,10 @@ export const EmployerFormSchema = yup
       .matches(/(^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d)?$/, 'Format as A1A 1A1'),
 
     // Site contact info
-    siteName: yup.string().nullable(errorMessage),
+    siteName: yup
+      .string()
+      .nullable(errorMessage)
+      .max(255, 'Site name should be no longer than 255 characters'),
     address: yup.string().nullable(errorMessage),
     healthAuthority: yup
       .string()
@@ -159,7 +162,10 @@ export const EmployerSiteBatchSchema = yup.array().of(
       .noUnknown(`Unknown field in site data (index ${index})`)
       .shape({
         siteId: yup.number().required(errorMessageIndex(index, indexName)),
-        siteName: yup.string().required(errorMessageIndex(index, indexName)),
+        siteName: yup
+          .string()
+          .required(errorMessageIndex(index, indexName))
+          .max(255, 'Site name should be no longer than 255 characters'),
         address: yup.string().nullable(errorMessageIndex(index, indexName)),
         city: yup.string().nullable(errorMessageIndex(index, indexName)),
         isRHO: yup.boolean().nullable().required('Regional Health Office status is required'),
@@ -211,7 +217,10 @@ export const CreateSiteSchema = yup
   .noUnknown('Unknown field in entry')
   .shape({
     siteId: yup.number().required('Site ID is required'),
-    siteName: yup.string().required(errorMessage),
+    siteName: yup
+      .string()
+      .required(errorMessage)
+      .max(255, 'Site name should be no longer than 255 characters'),
     address: yup.string().nullable(),
     city: yup.string().nullable(),
     isRHO: yup.boolean().nullable().required(errorMessage),
@@ -255,7 +264,10 @@ export const EditSiteSchema = yup
       .required(errorMessage)
       .matches(/^\d{10}$/, 'Phone number must be provided as 10 digits'),
     siteContactEmail: yup.string().required(errorMessage).email('Invalid email address'),
-    siteName: yup.string().required(errorMessage),
+    siteName: yup
+      .string()
+      .required(errorMessage)
+      .max(255, 'Site name should be no longer than 255 characters'),
     registeredBusinessName: yup.string().required(errorMessage),
     address: yup.string().required(errorMessage),
     city: yup.string().required(errorMessage),


### PR DESCRIPTION
## work completed
- Added max 255 characters for siteName on all yup validations
- Added tests to check failure if siteName is too long.
- Used addEllipsisMask on the link and modal header for siteName if over 50 characters (For the link - the full site name is displayed directly under, for the modal header if the siteName was too long the modal wouldn't scroll thus preventing editing. The full name is still visible in the form)


# clean up
- Deleted the `truncateString` function as a function already existed that did the same thing. `addEllipsisMask`