### PR TITLE
Fix/revert withdrawn at

### DIFF
--- a/client/src/pages/private/ReportingView.js
+++ b/client/src/pages/private/ReportingView.js
@@ -138,16 +138,6 @@ export default () => {
                 text='Download return of service milestones report'
               />
             </Box>
-            {isMoH && (
-              <Box py={1} display='flex' justifyContent='center'>
-                <Button
-                  fullWidth={false}
-                  loading={isLoadingReport === 'monitoring'}
-                  onClick={() => handleDownloadReport('monitoring')}
-                  text='Download program monitoring report'
-                />
-              </Box>
-            )}
             <Box py={1} display='flex' justifyContent='center'>
               <Button
                 fullWidth={false}

--- a/server/migrations/1701676149_remove_withdrawn_date_participant_status_infos.js
+++ b/server/migrations/1701676149_remove_withdrawn_date_participant_status_infos.js
@@ -1,0 +1,50 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = async (pgm) => {
+  await pgm.sql(`
+    CREATE VIEW public.participants_status_infos
+    AS SELECT p.id,
+        p.body,
+        p.search,
+        p.created_at,
+        p.updated_at,
+        jsonb_agg(ps.*) FILTER (WHERE ps.id IS NOT NULL) AS status_infos,
+        jsonb_agg(DISTINCT jsonb_build_object('id', rosstatus.id, 'data', rosstatus.data, 'status', rosstatus.status, 'site_id', rosstatus.site_id, 'rosSite', ros_site.*)) FILTER (WHERE rosstatus.id IS NOT NULL) AS ros_infos
+       FROM participants p
+         LEFT JOIN return_of_service_status rosstatus ON p.id = rosstatus.participant_id AND rosstatus.is_current IS TRUE
+         LEFT JOIN participants_status ps ON p.id = ps.participant_id AND ps.current IS TRUE
+         LEFT JOIN employer_sites ros_site ON rosstatus.site_id = ros_site.id
+      GROUP BY p.id, p.body, p.search, p.created_at, p.updated_at;
+  `);
+};
+
+exports.down = async (pgm) => {
+  await pgm.sql(`
+    CREATE OR REPLACE VIEW public.participants_status_infos AS
+    SELECT p.id,
+      p.body,
+      p.search,
+      p.created_at,
+      p.updated_at,
+      jsonb_agg(ps.*) FILTER (WHERE ps.id IS NOT NULL) AS status_infos,
+      jsonb_agg(DISTINCT jsonb_build_object('id', rosstatus.id, 'data', rosstatus.data, 'status', rosstatus.status, 'site_id', rosstatus.site_id, 'rosSite', ros_site.*)) FILTER (WHERE rosstatus.id IS NOT NULL) AS ros_infos,
+      case when p.body->>'interested' = 'withdrawn' and p.body->>'history' IS NOT NULL
+        then (
+          select
+          h.timestamp
+          from jsonb_to_recordset(p.body->'history') as h(timestamp timestamp, changes jsonb )
+          where (select * from jsonb_array_elements(h.changes) limit 1)->>'to' = 'withdrawn'
+          order by h.timestamp desc
+          limit 1
+        )
+        else null
+      end as withdrawn_at
+    FROM participants p
+    LEFT JOIN return_of_service_status rosstatus ON p.id = rosstatus.participant_id AND rosstatus.is_current IS TRUE
+    LEFT JOIN participants_status ps ON p.id = ps.participant_id AND ps.current IS TRUE
+    LEFT JOIN employer_sites ros_site ON rosstatus.site_id = ros_site.id
+    GROUP BY p.id, p.body, p.search, p.created_at, p.updated_at;
+  `);
+};

--- a/server/migrations/1701676909312_remove-withdrawn-date-participant-status-infos.js
+++ b/server/migrations/1701676909312_remove-withdrawn-date-participant-status-infos.js
@@ -1,7 +1,5 @@
 /* eslint-disable camelcase */
 
-exports.shorthands = undefined;
-
 exports.up = async (pgm) => {
   await pgm.sql(`
     CREATE VIEW public.participants_status_infos

--- a/server/services/participants-helper/FieldsFilteredParticipantsFinder.ts
+++ b/server/services/participants-helper/FieldsFilteredParticipantsFinder.ts
@@ -304,23 +304,22 @@ export class FieldsFilteredParticipantsFinder {
             : { status_infos: null }
         );
 
-        this.context.criteria = {
-          ...this.context.criteria,
-          and: [
-            ...(this.context.criteria.and ?? []),
-            {
-              or: mappedStatuses,
-            },
-            {
-              or: [
-                { 'withdrawn_at IS': null },
+        // need to add an 'and' as statuses map will overwrite the indigenous 'or' filter
+        // criteria.or checks if the indigenous 'or' filter is included in the query
+        this.context.criteria = this.context.criteria.or
+          ? {
+              ...this.context.criteria,
+              and: [
+                ...this.context.criteria.and,
                 {
-                  'withdrawn_at >': dayjs().subtract(4, 'month'),
+                  or: mappedStatuses,
                 },
               ],
-            },
-          ],
-        };
+            }
+          : {
+              ...this.context.criteria,
+              or: mappedStatuses,
+            };
       }
     }
     return new FilteredParticipantsFinder(this.context);


### PR DESCRIPTION
We have to pull two features.

For withdrawn_at, the reason we're pulling it is because `history` in prod is a little bit unpredictable. I have seen instances where it is just the number `3` (it doesn't seem to be THE issue), but ultimately, when retrieving participants, the error `cannot call jsonb_to_recordset on a non-array` often comes up. Hence, removing this from the view.

The report is being removed for now in lieu of providing some SQL to CGI to retrieve this report. Why: when this was clicked in production with 60k+ rows, it just hung. Then the database ballooned in memory and crashed. This makes me suspect that the reports are related to the ballooning memory issue we have had.