### PR TITLE
fix: cron job paths were no longer working

### DIFF
--- a/openshift/in-progres-stale-clean.cronjob.yml
+++ b/openshift/in-progres-stale-clean.cronjob.yml
@@ -42,7 +42,7 @@ objects:
                     - container-entrypoint
                     - bash
                     - '-c'
-                    - 'node scripts/clean-up.js'
+                    - 'npm run clean-stale-cronjob'
                   env:
                     - name: APP_ENV
                       value: ${IMAGE_TAG}

--- a/openshift/open-expired-clean.cronjob.yml
+++ b/openshift/open-expired-clean.cronjob.yml
@@ -43,7 +43,7 @@ objects:
                     - container-entrypoint
                     - bash
                     - '-c'
-                    - 'node scripts/withdraw-stale-open-participants.js'
+                    - 'npm run clean-stale-open-cronjob'
                   env:
                     - name: APP_ENV
                       value: ${IMAGE_TAG}

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,8 @@
     "participant-stats-in-progress": "npx ts-node scripts/participant-stats.ts in-progress",
     "participant-stats-rejected": "npx ts-node scripts/participant-stats.ts rejected",
     "participant-stats-no-offers": "npx ts-node scripts/participant-stats.ts no-offers",
+    "clean-stale-cronjob": "npx ts-node scripts/clean-up.ts",
+    "clean-stale-open-cronjob": "npx ts-node scripts/withdraw-stale-open-participants.js",
     "export": "npx ts-node scripts/export.ts",
     "watch": "nodemon main.ts",
     "debug": "nodemon --exec 'node --inspect=0.0.0.0:9229 --require ts-node/register main.ts'",


### PR DESCRIPTION
This moves the logic to npm commands that the cron job can hit. This is due to the typescript change.