### PR TITLE
HCAP-1507 - update indigenous only filter to include new question on PEOI

### DIFF
--- a/server/services/participants-helper/FieldsFilteredParticipantsFinder.ts
+++ b/server/services/participants-helper/FieldsFilteredParticipantsFinder.ts
@@ -293,16 +293,29 @@ export class FieldsFilteredParticipantsFinder {
         const statuses = statusFilters.includes('open')
           ? [null, ...statusFilters]
           : statusFilters || [];
-        this.context.criteria = {
-          ...this.context.criteria,
-          or: statuses.map((status) =>
-            status
-              ? {
-                  'status_infos::text ilike': `%{%"status": "${status}"%}%`,
-                }
-              : { status_infos: null }
-          ),
-        };
+        const mappedStatuses = statuses.map((status) =>
+          status
+            ? {
+                'status_infos::text ilike': `%{%"status": "${status}"%}%`,
+              }
+            : { status_infos: null }
+        );
+
+        // need to add an 'and' as statuses map will overwrite the indigenous 'or' filter
+        // criteria.or checks if the indigenous 'or' filter is included in the query
+        this.context.criteria = this.context.criteria.or
+          ? {
+              ...this.context.criteria,
+              and: [
+                {
+                  or: mappedStatuses,
+                },
+              ],
+            }
+          : {
+              ...this.context.criteria,
+              or: mappedStatuses,
+            };
       }
     }
     return new FilteredParticipantsFinder(this.context);

--- a/server/services/participants-helper/RegionsFilteredParticipantsFinder.ts
+++ b/server/services/participants-helper/RegionsFilteredParticipantsFinder.ts
@@ -38,7 +38,9 @@ export class RegionsFilteredParticipantsFinder {
       ...(lastName && { 'body.lastName ilike': `${lastName}%` }),
       ...(emailAddress && { 'body.emailAddress ilike': `${emailAddress}%` }),
       ...(interestFilter && { 'body.interested <>': ['no', 'withdrawn'] }),
-      ...(isIndigenousFilter && { 'body.isIndigenous =': true }),
+      ...(isIndigenousFilter && {
+        or: [{ 'body.isIndigenous =': true }, { 'body.indigenous =': 'Yes' }],
+      }),
     };
 
     return new FieldsFilteredParticipantsFinder(this.context);


### PR DESCRIPTION
### Summary
- update query to include indigenous field from PEOI question -> changed to an `or`
- update query for super users to prevent overwriting if `or` query exists from indigenous filter