### PR TITLE
add CPU&Memory request&limits to patroni pods

### DIFF
--- a/openshift/patroni.bc.yml
+++ b/openshift/patroni.bc.yml
@@ -68,7 +68,7 @@ objects:
           cpu: 500m
           memory: 2Gi
         limits:
-          cpu: '1'
+          cpu: '2'
           memory: 4Gi
       output:
         to:

--- a/openshift/patroni.dc.yml
+++ b/openshift/patroni.dc.yml
@@ -12,19 +12,19 @@ parameters:
     required: true
   - name: CPU_REQUEST
     description: Starting amount of CPU the container can use
-    value: 250m
+    value: 500m
     required: true
   - name: CPU_LIMIT
     description: Maximum amount of CPU the container can use
-    value: 500m
+    value: '2'
     required: true
   - name: MEMORY_REQUEST
     description: Starting amount of memory the container can use
-    value: 1Gi
+    value: 2Gi
     required: true
   - name: MEMORY_LIMIT
     description: Maximum amount of memory the container can use
-    value: 2Gi
+    value: 4Gi
     required: true
   - name: IMAGE_NAMESPACE
     description: Namespace from which to pull the image


### PR DESCRIPTION
this PR is to add CPU&Memory request&limits to patroni pods.

the patroni.bc.yml is used for builds.
the patroni.dc.yml is used for running containers.

target resource config:
            limits:
              cpu: "2"
              memory: 4Gi
            requests:
              cpu: 500m
              memory: 2Gi
