### PR TITLE
fix: comment out site allocation removal

### DIFF
--- a/server/migrations/1661465391816_allocation_migration.js
+++ b/server/migrations/1661465391816_allocation_migration.js
@@ -60,7 +60,8 @@ exports.up = async () => {
     END $$`,
 
     // Drop the allocation from the sites table
-    `UPDATE ${collections.EMPLOYER_SITES} SET body = body::jsonb - 'allocation'`,
+    // Should go in a future migration. Commented out for now in case we need to roll back for any reason
+    // `UPDATE ${collections.EMPLOYER_SITES} SET body = body::jsonb - 'allocation'`,
   ];
   await dbClient.db.withTransaction(async (tx) => {
     for (const query of queries) {


### PR DESCRIPTION
Commenting out this line for now so we don't remove the current allocations of sites
This is strictly in case we need to rollback. I created https://eydscanada.atlassian.net/browse/HCAP-1477 for this.