### PR TITLE
fix: add optional for pstatus without site

### DIFF
--- a/server/services/participant-details.ts
+++ b/server/services/participant-details.ts
@@ -92,7 +92,7 @@ export const participantDetails = async (id: number) => {
     participant.latestStatuses = latestStatuses.map((status) => ({
       id: status.id,
       employerId: status.employer_id,
-      siteId: status.data.site,
+      siteId: status.data?.site,
       status: status.status,
     }));
 


### PR DESCRIPTION
Viewing some participants was returning a 500 error due to some statuses having null data