### PR TITLE
add text explaining to participants to apply twice 

### DIFF
--- a/client/src/components/participant-form/sections/HCAPProgramSection.js
+++ b/client/src/components/participant-form/sections/HCAPProgramSection.js
@@ -4,11 +4,13 @@ import { Question } from '../Question';
 import { SectionHeader } from '../SectionHeader';
 import { FastField } from 'formik';
 import { RenderRadioGroup } from '../../fields';
+import { PleaseNoteBanner } from '../PleaseNoteBanner';
 
 export const HCAPProgramSection = ({ checkFieldDisability }) => {
   return (
     <>
       <SectionHeader text='HCAP Program' />
+      <PleaseNoteBanner text='Please submit a separate application for each program if you are interested in both.' />
       <Question text='1. * Which program are you applying for:' />
       <Grid item xs={12}>
         <FastField


### PR DESCRIPTION
### Summary
- add text to let participants know to apply twice if they are interested in both streams.

Text: Please Note: Please submit a separate application for each program if you are interested in both.

Under “HCAP Program” and above “1. * Which program are you applying for?”

[HCAP-1509](https://eydscanada.atlassian.net/jira/software/c/projects/HCAP/boards/206?selectedIssue=HCAP-1509)