### PR TITLE
HCAP-1346 - HCAP and nonHCAP hire count bug fix

### DIFF
--- a/client/src/constants/siteDetailsConstants.js
+++ b/client/src/constants/siteDetailsConstants.js
@@ -61,7 +61,7 @@ export const fieldsLabelMap = {
     Region: 'healthAuthority',
   },
   ...(featureFlag(flagKeys.FEATURE_PHASE_ALLOCATION) && {
-    'Positions Overview': {
+    'Positions Overview (Current Phase)': {
       Allocation: 'allocation',
       'HCAP Hires': 'hcapHires',
       'Non-HCAP Hires': 'nonHcapHires',


### PR DESCRIPTION
## BUG fix
- Site detail page is now displaying the correct count for HCAP Hires and non-HCAP hires. (same logic used on the allocation table view)
![Screen Shot 2023-03-24 at 3 11 55 PM](https://user-images.githubusercontent.com/25125247/227642526-3227704a-2c72-46e0-a504-72ec3cdc233a.png)
![Screen Shot 2023-03-24 at 3 12 08 PM](https://user-images.githubusercontent.com/25125247/227642553-0b725fc8-9406-43c0-ae52-0d5da4225b05.png)

If there is no allocation or current phase, count displays as 0
![Screen Shot 2023-03-24 at 3 18 48 PM](https://user-images.githubusercontent.com/25125247/227643520-7d3b2aac-63cd-458d-b40f-90a98fa232e6.png)

