### PR TITLE
fix: add email guard for user info middleware and email check for user migration

### DIFF
--- a/server/keycloak.ts
+++ b/server/keycloak.ts
@@ -128,12 +128,17 @@ class Keycloak {
         const keycloakId = content.sub;
         const { preferred_username: username, email } = content;
 
-        const existingUser = await dbClient.db[collections.USER_MIGRATION].findOne({
-          'email ilike': email,
-          'username ilike': username.includes('@bceid')
-            ? `${username.split('@')[0]}@bceid%`
-            : username,
-        });
+        const usernameCondition = username.includes('@bceid')
+          ? `${username.split('@')[0]}@bceid%`
+          : username;
+
+        // if no email, user should not be in user_migration table
+        const existingUser = email
+          ? await dbClient.db[collections.USER_MIGRATION].findOne({
+              'email ilike': email,
+              'username ilike': usernameCondition,
+            })
+          : null;
 
         const type = username.split('@')[1];
         const shouldSetRoles = !content?.resource_access && !existingUser && options.includes(type);
@@ -144,7 +149,8 @@ class Keycloak {
           roles = content?.resource_access?.[this.clientNameFrontend]?.roles || [];
         }
 
-        if (roles.length === 0 || (roles.length === 1 && roles.includes('pending'))) {
+        // if no email, don't migrate user
+        if (email && (roles.length === 0 || (roles.length === 1 && roles.includes('pending')))) {
           const cachedRoles = await this.migrateUser(keycloakId, email, username);
           if (cachedRoles) {
             roles = cachedRoles;
@@ -438,6 +444,7 @@ class Keycloak {
       ? `${username.split('@')[0]}@bceid%`
       : username;
 
+    let message = '';
     let migrationStatus = await dbClient.db[collections.USER_MIGRATION].findOne({
       'email ilike': email,
       'username ilike': usernameCondition,
@@ -448,10 +455,20 @@ class Keycloak {
         'username ilike': usernameCondition,
       });
       if (migrationStatus) {
-        const message = `user migration record with same username but different email found for ${keycloakId}`;
+        message = `user migration record with same username but different email found for ${keycloakId}`;
         migrationStatus.message = message;
         logger.error(message, meta);
         await dbClient.db[collections.USER_MIGRATION].save(migrationStatus);
+      } else {
+        migrationStatus = await dbClient.db[collections.USER_MIGRATION].findOne({
+          'email ilike': email,
+        });
+        if (migrationStatus) {
+          message = `user migration record with same email but different username found for ${keycloakId}`;
+          migrationStatus.message = message;
+          logger.error(message, meta);
+          await dbClient.db[collections.USER_MIGRATION].save(migrationStatus);
+        }
       }
       return null;
     }


### PR DESCRIPTION
- add guard for scenarios where `email` is undefined
- prevent user migration from running if there is no `email`
- add `email` check in `migrateUser` function