### PR TITLE
HCAP-1466 - Bug fix

### DIFF
--- a/client/src/components/modal-forms/PhaseDialog.js
+++ b/client/src/components/modal-forms/PhaseDialog.js
@@ -87,7 +87,6 @@ export const PhaseDialog = ({ onSubmit, onClose, open, content, isNew = false })
     }
   };
 
-  console.log(phases);
   return (
     <Dialog title={isNew ? 'Create Phase' : 'Edit Phase'} open={open} onClose={onClose}>
       <Formik

--- a/client/src/components/modal-forms/PhaseDialog.js
+++ b/client/src/components/modal-forms/PhaseDialog.js
@@ -37,7 +37,11 @@ export const PhaseDialog = ({ onSubmit, onClose, open, content, isNew = false })
   const [isPendingRequests, setIsPendingRequests] = useState(true);
 
   useEffect(() => {
-    if (isPendingRequests) {
+    // reset state to re-fetch data if dialog is re-opened
+    if (!open) {
+      setIsPendingRequests(true);
+    }
+    if (isPendingRequests && open) {
       const fetchData = async () => {
         let phases = await fetchPhases();
         setPhases(phases);
@@ -46,7 +50,7 @@ export const PhaseDialog = ({ onSubmit, onClose, open, content, isNew = false })
 
       fetchData();
     }
-  }, [isPendingRequests, content]);
+  }, [isPendingRequests, content, open]);
 
   const initialValues = content
     ? {
@@ -83,12 +87,14 @@ export const PhaseDialog = ({ onSubmit, onClose, open, content, isNew = false })
     }
   };
 
+  console.log(phases);
   return (
     <Dialog title={isNew ? 'Create Phase' : 'Edit Phase'} open={open} onClose={onClose}>
       <Formik
         initialValues={{ ...initialValues, phases: phases }}
         validationSchema={CreatePhaseSchema}
         onSubmit={handleSubmit}
+        enableReinitialize={true}
       >
         {({ submitForm, errors }) => {
           // yup error message is a string - convert to an array of Id's to allow for a dynamic error message


### PR DESCRIPTION
## BUG fix
- The `PhaseDialog` component is initialized when 'siteTable` mounts, and fetches the phase data. When the user creates a phase, closes the modal and re-opens it, the component doesn't re-fetch the data therefore the validation fails, as the newly created phase isn't in the array being used for validation. 
- If the component is not opened, reset the `'isPendingRequests` flag, and only fetch data if that flag is true and modal is open. 