### PR TITLE
update keycloak docker to use quay keycloak

### DIFF
--- a/.docker/keycloak/Dockerfile.test
+++ b/.docker/keycloak/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM jboss/keycloak:16.1.1
+FROM quay.io/keycloak/keycloak:16.1.1
 
 USER 0
 COPY create-users.sh /opt/jboss/startup-scripts/create-users.sh


### PR DESCRIPTION
- jboss keycloak repo has been removed, need to replace with a new repo