### PR TITLE
HCAP-1469 - fix validations on graduation date

### DIFF
--- a/client/src/components/modal-forms/ManageGraduationForm.js
+++ b/client/src/components/modal-forms/ManageGraduationForm.js
@@ -7,12 +7,11 @@ import { Button } from '../../components/generic/Button';
 import { AuthContext } from '../../providers';
 import { ParticipantPostHireStatusSchema } from '../../constants/validation';
 import { postHireStatuses } from '../../constants';
-import dayjs from 'dayjs';
+
 export const ManageGraduationForm = ({ initialValues, onClose, onSubmit, cohortEndDate }) => {
   const { auth } = AuthContext.useAuth();
   const roles = useMemo(() => auth.user?.roles || [], [auth.user?.roles]);
-  const cohortEndDateObj = dayjs(cohortEndDate, 'YYYY/MM/DD');
-  const today = new Date();
+
   return (
     <Box spacing={10} p={4} width={380}>
       <Formik
@@ -32,9 +31,10 @@ export const ManageGraduationForm = ({ initialValues, onClose, onSubmit, cohortE
               setFieldValue('data.date', '');
             }
           };
+
           const isGraduatingBeforeCohortEndDate =
             values.status === postHireStatuses.postSecondaryEducationCompleted &&
-            cohortEndDateObj > today;
+            new Date(cohortEndDate) > new Date(values.data.date);
           return (
             <FormikForm>
               <Box>

--- a/client/src/components/modal-forms/ManageGraduationForm.js
+++ b/client/src/components/modal-forms/ManageGraduationForm.js
@@ -29,6 +29,7 @@ export const ManageGraduationForm = ({ initialValues, onClose, onSubmit, cohortE
               setFieldValue('continue', 'continue_yes');
             } else {
               setFieldValue('data.date', '');
+              setFieldTouched('data.date', false);
             }
           };
 

--- a/client/src/constants/validation/schema/schema-participant-post-hire-status.js
+++ b/client/src/constants/validation/schema/schema-participant-post-hire-status.js
@@ -13,13 +13,6 @@ export const ParticipantPostHireStatusSchema = yup
     data: yup.object().when(['status'], (status, schema) => {
       switch (status) {
         case postHireStatuses.postSecondaryEducationCompleted:
-          return schema.noUnknown('Unknown field in data form').shape({
-            date: yup
-              .string()
-              .required('Date is required')
-              .test('is-date', 'Invalid date', validateDateString),
-          });
-
         case postHireStatuses.cohortUnsuccessful:
           return schema.noUnknown('Unknown field in data form').shape({
             date: yup

--- a/client/src/constants/validation/schema/schema-participant-post-hire-status.js
+++ b/client/src/constants/validation/schema/schema-participant-post-hire-status.js
@@ -14,14 +14,17 @@ export const ParticipantPostHireStatusSchema = yup
       switch (status) {
         case postHireStatuses.postSecondaryEducationCompleted:
           return schema.noUnknown('Unknown field in data form').shape({
-            date: yup.string().optional(),
+            date: yup
+              .string()
+              .required('Date is required')
+              .test('is-date', 'Invalid date', validateDateString),
           });
 
         case postHireStatuses.cohortUnsuccessful:
           return schema.noUnknown('Unknown field in data form').shape({
             date: yup
               .string()
-              .required('Unsuccessful cohort date is required')
+              .required('Date is required')
               .test('is-date', 'Invalid date', validateDateString),
           });
         default:


### PR DESCRIPTION
## Bug Fix
- Since the graduation date was previously populated and disabled, there was no way for the user to clear the form before submitting. Added required to yup. 
- Updated logic surrounding `isGraduatingBeforeCohortEndDate`, this now disables the form before being submitted and prevents users from graduating a participant before the cohort has ended. 

![Screen Shot 2023-03-17 at 10 24 18 AM](https://user-images.githubusercontent.com/25125247/225962316-752e5ffb-40bb-4ef3-8547-f26fd102579a.png)
