### PR TITLE
add option for bcsc id and add user_id attr to keycloak users

### DIFF
--- a/.docker/keycloak/realm-testing.json
+++ b/.docker/keycloak/realm-testing.json
@@ -817,6 +817,21 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
+          "id": "99a318ea-7b43-45d4-af69-681d437d9c3e",
+          "name": "bcsc_guid",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "bcsc_guid",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bcsc_guid",
+            "jsonType.label": "String"
+          }
+        },
+        {
           "id": "60507962-9c5e-4b75-ab39-26f39f5fccb9",
           "name": "Client IP Address",
           "protocol": "openid-connect",

--- a/.docker/keycloak/realm-testing.json
+++ b/.docker/keycloak/realm-testing.json
@@ -1176,7 +1176,7 @@
           }
         }
       ],
-      "defaultClientScopes": ["web-origins", "user_id", "profile", "roles", "email"],
+      "defaultClientScopes": ["web-origins", "user_id", "profile", "roles", "bcsc_guid", "email"],
       "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"]
     },
     {
@@ -1786,6 +1786,33 @@
             "claim.name": "resource_access.${client_id}.roles",
             "jsonType.label": "String",
             "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c014861f-c9d5-418e-a81c-dd2a4009005f",
+      "name": "bcsc_guid",
+      "description": "BCSC login guid",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "3cb806ff-6c40-4ca1-a9cc-4055c337e66c",
+          "name": "bcsc_guid",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "bcsc_guid",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "bcsc_guid",
+            "jsonType.label": "String"
           }
         }
       ]

--- a/.docker/keycloak/realm-testing.json
+++ b/.docker/keycloak/realm-testing.json
@@ -817,21 +817,6 @@
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
-          "id": "99a318ea-7b43-45d4-af69-681d437d9c3e",
-          "name": "bcsc_guid",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "bcsc_guid",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "bcsc_guid",
-            "jsonType.label": "String"
-          }
-        },
-        {
           "id": "60507962-9c5e-4b75-ab39-26f39f5fccb9",
           "name": "Client IP Address",
           "protocol": "openid-connect",
@@ -1176,7 +1161,7 @@
           }
         }
       ],
-      "defaultClientScopes": ["web-origins", "user_id", "profile", "roles", "bcsc_guid", "email"],
+      "defaultClientScopes": ["web-origins", "user_id", "profile", "roles", "email"],
       "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"]
     },
     {
@@ -1786,33 +1771,6 @@
             "claim.name": "resource_access.${client_id}.roles",
             "jsonType.label": "String",
             "multivalued": "true"
-          }
-        }
-      ]
-    },
-    {
-      "id": "c014861f-c9d5-418e-a81c-dd2a4009005f",
-      "name": "bcsc_guid",
-      "description": "BCSC login guid",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
-      },
-      "protocolMappers": [
-        {
-          "id": "3cb806ff-6c40-4ca1-a9cc-4055c337e66c",
-          "name": "bcsc_guid",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "bcsc_guid",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "bcsc_guid",
-            "jsonType.label": "String"
           }
         }
       ]

--- a/.docker/keycloak/realm-testing.json
+++ b/.docker/keycloak/realm-testing.json
@@ -832,6 +832,21 @@
           }
         },
         {
+          "id": "b6b38cde-a138-4d86-a7fe-db9be27c724f",
+          "name": "user_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "user_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "user_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
           "id": "4b546d98-1959-4ec2-9077-f96fd8651921",
           "name": "Client Host",
           "protocol": "openid-connect",

--- a/.docker/keycloak/users.json
+++ b/.docker/keycloak/users.json
@@ -1,12 +1,15 @@
 [
   {
     "user": {
-      "id": "4e9d7805-8284-4790-a2d6-39acd72e6f77",
-      "createdTimestamp": 1625597671479,
+      "id": "d7db5091-ac9e-40c5-a0e9-f46292afa641",
+      "createdTimestamp": 1680794921139,
       "username": "test-admin",
       "enabled": true,
       "totp": false,
       "emailVerified": false,
+      "attributes": {
+        "user_id": ["56d8c2f2-6b1c-484e-a66f-0b9b8cd9a081"]
+      },
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "notBefore": 0,
@@ -31,8 +34,8 @@
   },
   {
     "user": {
-      "id": "a16221b1-c6f3-4bc7-83bb-0875ac41beac",
-      "createdTimestamp": 1625597738219,
+      "id": "eaf66d03-6be3-4dc2-ae43-d33f489d1400",
+      "createdTimestamp": 1680795682784,
       "username": "test-employer",
       "enabled": true,
       "totp": false,
@@ -40,6 +43,9 @@
       "firstName": "Em",
       "lastName": "Ployer",
       "email": "employer@freshworks.club",
+      "attributes": {
+        "user_id": ["e7d2dda8-08e0-42f6-b28a-88423ce84098"]
+      },
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "notBefore": 0,
@@ -72,8 +78,8 @@
   },
   {
     "user": {
-      "id": "44852cab-1c53-4460-af0d-0bd97d7010af",
-      "createdTimestamp": 1625597738468,
+      "id": "4f67ed77-9c58-440c-be8f-373d57c2a4e9",
+      "createdTimestamp": 1680795682860,
       "username": "test-employer-multi",
       "enabled": true,
       "totp": false,
@@ -81,6 +87,9 @@
       "firstName": "Megan",
       "lastName": "Multi",
       "email": "multi@freshworks.club",
+      "attributes": {
+        "user_id": ["42955d8e-b22a-4700-a435-421e6de2f5cf"]
+      },
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "notBefore": 0,
@@ -121,8 +130,8 @@
   },
   {
     "user": {
-      "id": "f663f6e6-8cba-4d16-a2af-0b52132e00e3",
-      "createdTimestamp": 1625597738619,
+      "id": "ef963828-37db-44b4-ae5d-1e65b5a9b588",
+      "createdTimestamp": 1680795682920,
       "username": "test-ha",
       "enabled": true,
       "totp": false,
@@ -130,6 +139,9 @@
       "firstName": "Mr",
       "lastName": "Clean",
       "email": "auth@freshworks.club",
+      "attributes": {
+        "user_id": ["b4d11f7e-e44a-44c3-a90d-fadd540ecf6c"]
+      },
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "notBefore": 0,
@@ -162,14 +174,17 @@
   },
   {
     "user": {
-      "id": "c7f0b367-2213-4786-9f8e-d40265ac382d",
-      "createdTimestamp": 1625599942412,
+      "id": "2fabff95-6723-41be-aa05-8179486e851a",
+      "createdTimestamp": 1680795682986,
       "username": "test-maximus",
       "enabled": true,
       "totp": false,
       "emailVerified": false,
       "firstName": "Maximillion",
       "lastName": "Pegasus",
+      "attributes": {
+        "user_id": ["bc842519-8937-4206-be17-ff6b5c005d11"]
+      },
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "notBefore": 0,
@@ -194,8 +209,8 @@
   },
   {
     "user": {
-      "id": "2a1958f1-ba6a-49d2-8fe5-cd66e411c738",
-      "createdTimestamp": 1625597738773,
+      "id": "5edd1300-38cf-45ae-a616-edb1cd0d8f70",
+      "createdTimestamp": 1680795683045,
       "username": "test-moh",
       "enabled": true,
       "totp": false,
@@ -203,6 +218,9 @@
       "firstName": "Miss",
       "lastName": "Ministry",
       "email": "moh@freshworks.club",
+      "attributes": {
+        "user_id": ["b3146995-cd9b-4577-8a54-466549303775"]
+      },
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "notBefore": 0,
@@ -267,8 +285,80 @@
   },
   {
     "user": {
-      "id": "2d9de443-1dd5-44a3-bf5a-cb16bb117d57",
-      "createdTimestamp": 1625597738925,
+      "id": "8e55983e-9a02-419e-952b-4af27313b586",
+      "createdTimestamp": 1680795683222,
+      "username": "test-pending-1",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "firstName": "Test",
+      "lastName": "Pending1",
+      "email": "test.pending1@hcap.club",
+      "attributes": {
+        "user_id": ["3edb20d1-3fce-4dea-87e4-ce62c9a781c9"]
+      },
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "notBefore": 0,
+      "access": {
+        "manageGroupMembership": true,
+        "view": true,
+        "mapRoles": true,
+        "impersonate": true,
+        "manage": true
+      }
+    },
+    "roles": [
+      {
+        "id": "1fb5d3b3-ef4f-422d-8901-1b3e40451534",
+        "name": "pending",
+        "description": "Default role added to new users",
+        "composite": false,
+        "clientRole": true,
+        "containerId": "8661c12a-5269-47af-bdb9-4f9a4c21f3c9"
+      }
+    ]
+  },
+  {
+    "user": {
+      "id": "595ce0f8-8338-4ba6-bd39-6a2fed191939",
+      "createdTimestamp": 1680795683286,
+      "username": "test-pending-2",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "firstName": "Test",
+      "lastName": "Pending2",
+      "email": "test.pending2@hcap.club",
+      "attributes": {
+        "user_id": ["597c2c68-b0fd-42a8-9811-efe90eb2aff9"]
+      },
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "notBefore": 0,
+      "access": {
+        "manageGroupMembership": true,
+        "view": true,
+        "mapRoles": true,
+        "impersonate": true,
+        "manage": true
+      }
+    },
+    "roles": [
+      {
+        "id": "1fb5d3b3-ef4f-422d-8901-1b3e40451534",
+        "name": "pending",
+        "description": "Default role added to new users",
+        "composite": false,
+        "clientRole": true,
+        "containerId": "8661c12a-5269-47af-bdb9-4f9a4c21f3c9"
+      }
+    ]
+  },
+  {
+    "user": {
+      "id": "97469dd7-6380-41ac-83ee-022cfb9dbdc6",
+      "createdTimestamp": 1680795683100,
       "username": "test-superuser",
       "enabled": true,
       "totp": false,
@@ -276,6 +366,9 @@
       "firstName": "Clark",
       "lastName": "Kent",
       "email": "superuser@freshworks.club",
+      "attributes": {
+        "user_id": ["86f196c5-445c-47ce-9c16-7e0ac46b965a"]
+      },
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "notBefore": 0,
@@ -300,8 +393,8 @@
   },
   {
     "user": {
-      "id": "6d351475-69a5-49be-8852-160e98fd2b1b",
-      "createdTimestamp": 1625597748925,
+      "id": "2a506dff-3622-4a3e-8300-dc5aba98d553",
+      "createdTimestamp": 1680795683154,
       "username": "test.participant",
       "enabled": true,
       "totp": false,
@@ -309,12 +402,12 @@
       "firstName": "Cristiano",
       "lastName": "Ronaldo",
       "email": "cristiano.ronaldo@hcap.club",
+      "attributes": {
+        "user_id": ["ec3f8e58-55fd-447b-91c9-56d82e02fae9"]
+      },
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "notBefore": 0,
-      "attributes": {
-        "user_id": "ec3f8e58-55fd-447b-91c9-56d82e02fae9"
-      },
       "access": {
         "manageGroupMembership": true,
         "view": true,
@@ -330,76 +423,7 @@
         "description": "Participant use role",
         "composite": false,
         "clientRole": true,
-        "containerId": "8661c12a-5269-47af-bdb9-4f9a4c21f3c9",
-        "attributes": {}
-      }
-    ]
-  },
-  {
-    "user": {
-      "id": "fc2aa6d0-31fb-4bb7-a82c-7bb22c5b5a71",
-      "createdTimestamp": 1625597758925,
-      "username": "test-pending-1",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": false,
-      "firstName": "Test",
-      "lastName": "Pending1",
-      "email": "test.pending1@hcap.club",
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "notBefore": 0,
-      "access": {
-        "manageGroupMembership": true,
-        "view": true,
-        "mapRoles": true,
-        "impersonate": true,
-        "manage": true
-      }
-    },
-    "roles": [
-      {
-        "id": "1fb5d3b3-ef4f-422d-8901-1b3e40451534",
-        "name": "pending",
-        "description": "Default role added to new users",
-        "composite": false,
-        "clientRole": true,
-        "containerId": "8661c12a-5269-47af-bdb9-4f9a4c21f3c9",
-        "attributes": {}
-      }
-    ]
-  },
-  {
-    "user": {
-      "id": "c82a10c0-dc64-4996-97cf-b87ce15b1b04",
-      "createdTimestamp": 1625597778925,
-      "username": "test-pending-2",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": false,
-      "firstName": "Test",
-      "lastName": "Pending2",
-      "email": "test.pending2@hcap.club",
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "notBefore": 0,
-      "access": {
-        "manageGroupMembership": true,
-        "view": true,
-        "mapRoles": true,
-        "impersonate": true,
-        "manage": true
-      }
-    },
-    "roles": [
-      {
-        "id": "1fb5d3b3-ef4f-422d-8901-1b3e40451534",
-        "name": "pending",
-        "description": "Default role added to new users",
-        "composite": false,
-        "clientRole": true,
-        "containerId": "8661c12a-5269-47af-bdb9-4f9a4c21f3c9",
-        "attributes": {}
+        "containerId": "8661c12a-5269-47af-bdb9-4f9a4c21f3c9"
       }
     ]
   }

--- a/.docker/keycloak/users.json
+++ b/.docker/keycloak/users.json
@@ -403,7 +403,7 @@
       "lastName": "Ronaldo",
       "email": "cristiano.ronaldo@hcap.club",
       "attributes": {
-        "bcsc_guid": ["ec3f8e58-55fd-447b-91c9-56d82e02fae9"]
+        "user_id": ["ec3f8e58-55fd-447b-91c9-56d82e02fae9"]
       },
       "disableableCredentialTypes": [],
       "requiredActions": [],

--- a/.docker/keycloak/users.json
+++ b/.docker/keycloak/users.json
@@ -403,7 +403,7 @@
       "lastName": "Ronaldo",
       "email": "cristiano.ronaldo@hcap.club",
       "attributes": {
-        "user_id": ["ec3f8e58-55fd-447b-91c9-56d82e02fae9"]
+        "bcsc_guid": ["ec3f8e58-55fd-447b-91c9-56d82e02fae9"]
       },
       "disableableCredentialTypes": [],
       "requiredActions": [],

--- a/server/middleware/access-logger.ts
+++ b/server/middleware/access-logger.ts
@@ -29,7 +29,6 @@ export default (req: Request & HasKauth, res: Response, next: () => void) => {
         preferred_username: userName = null,
         sub = null,
         user_id: userId = null,
-        bcsc_guid: bcscGuid = null,
       } = req.kauth?.grant?.access_token?.content || {};
       logger[logLevel]({
         context: 'access-log',
@@ -44,7 +43,6 @@ export default (req: Request & HasKauth, res: Response, next: () => void) => {
                 userName,
                 sub,
                 userId,
-                bcscGuid,
               }
             : null,
       });

--- a/server/middleware/access-logger.ts
+++ b/server/middleware/access-logger.ts
@@ -29,6 +29,7 @@ export default (req: Request & HasKauth, res: Response, next: () => void) => {
         preferred_username: userName = null,
         sub = null,
         user_id: userId = null,
+        bcsc_guid: bcscGuid = null,
       } = req.kauth?.grant?.access_token?.content || {};
       logger[logLevel]({
         context: 'access-log',
@@ -43,6 +44,7 @@ export default (req: Request & HasKauth, res: Response, next: () => void) => {
                 userName,
                 sub,
                 userId,
+                bcscGuid,
               }
             : null,
       });

--- a/server/routes/participant-user.ts
+++ b/server/routes/participant-user.ts
@@ -33,7 +33,7 @@ router.get(
   '/participants',
   asyncMiddleware(async (req, res) => {
     const { email } = req.user;
-    const userId = req.user.user_id ?? req.user.sub;
+    const userId = req.user.user_id ?? req.user.bcsc_guid;
     if (email && userId) {
       const response = await getParticipantsForUser(userId, email);
       logger.info({
@@ -52,7 +52,7 @@ router.get(
 router.get(
   '/participant/:id',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.sub;
+    const userId = req.user.user_id ?? req.user.bcsc_guid;
     const { id } = req.params;
     const participants = await getParticipantByIdWithStatus({ id, userId });
     if (!participants.length) {
@@ -83,7 +83,7 @@ router.patch(
   '/participant/batch',
   asyncMiddleware(async (req, res) => {
     const { email } = req.user;
-    const userId = req.user.user_id ?? req.user.sub;
+    const userId = req.user.user_id ?? req.user.bcsc_guid;
 
     const changes = { ...patchObject(req.body, patchableFields) };
     await validate(UserParticipantEditSchema, changes);
@@ -117,7 +117,7 @@ router.patch(
 router.patch(
   '/participant/:id',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.sub;
+    const userId = req.user.user_id ?? req.user.bcsc_guid;
     const id = sanitize(req.params.id);
     const changes = { ...patchObject(req.body, patchableFields), id };
     await validate(UserParticipantEditSchema, changes);
@@ -144,7 +144,7 @@ router.patch(
 router.post(
   '/participant/:id/withdraw',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.sub;
+    const userId = req.user.user_id ?? req.user.bcsc_guid;
     const { id } = req.params;
     const participants = await getParticipantByIdWithStatus({ id, userId });
     if (participants.length > 0) {
@@ -174,7 +174,7 @@ router.post(
 router.post(
   '/withdraw',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.sub;
+    const userId = req.user.user_id ?? req.user.bcsc_guid;
     await withdrawParticipantsByEmail(userId, req.user.email);
     return res.status(204).send({});
   })
@@ -183,7 +183,7 @@ router.post(
 router.post(
   '/participant/:id/reconfirm_interest',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.sub;
+    const userId = req.user.user_id ?? req.user.bcsc_guid;
     const { id } = req.params;
     const participants = await getParticipantByIdWithStatus({ id, userId });
     if (!participants.length) {

--- a/server/routes/participant-user.ts
+++ b/server/routes/participant-user.ts
@@ -32,8 +32,7 @@ router.use(applyMiddleware(keycloak.allowRolesMiddleware('participant')));
 router.get(
   '/participants',
   asyncMiddleware(async (req, res) => {
-    const { email } = req.user;
-    const userId = req.user.user_id ?? req.user.bcsc_guid;
+    const { email, user_id: userId } = req.user;
     if (email && userId) {
       const response = await getParticipantsForUser(userId, email);
       logger.info({
@@ -52,7 +51,7 @@ router.get(
 router.get(
   '/participant/:id',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.bcsc_guid;
+    const { user_id: userId } = req.user;
     const { id } = req.params;
     const participants = await getParticipantByIdWithStatus({ id, userId });
     if (!participants.length) {
@@ -82,8 +81,7 @@ const patchableFields = [
 router.patch(
   '/participant/batch',
   asyncMiddleware(async (req, res) => {
-    const { email } = req.user;
-    const userId = req.user.user_id ?? req.user.bcsc_guid;
+    const { user_id: userId, email } = req.user;
 
     const changes = { ...patchObject(req.body, patchableFields) };
     await validate(UserParticipantEditSchema, changes);
@@ -117,7 +115,7 @@ router.patch(
 router.patch(
   '/participant/:id',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.bcsc_guid;
+    const { user_id: userId } = req.user;
     const id = sanitize(req.params.id);
     const changes = { ...patchObject(req.body, patchableFields), id };
     await validate(UserParticipantEditSchema, changes);
@@ -144,7 +142,7 @@ router.patch(
 router.post(
   '/participant/:id/withdraw',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.bcsc_guid;
+    const { user_id: userId } = req.user;
     const { id } = req.params;
     const participants = await getParticipantByIdWithStatus({ id, userId });
     if (participants.length > 0) {
@@ -174,8 +172,7 @@ router.post(
 router.post(
   '/withdraw',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.bcsc_guid;
-    await withdrawParticipantsByEmail(userId, req.user.email);
+    await withdrawParticipantsByEmail(req.user.user_id, req.user.email);
     return res.status(204).send({});
   })
 );
@@ -183,7 +180,7 @@ router.post(
 router.post(
   '/participant/:id/reconfirm_interest',
   asyncMiddleware(async (req, res) => {
-    const userId = req.user.user_id ?? req.user.bcsc_guid;
+    const { user_id: userId } = req.user;
     const { id } = req.params;
     const participants = await getParticipantByIdWithStatus({ id, userId });
     if (!participants.length) {


### PR DESCRIPTION
- added user_id attributes to local keycloak users to prevent null userId's being returned

- ~~user id for bcsc login is now called `bcsc_guid`~~ **no longer needed**
- ~~added bcsc_guid attribute to test participant~~ **no longer needed**
- ~~added bcsc_guid client scope mapper for FE client so it is included in token~~ **no longer needed**