### PR TITLE
Feature - HCAP-1429 - Make ROS emoloyment type required

### DIFF
--- a/client/src/components/modal-forms/ReturnOfServiceForm.js
+++ b/client/src/components/modal-forms/ReturnOfServiceForm.js
@@ -144,7 +144,7 @@ export const ReturnOfServiceForm = ({
                   <Field
                     name='employmentType'
                     component={RenderRadioGroup}
-                    label='Specific position type (optional)'
+                    label='Specific position type'
                     options={rosEmploymentTypeOptions}
                     boldLabel
                   />

--- a/client/src/constants/validation/schema/schema-edit-ros-site.js
+++ b/client/src/constants/validation/schema/schema-edit-ros-site.js
@@ -7,7 +7,10 @@ export const EditRosSiteSchema = yup
   .shape({
     startDate: yup.date().required('Start Date at a New Site is required'),
     positionType: yup.string().required('Position Type is required').oneOf(rosPositionTypeValues),
-    employmentType: yup.string().optional().oneOf(rosEmploymentTypeValues),
+    employmentType: yup
+      .string()
+      .required('Employment Type is required')
+      .oneOf(rosEmploymentTypeValues),
     site: yup.number('Invalid type for New Site').required('New Site Name is required'),
     healthAuthority: yup.string().required('Health Authority is required'),
   });

--- a/client/src/constants/validation/schema/schema-return-of-service.js
+++ b/client/src/constants/validation/schema/schema-return-of-service.js
@@ -18,7 +18,7 @@ export const ReturnOfServiceSchema = yup
     positionType: yup.string().required('Position Type is required').oneOf(rosPositionTypeValues),
     employmentType: yup
       .string()
-      .optional('Please select employment type')
+      .required('Employment Type is required')
       .oneOf(rosEmploymentTypeValues),
     sameSite: yup
       .boolean()

--- a/cypress/integration/returnOfService.spec.js
+++ b/cypress/integration/returnOfService.spec.js
@@ -15,6 +15,34 @@ describe('Return of Service Form', () => {
   const maxValidDate = '2099/12/31';
   const futureInvalidDate = '2100/01/01';
 
+  it('Should validate required fields', () => {
+    const participantId = 27;
+    // go to participant view
+    cy.visit('participant-view');
+
+    // go to hired tab
+    cy.contains('button', 'Hired Candidates').click();
+
+    // find a hired participant
+    cy.contains('td', participantId)
+      .parent()
+      .within(() => {
+        // click the Actions button belonging to that participant
+        cy.get('td:last-child button').click();
+      });
+
+    // click Return of Service
+    cy.contains('li', 'Return Of Service').click();
+    // go to hired tab
+    cy.contains('button', 'Confirm').click();
+
+    // expect: required error on every field
+    cy.contains('p.Mui-error', 'Return of service date is required');
+    cy.contains('p.Mui-error', 'Position Type is required');
+    cy.contains('p.Mui-error', 'Please confirm');
+    cy.contains('p.Mui-error', 'Employment Type is required');
+  });
+
   it('Should produce error when ROS date is past max valid date', () => {
     const participantId = 27;
     completeROSForm(participantId, futureInvalidDate);

--- a/server/tests/return-of-service.e2e.test.js
+++ b/server/tests/return-of-service.e2e.test.js
@@ -45,6 +45,17 @@ describe('api e2e tests for /ros routes', () => {
     expect(res.body).toHaveProperty('id');
   });
 
+  it('should fail to create ros status due to validation errors', async () => {
+    const header = await getKeycloakToken(healthAuthority);
+    const res = await request(app)
+      .post(`/api/v1/ros/participant/${testParticipant.id}`)
+      .send({
+        data: rosData({ employmentType: null }),
+      })
+      .set(header);
+    expect(res.status).toEqual(400);
+  });
+
   it('should create RoS status with different site', async () => {
     const { participant } = await createTestParticipantStatus({
       participantData: participantData({ emailAddress: 'test.e2e.ros1@hcap.io' }),
@@ -70,6 +81,23 @@ describe('api e2e tests for /ros routes', () => {
       .set(header);
     expect(res.status).toEqual(201);
     expect(res.body).toHaveProperty('id');
+  });
+
+  it('should fail to create RoS status with different site due to validation errors', async () => {
+    const siteOther = await makeTestSite({
+      siteId: 2006706702001,
+      siteName: 'Test E2E ROS Service Global - 2',
+      operatorEmail: 'test.e2e.ros.ops2@hcap.io',
+    });
+    const header = await getKeycloakToken(healthAuthority);
+    const res = await request(app)
+      .post(`/api/v1/ros/participant/${testParticipant.id}`)
+      .send({
+        siteId: siteOther.id,
+        data: rosData({ employmentType: null }),
+      })
+      .set(header);
+    expect(res.status).toEqual(400);
   });
 
   it('should get ros status', async () => {

--- a/server/validators/return-of-service.ts
+++ b/server/validators/return-of-service.ts
@@ -20,7 +20,10 @@ export const CreateReturnOfServiceSchema = yup
           .string()
           .required('Position Type (data.positionType) is required')
           .oneOf(rosPositionTypeValues),
-        employmentType: yup.string().optional().oneOf(rosEmploymentTypeValues),
+        employmentType: yup
+          .string()
+          .required('Employment Type is required')
+          .oneOf(rosEmploymentTypeValues),
         sameSite: yup.boolean().required('Same Site flag (data.sameSite) is required'),
       }),
   });
@@ -44,7 +47,10 @@ export const ChangeReturnOfServiceSiteSchema = yup
           .string()
           .required('Position Type (data.positionType) is required')
           .oneOf(rosPositionTypeValues),
-        employmentType: yup.string().optional().oneOf(rosEmploymentTypeValues),
+        employmentType: yup
+          .string()
+          .required('Employment Type is required')
+          .oneOf(rosEmploymentTypeValues),
       }),
   });
 


### PR DESCRIPTION
## Work completed
- added yup validation to make Employment type required
- removed `(optional)` from form Label
- added server tests for failure 
- added cypress test to test for required fields on the form.

![Screen Shot 2023-03-10 at 1 37 41 PM](https://user-images.githubusercontent.com/25125247/224423612-5c7c0000-8f09-47c8-8d90-4de0b1b149f4.png)
