### PR TITLE
add pagination to hiring report and increased the timeout to 60s

### DIFF
--- a/openshift/server.dc.yml
+++ b/openshift/server.dc.yml
@@ -97,6 +97,8 @@ objects:
                     secretKeyRef:
                       key: db-password
                       name: ${APP_NAME}-patroni
+                - name: POSTGRES_QUERY_TIMEOUT
+                  value: '60000' # 60 seconds
                 - name: KEYCLOAK_REALM
                   valueFrom:
                     secretKeyRef:

--- a/server/db/db.ts
+++ b/server/db/db.ts
@@ -8,7 +8,14 @@ import logger from '../logger';
  * to easily interact with a Postgres database
  */
 class DBClient {
-  settings: { host: string; port: number; database: string; user: string; password: string };
+  settings: {
+    host: string;
+    port: number;
+    database: string;
+    user: string;
+    password: string;
+    query_timeout?: number;
+  };
 
   db?: massive.Database;
 
@@ -21,6 +28,7 @@ class DBClient {
       database: process.env.NODE_ENV === 'test' ? 'db_test' : process.env.POSTGRES_DB,
       user: process.env.POSTGRES_USER,
       password: process.env.POSTGRES_PASSWORD,
+      query_timeout: Number(process.env.POSTGRES_QUERY_TIMEOUT) || 30000, // Default 30 seconds
     };
     this.db = null;
   }

--- a/server/services/reporting/participants-report.ts
+++ b/server/services/reporting/participants-report.ts
@@ -117,6 +117,36 @@ type HiredEntry = {
   employer_id: string;
 };
 
+/**
+ * Maps a hired entry to the report format
+ * @param entry The hired entry from the database
+ * @returns Formatted report entry
+ */
+const mapHiredEntryToReport = (entry: HiredEntry) => ({
+  participantId: entry.participant_id,
+  firstName: entry.participantJoin?.[0]?.body?.firstName,
+  lastName: entry.participantJoin?.[0]?.body?.lastName,
+  employerId: entry.employer_id,
+  email: entry.participantJoin?.[0]?.body?.emailAddress,
+  program: entry.participantJoin?.[0].body?.program,
+  driverLicense: entry.participantJoin?.[0].body?.driverLicense,
+  indigenous: entry.participantJoin?.[0].body?.indigenous,
+  reasonForFindingOut: entry.participantJoin?.[0].body?.reasonForFindingOut?.join(','),
+  currentOrMostRecentIndustry: entry.participantJoin?.[0].body?.currentOrMostRecentIndustry,
+  experienceWithMentalHealthOrSubstanceUse:
+    entry.participantJoin?.[0].body?.experienceWithMentalHealthOrSubstanceUse,
+  interestedWorkingPeerSupportRole:
+    entry.participantJoin?.[0].body?.interestedWorkingPeerSupportRole,
+  employerRegion: entry.employerSiteJoin?.[0]?.body?.healthAuthority,
+  employerSite: entry.employerSiteJoin?.[0]?.body?.siteName,
+  employerCity: entry.employerSiteJoin?.[0]?.body.city,
+  employerSiteId: entry.employerSiteJoin?.[0]?.body?.siteId,
+  startDate: entry.data?.startDate,
+  hiredDate: entry.data?.hiredDate,
+  withdrawReason: entry.archivedJoin?.[0]?.data?.reason,
+  withdrawDate: entry.archivedJoin?.[0]?.data?.endDate,
+});
+
 export const getParticipantsReport = async () => {
   const inProgressEntries = await dbClient.db[collections.PARTICIPANTS_STATUS]
     .join({
@@ -234,58 +264,11 @@ export const getHiredParticipantsReport = async (
     // Execute the query with pagination
     const hiredEntries: HiredEntry[] = await query.find(searchOptions).page(offset, limit);
 
-    return hiredEntries.map((entry) => ({
-      participantId: entry.participant_id,
-      firstName: entry.participantJoin?.[0]?.body?.firstName,
-      lastName: entry.participantJoin?.[0]?.body?.lastName,
-      employerId: entry.employer_id,
-      email: entry.participantJoin?.[0]?.body?.emailAddress,
-      program: entry.participantJoin?.[0].body?.program,
-      driverLicense: entry.participantJoin?.[0].body?.driverLicense,
-      indigenous: entry.participantJoin?.[0].body?.indigenous,
-      reasonForFindingOut: entry.participantJoin?.[0].body?.reasonForFindingOut?.join(','),
-      currentOrMostRecentIndustry: entry.participantJoin?.[0].body?.currentOrMostRecentIndustry,
-      experienceWithMentalHealthOrSubstanceUse:
-        entry.participantJoin?.[0].body?.experienceWithMentalHealthOrSubstanceUse,
-      interestedWorkingPeerSupportRole:
-        entry.participantJoin?.[0].body?.interestedWorkingPeerSupportRole,
-      employerRegion: entry.employerSiteJoin?.[0]?.body?.healthAuthority,
-      employerSite: entry.employerSiteJoin?.[0]?.body?.siteName,
-      employerCity: entry.employerSiteJoin?.[0]?.body.city,
-      employerSiteId: entry.employerSiteJoin?.[0]?.body?.siteId,
-      startDate: entry.data?.startDate,
-      hiredDate: entry.data?.hiredDate,
-      withdrawReason: entry.archivedJoin?.[0]?.data?.reason,
-      withdrawDate: entry.archivedJoin?.[0]?.data?.endDate,
-    }));
+    return hiredEntries.map(mapHiredEntryToReport);
   } else {
     // Original implementation without pagination
     const hiredEntries: HiredEntry[] = await query.find(searchOptions);
-
-    return hiredEntries.map((entry) => ({
-      participantId: entry.participant_id,
-      firstName: entry.participantJoin?.[0]?.body?.firstName,
-      lastName: entry.participantJoin?.[0]?.body?.lastName,
-      employerId: entry.employer_id,
-      email: entry.participantJoin?.[0]?.body?.emailAddress,
-      program: entry.participantJoin?.[0].body?.program,
-      driverLicense: entry.participantJoin?.[0].body?.driverLicense,
-      indigenous: entry.participantJoin?.[0].body?.indigenous,
-      reasonForFindingOut: entry.participantJoin?.[0].body?.reasonForFindingOut?.join(','),
-      currentOrMostRecentIndustry: entry.participantJoin?.[0].body?.currentOrMostRecentIndustry,
-      experienceWithMentalHealthOrSubstanceUse:
-        entry.participantJoin?.[0].body?.experienceWithMentalHealthOrSubstanceUse,
-      interestedWorkingPeerSupportRole:
-        entry.participantJoin?.[0].body?.interestedWorkingPeerSupportRole,
-      employerRegion: entry.employerSiteJoin?.[0]?.body?.healthAuthority,
-      employerSite: entry.employerSiteJoin?.[0]?.body?.siteName,
-      employerCity: entry.employerSiteJoin?.[0]?.body.city,
-      employerSiteId: entry.employerSiteJoin?.[0]?.body?.siteId,
-      startDate: entry.data?.startDate,
-      hiredDate: entry.data?.hiredDate,
-      withdrawReason: entry.archivedJoin?.[0]?.data?.reason,
-      withdrawDate: entry.archivedJoin?.[0]?.data?.endDate,
-    }));
+    return hiredEntries.map(mapHiredEntryToReport);
   }
 };
 


### PR DESCRIPTION
Implemented Streaming in server/routes/milestone-report.ts (rewrote the generateHiredReport function to use a batched approach)

Fetches data in batches of 500 records
Processes each batch and writes it to the CSV stream immediately
Continues until no more records are found
Logs progress periodically and at completion