### PR TITLE
HCAP-1449 - Remove ability for employer to bulk engage participants

### DIFF
--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -202,6 +202,7 @@ const ParticipantTable = () => {
   const isSuperUser = roles.includes('superuser');
   const isAdmin = isMoH || isSuperUser;
   const isEmployer = roles.includes('health_authority') || roles.includes('employer');
+  const isHA = roles.includes('health_authority');
 
   const fetchParticipants = async () => {
     if (!columns) return;
@@ -580,7 +581,7 @@ const ParticipantTable = () => {
               }}
               rows={rows}
               isLoading={isLoadingData}
-              isMultiSelect={selectedTab === 'Available Participants'}
+              isMultiSelect={selectedTab === 'Available Participants' && isHA}
               selectedRows={selectedParticipants}
               updateSelectedRows={setSelectedParticipants}
               multiSelectAction={bulkEngage}

--- a/client/src/pages/private/ParticipantTable.js
+++ b/client/src/pages/private/ParticipantTable.js
@@ -201,8 +201,8 @@ const ParticipantTable = () => {
   const isMoH = roles.includes('ministry_of_health');
   const isSuperUser = roles.includes('superuser');
   const isAdmin = isMoH || isSuperUser;
-  const isEmployer = roles.includes('health_authority') || roles.includes('employer');
   const isHA = roles.includes('health_authority');
+  const isEmployer = roles.includes('employer');
 
   const fetchParticipants = async () => {
     if (!columns) return;
@@ -383,7 +383,7 @@ const ParticipantTable = () => {
       case 'lastName':
         if (
           isAdmin ||
-          (isEmployer && ['Hired Candidates', 'Return Of Service'].includes(selectedTab))
+          ((isEmployer || isHA) && ['Hired Candidates', 'Return Of Service'].includes(selectedTab))
         ) {
           return (
             <Link

--- a/cypress/fixtures/participantTableTabs.json
+++ b/cypress/fixtures/participantTableTabs.json
@@ -132,7 +132,7 @@
     {
       "name": "employer",
       "fixture": "test-employer",
-      "tabsWithMultiselect": ["Available Participants"],
+      "tabsWithMultiselect": [],
       "tabsWithActions": [
         "Available Participants",
         "My Candidates",

--- a/cypress/integration/participantStatus.spec.js
+++ b/cypress/integration/participantStatus.spec.js
@@ -79,7 +79,7 @@ describe('Participants status suite', () => {
       // acknowledge participant accepted offer in writing
       cy.get('input[name="acknowledge"]').click();
       //  expect alert with allocations/remainingHires to exist
-      cy.wait(2000);
+      cy.wait(2500);
       cy.get('.MuiAlert-message').contains('This site has 100 allocations assigned');
 
       cy.contains('button', 'Submit').click();

--- a/server/routes/participant.ts
+++ b/server/routes/participant.ts
@@ -474,7 +474,7 @@ employerActionsRouter.delete(
  */
 employerActionsRouter.post(
   '/bulk-engage',
-  keycloak.allowRolesMiddleware('employer', 'health_authority'),
+  keycloak.allowRolesMiddleware('health_authority'),
   keycloak.getUserInfoMiddleware(),
   asyncMiddleware(async (req, res) => {
     // Validate Body

--- a/server/tests/employer-action.e2e.test.ts
+++ b/server/tests/employer-action.e2e.test.ts
@@ -44,7 +44,7 @@ describe.skip('Test api/v1/employer-actions', () => {
   it('should create participant status as HA', async () => {
     // Participant
     const participant = await makeTestParticipant({
-      emailAddress: 'employer.action.e2e.1@hcap.io',
+      emailAddress: 'HAemployer.action.e2e.1@hcap.io',
     });
     const site = await makeTestSite({
       siteId: 54353535623,

--- a/server/tests/employer-action.e2e.test.ts
+++ b/server/tests/employer-action.e2e.test.ts
@@ -2,7 +2,7 @@
 import request from 'supertest';
 import { app } from '../server';
 import { startDB, closeDB } from './util/db';
-import { getKeycloakToken, employer } from './util/keycloak';
+import { getKeycloakToken, employer, healthAuthority } from './util/keycloak';
 import { makeTestParticipant, makeTestSite } from './util/integrationTestData';
 
 describe.skip('Test api/v1/employer-actions', () => {
@@ -17,7 +17,7 @@ describe.skip('Test api/v1/employer-actions', () => {
     await server.close();
   });
 
-  it('should create participant status', async () => {
+  it('should create participant status as employer', async () => {
     // Participant
     const participant = await makeTestParticipant({
       emailAddress: 'employer.action.e2e.1@hcap.io',
@@ -41,7 +41,32 @@ describe.skip('Test api/v1/employer-actions', () => {
     expect(res.statusCode).toBe(201);
   });
 
-  it('should create participant status with bulk engage', async () => {
+  it('should create participant status as HA', async () => {
+    // Participant
+    const participant = await makeTestParticipant({
+      emailAddress: 'employer.action.e2e.1@hcap.io',
+    });
+    const site = await makeTestSite({
+      siteId: 54353535623,
+      siteName: 'Test Site e2e 01',
+      city: 'Test City e2e 01',
+    });
+
+    const header = await getKeycloakToken(healthAuthority);
+    const res = await request(app)
+      .post(`/api/v1/employer-actions`)
+      .set(header)
+      .send({
+        participantId: participant.id,
+        status: 'prospecting',
+        data: {},
+        sites: [site],
+      });
+    expect(res.statusCode).toBe(201);
+  });
+
+  // The API is current depricated, not being used by the FE. But employers no longer have permission to bulk engage.
+  it('should fail to create participant status with bulk engage as an employer', async () => {
     // Test Data
     const participant1 = await makeTestParticipant({
       emailAddress: 'employer.action.e2e.21@hcap.io',
@@ -67,6 +92,35 @@ describe.skip('Test api/v1/employer-actions', () => {
         participants: [participant1.id, participant2.id],
         sites: [site1, site2],
       });
-    expect(res.statusCode).toBe(201);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('should create participant status with bulk engage as a HA', async () => {
+    // Test Data
+    const participant1 = await makeTestParticipant({
+      emailAddress: 'HAemployer.action.e2e.21@hcap.io',
+    });
+    const participant2 = await makeTestParticipant({
+      emailAddress: 'HAemployer.action.e2e.22@hcap.io',
+    });
+    const site1 = await makeTestSite({
+      siteId: 52345346146,
+      siteName: 'Test Site e2e 021',
+      city: 'Test City e2e 021',
+    });
+    const site2 = await makeTestSite({
+      siteId: 6345634646,
+      siteName: 'Test Site e2e 022',
+      city: 'Test City e2e 022',
+    });
+    const header = await getKeycloakToken(healthAuthority);
+    const res = await request(app)
+      .post(`/api/v1/employer-actions/bulk-engage`)
+      .set(header)
+      .send({
+        participants: [participant1.id, participant2.id],
+        sites: [site1, site2],
+      });
+    expect(res.statusCode).toBe(200);
   });
 });


### PR DESCRIPTION
## Work completed

Note - The FE isn't using the `employer-actions/bulk-engage` API, it is looping through participants and hitting `employer-actions`, so I did not make any changes to the permissions of that API as employers can still engage participants individually. (The FE is currently making 3 API calls per participant in the bulk engage list)
- removed employer permission from bulk-engage API (although it's deprecated/only being used by tests) 
- updated test suites to include failure if unauthenticated, 
- added check for HA on UI to see multi-select and bulk engage button

HA view:
![Screen Shot 2023-03-16 at 10 56 24 AM](https://user-images.githubusercontent.com/25125247/225694946-47164039-18de-4244-bca8-1e6f4d7fb485.png)

Employer view:
![Screen Shot 2023-03-16 at 10 57 26 AM](https://user-images.githubusercontent.com/25125247/225695230-16859726-4b9c-4335-bc2e-a4378837c7b9.png)
