### PR TITLE
Cypress updates to inconsistent tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,5 @@
 {
   "baseUrl": "http://hcapemployers.local.freshworks.club:4000",
-  "defaultCommandTimeout": 20000,
   "chromeWebSecurity": false,
   "video": false,
   "isLocal": false,

--- a/cypress/integration/cohortView.spec.js
+++ b/cypress/integration/cohortView.spec.js
@@ -67,9 +67,10 @@ describe('Tests the Cohort View', () => {
     cy.get('@psi').then((psi) => {
       // intentionally select a PSI with 0 existing cohorts
       cy.contains(psi[12].institute_name).click();
+      cy.intercept(`${Cypress.env('apiBaseURL')}/cohorts/*`).as('cohortGet');
       cy.contains('Empty New Cohort').click();
       // Wait for page to load after click
-      cy.wait(500);
+      cy.wait('@cohortGet');
       // wait for page to load before checking for notification
       cy.get('.MuiTypography-body1').contains('100');
       cy.get('.MuiTypography-subtitle1')
@@ -133,11 +134,12 @@ describe('Tests the Cohort View', () => {
             cy.get('[name=GraduationDate]').clear().type(`{ctrl+v}${formattedDate}`);
           });
 
+          cy.intercept(`${Cypress.env('apiBaseURL')}/post-hire-status`).as('statusPost');
           cy.contains('button', 'Submit').click();
           // expect: no errors, success message.
           cy.contains('.Mui-error').should('not.exist');
           // wait for form to submit and message to show
-          cy.wait(1000);
+          cy.wait('@statusPost');
           cy.get('.MuiAlert-message').contains('Participant(s) status updated');
         });
       });

--- a/cypress/integration/participantStatus.spec.js
+++ b/cypress/integration/participantStatus.spec.js
@@ -1,5 +1,5 @@
 // Override the default timeout, this test timesout in the pipeline
-describe('Participants status suite', { defaultCommandTimeout: 10000 }, () => {
+describe('Participants status suite', { defaultCommandTimeout: 50000 }, () => {
   // Ensure phases and allocations exist - to test alert message
   before(() => {
     // get test phase data and assign to alias

--- a/cypress/integration/participantStatus.spec.js
+++ b/cypress/integration/participantStatus.spec.js
@@ -1,4 +1,5 @@
-describe('Participants status suite', { defaultCommandTimeout: 1000 }, () => {
+// Override the default timeout, this test timesout in the pipeline
+describe('Participants status suite', { defaultCommandTimeout: 10000 }, () => {
   // Ensure phases and allocations exist - to test alert message
   before(() => {
     // get test phase data and assign to alias

--- a/cypress/integration/participantStatus.spec.js
+++ b/cypress/integration/participantStatus.spec.js
@@ -64,9 +64,8 @@ describe('Participants status suite', () => {
       cy.get(`li[data-value='${siteId}']`).click();
       // acknowledge participant accepted offer in writing
       cy.get('input[name="acknowledge"]').click();
-      // cy.intercept('GET', `/phase/${siteId}`).as('phaseGet');
-      //  expect alert with allocations/remainingHires to exist
       cy.wait('@phaseGet');
+      //  expect alert with allocations/remainingHires to exist
       cy.get('.MuiAlert-message').contains('This site has 100 allocations assigned');
 
       cy.contains('button', 'Submit').click();

--- a/cypress/integration/participantStatus.spec.js
+++ b/cypress/integration/participantStatus.spec.js
@@ -58,11 +58,15 @@ describe('Participants status suite', () => {
       });
       // select site
       cy.get('#mui-component-select-site').click();
+      // when siteID is selected, the component fetches all sitePhases and displays an alert
+      // Intercept the GET request, check for alert once request resolves
+      cy.intercept(`${Cypress.env('apiBaseURL')}/phase/*`).as('phaseGet');
       cy.get(`li[data-value='${siteId}']`).click();
       // acknowledge participant accepted offer in writing
       cy.get('input[name="acknowledge"]').click();
+      // cy.intercept('GET', `/phase/${siteId}`).as('phaseGet');
       //  expect alert with allocations/remainingHires to exist
-      cy.wait(2500);
+      cy.wait('@phaseGet');
       cy.get('.MuiAlert-message').contains('This site has 100 allocations assigned');
 
       cy.contains('button', 'Submit').click();

--- a/cypress/integration/participantStatus.spec.js
+++ b/cypress/integration/participantStatus.spec.js
@@ -1,4 +1,4 @@
-describe('Participants status suite', () => {
+describe('Participants status suite', { defaultCommandTimeout: 1000 }, () => {
   // Ensure phases and allocations exist - to test alert message
   before(() => {
     // get test phase data and assign to alias

--- a/cypress/integration/participantTable.spec.js
+++ b/cypress/integration/participantTable.spec.js
@@ -4,8 +4,11 @@ describe('Participant Table', () => {
   fixture.roles.map((role) => {
     it(`Correctly renders tabs for ${role.name}`, () => {
       cy.kcLogin(role.fixture);
+      cy.intercept(`${Cypress.env('apiBaseURL')}/participants?*`).as('participantGet');
+      // Wait for page to load after click
       cy.visit('/participant-view');
-      cy.wait(1500);
+
+      cy.wait('@participantGet');
       cy.get('div.MuiTabs-root')
         .find('button.MuiTab-root')
         .should('have.length', role.allTabs.length);

--- a/cypress/integration/psiDetailView.spec.js
+++ b/cypress/integration/psiDetailView.spec.js
@@ -45,8 +45,9 @@ describe('Tests the PSI View', () => {
     cy.get('button').contains('Manage').click();
     cy.get('li').contains('Edit').should('be.visible').click();
     cy.get('input#streetAddress').clear().type('146 Numeral Ave');
+    cy.intercept(`${Cypress.env('apiBaseURL')}/psi/*`).as('psiPatch');
     cy.get('span.MuiButton-label').contains('Submit').click();
-    cy.wait(1000);
+    cy.wait('@psiPatch');
     cy.get('[test-id=psi-details-view-addr]').should('have.text', '146 Numeral Ave');
   });
 

--- a/cypress/integration/setAllocation.spec.js
+++ b/cypress/integration/setAllocation.spec.js
@@ -85,7 +85,6 @@ describe('Allocation functionality', () => {
     navigateToForm('set');
     // the MUI number component does not allow users to type a negative, so cypress needs to mock a keydown action
     cy.get('[name=allocation]').type('1{downArrow}{downArrow}{downArrow}');
-    cy.wait(500);
     cy.contains('button', 'Set').click();
 
     cy.contains('p.Mui-error', 'Must be a positive number');

--- a/cypress/integration/userView.spec.js
+++ b/cypress/integration/userView.spec.js
@@ -29,8 +29,9 @@ describe('Tests the User View', () => {
     cy.get('input[name=acknowledgement]').focus();
     cy.get('input[name=acknowledgement]').check();
     cy.get('input[name=acknowledgement]').should('have.attr', 'value', 'true');
+    cy.intercept(`${Cypress.env('apiBaseURL')}/approve-user`).as('userPost');
     cy.get('button').contains('Submit').click({ force: true });
-    cy.wait(2000);
+    cy.wait('@userPost');
     cy.get('div.MuiAlert-message').contains('Access request approved').should('be.visible');
   });
 });


### PR DESCRIPTION
## Work completed
- Possible fix to unreliable cypress tests. 
- Removed default timeout override
- Instead of using an arbitrary cy.wait, Updated the test to listen for the GET request to resolve before checking the DOM for an element. 