### PR TITLE
fix: removing keycloak health check

### DIFF
--- a/server/services/health-check.ts
+++ b/server/services/health-check.ts
@@ -1,5 +1,4 @@
 import { dbClient, collections } from '../db';
-import keycloak from '../keycloak';
 import logger from '../logger';
 
 // Script method

--- a/server/services/health-check.ts
+++ b/server/services/health-check.ts
@@ -5,7 +5,6 @@ import logger from '../logger';
 // Script method
 export const healthCheck = async () => {
   let db = false;
-  let kc = false;
   try {
     // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
     const _ = await dbClient.db[collections.EMPLOYER_SITES].count();
@@ -17,19 +16,19 @@ export const healthCheck = async () => {
     });
   }
 
-  try {
-    await keycloak.checkHealth();
-    kc = true;
-  } catch (excp) {
-    logger.error('KC Health Check Failed!', {
-      context: 'health-check-kc',
-      error: excp,
-    });
-  }
+  // Removing for now - the Keycloak health check may not be necessary for the probes
+  // try {
+  //   await keycloak.checkHealth();
+  //   kc = true;
+  // } catch (excp) {
+  //   logger.error('KC Health Check Failed!', {
+  //     context: 'health-check-kc',
+  //     error: excp,
+  //   });
+  // }
 
   return {
     healthCheck: {
-      keycloak: kc,
       postgres: db,
     },
     version: process.env.VERSION,


### PR DESCRIPTION
The Keycloak team reached out and said we were making way more requests than necessary, and this is believed to be due to the liveness / readiness probes. We shouldn't need to check KC for our health check; if its down, we may not necessarily want the whole application to be down (which the liveness probe will do before this change).