### PR TITLE
Feature Flagging

### DIFF
--- a/client/src/constants/siteDetailsConstants.js
+++ b/client/src/constants/siteDetailsConstants.js
@@ -1,3 +1,5 @@
+import { flagKeys, featureFlag } from '../services';
+
 export const tabColumns = {
   // Tabs, associated allowed roles, displayed statuses
   'Site Details': {
@@ -58,9 +60,11 @@ export const fieldsLabelMap = {
     'Postal Code': 'postalCode',
     Region: 'healthAuthority',
   },
-  'Positions Overview': {
-    Allocation: 'allocation',
-    'HCAP Hires': 'hcapHires',
-    'Non-HCAP Hires': 'nonHcapHires',
-  },
+  ...(featureFlag(flagKeys.FEATURE_PHASE_ALLOCATION) && {
+    'Positions Overview': {
+      Allocation: 'allocation',
+      'HCAP Hires': 'hcapHires',
+      'Non-HCAP Hires': 'nonHcapHires',
+    },
+  }),
 };

--- a/client/src/pages/private/SiteTable.js
+++ b/client/src/pages/private/SiteTable.js
@@ -34,9 +34,11 @@ const columns = [
   { id: 'city', name: 'City' },
   { id: 'postalCode', name: 'Postal Code' },
   {
-    id: 'allocation',
-    name: 'Allocation',
-    customComponent: (row) => <SiteTableAllocation row={row} />,
+    ...(featureFlag(flagKeys.FEATURE_PHASE_ALLOCATION) && {
+      id: 'allocation',
+      name: 'Allocation',
+      customComponent: (row) => <SiteTableAllocation row={row} />,
+    }),
   },
   { id: 'details' },
   { id: 'startDate', isHidden: true },


### PR DESCRIPTION
## Work completed
- For the upcoming release, I wrapped the allocations column and positions overview in a feature flag as they were the only part of the allocation work not in a feature flag. 

Details page without Position Overview
![Screen Shot 2023-03-23 at 1 29 58 PM](https://user-images.githubusercontent.com/25125247/227328453-fe2fc7a8-b766-4ed7-8d04-0993cc10ceab.png)

Site table without allocation: 
![Screen Shot 2023-03-23 at 1 30 46 PM](https://user-images.githubusercontent.com/25125247/227328785-89cf89d2-3aa3-4a23-b18b-9e758f67f65a.png)



