### PR TITLE
Fix the infinite loop on cohort update page & Fix the data mismatch on ROS report

### DIFF
--- a/client/src/hooks/useCohortActions.js
+++ b/client/src/hooks/useCohortActions.js
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Routes, ToastStatus } from '../constants';
 import { keyedString } from '../utils';
-import { useCohortData, useToast } from './';
+import { useToast } from './';
 import { fetchParticipant, getPsi } from '../services';
 
 export const useCohortActions = (cohortId) => {
@@ -13,8 +13,8 @@ export const useCohortActions = (cohortId) => {
   const [allCohorts, setAllCohorts] = useState([]);
   // eslint-disable-next-line no-unused-vars
   const [disableAssign, setDisableAssign] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
-  const { setIsLoading } = useCohortData(cohortId);
   const { openToast } = useToast();
 
   const handleOpenParticipantDetails = useCallback(
@@ -60,7 +60,7 @@ export const useCohortActions = (cohortId) => {
         setIsLoading(false);
       }
     },
-    [openToast, setIsLoading]
+    [openToast]
   );
 
   const handleTransferParticipant = useCallback(
@@ -79,5 +79,6 @@ export const useCohortActions = (cohortId) => {
     transferModalOpen,
     setTransferModalOpen,
     disableAssign,
+    isLoading,
   };
 };

--- a/server/routes/milestone-report.ts
+++ b/server/routes/milestone-report.ts
@@ -96,29 +96,59 @@ const generateHiredReport = async (csvStream, region = DEFAULT_REGION_NAME) => {
  * Generate ROS milestone report
  * @param csvStream output stream
  */
+// Update the generateRosReport function to handle errors better
 const generateRosReport = async (csvStream, region) => {
-  const results =
-    region === DEFAULT_REGION_NAME
-      ? await getMohRosMilestonesReport()
-      : await getHARosMilestonesReport(region);
-  results.forEach((result) => {
-    csvStream.write({
-      'Participant ID': result.participantId,
-      'First Name': result.firstName,
-      'Last Name': result.lastName,
-      Pathway: result.program,
-      'ROS Start Date': result.startDate,
-      'ROS End Date': result.endDate,
-      'Start Date at a Site': result.siteStartDate,
-      'Position Type': result.positionType,
-      'Specific Position Type': result.employmentType,
-      'Site of ROS': result.site,
-      'Health Region': result.healthRegion,
-      'Return of Service Completed': result.rosCompleted,
-      'Intends to Continue as HCA/MHAW Following ROS Completion':
-        result.remainingInSectorOrRoleOrAnother,
+  try {
+    const results =
+      region === DEFAULT_REGION_NAME
+        ? await getMohRosMilestonesReport()
+        : await getHARosMilestonesReport(region);
+
+    if (results.length === 0) {
+      // Write a header row even if there's no data
+      csvStream.write({
+        'Participant ID': '',
+        'First Name': '',
+        'Last Name': '',
+        Pathway: '',
+        'ROS Start Date': '',
+        'ROS End Date': '',
+        'Start Date at a Site': '',
+        'Position Type': '',
+        'Specific Position Type': '',
+        'Site of ROS': '',
+        'Health Region': '',
+        'Return of Service Completed': '',
+        'Intends to Continue as HCA/MHAW Following ROS Completion': '',
+      });
+      return;
+    }
+
+    results.forEach((result) => {
+      csvStream.write({
+        'Participant ID': result.participantId,
+        'First Name': result.firstName,
+        'Last Name': result.lastName,
+        Pathway: result.program,
+        'ROS Start Date': result.startDate,
+        'ROS End Date': result.endDate,
+        'Start Date at a Site': result.siteStartDate,
+        'Position Type': result.positionType,
+        'Specific Position Type': result.employmentType,
+        'Site of ROS': result.site,
+        'Health Region': result.healthRegion,
+        'Return of Service Completed': result.rosCompleted,
+        'Intends to Continue as HCA/MHAW Following ROS Completion':
+          result.remainingInSectorOrRoleOrAnother,
+      });
     });
-  });
+  } catch (error) {
+    logger.error(`Error generating ROS report: ${error.message}`);
+    // Write an error message to the CSV
+    csvStream.write({
+      Error: `Failed to generate report: ${error.message}`,
+    });
+  }
 };
 
 /**

--- a/server/services/reporting/milestones-report.ts
+++ b/server/services/reporting/milestones-report.ts
@@ -1,135 +1,232 @@
 import { dbClient, collections } from '../../db';
 import { mapRosEntries } from './ros-entries';
+import logger from '../../logger';
 
 export const getMohRosMilestonesReport = async () => {
-  const entries = await dbClient.db[collections.ROS_STATUS]
-    .join({
-      participantJoin: {
-        type: 'LEFT OUTER',
-        relation: collections.PARTICIPANTS,
-        on: {
-          id: 'participant_id',
-        },
-      },
-      siteJoin: {
-        type: 'LEFT OUTER',
-        decomposeTo: 'object',
-        relation: collections.EMPLOYER_SITES,
-        on: {
-          id: 'site_id',
-        },
-      },
-      participantStatusJoin: {
-        type: 'LEFT OUTER',
-        decomposeTo: 'object',
-        relation: collections.PARTICIPANTS_STATUS,
-        on: {
-          participant_id: 'participant_id',
-          current: true,
-          'data.site': 'siteJoin.body.siteId',
-        },
-      },
-    })
-    .find(
-      {},
-      {
-        order: [
-          {
-            field: 'participant_id',
+  try {
+    // First, get all ROS status entries with their related data
+    const entries = await dbClient.db[collections.ROS_STATUS]
+      .join({
+        participantJoin: {
+          type: 'LEFT OUTER',
+          relation: collections.PARTICIPANTS,
+          on: {
+            id: 'participant_id',
           },
-        ],
-      }
-    );
+        },
+        siteJoin: {
+          type: 'LEFT OUTER',
+          decomposeTo: 'object',
+          relation: collections.EMPLOYER_SITES,
+          on: {
+            id: 'site_id',
+          },
+        },
+        participantStatusJoin: {
+          type: 'LEFT OUTER',
+          decomposeTo: 'object',
+          relation: collections.PARTICIPANTS_STATUS,
+          on: {
+            participant_id: 'participant_id',
+            current: true,
+            'data.site': 'siteJoin.body.siteId',
+          },
+        },
+      })
+      .find(
+        {},
+        {
+          order: [
+            {
+              field: 'participant_id',
+            },
+          ],
+        }
+      );
 
-  return mapRosEntries(entries);
+    // Get the ROS completion status for each participant
+    const participantIds = entries.map((entry) => entry.participant_id);
+
+    // If no participants found, return empty array
+    if (participantIds.length === 0) {
+      logger.info('No participants found for ROS milestone report');
+      return [];
+    }
+
+    const rosCompletionStatuses = await dbClient.db[collections.PARTICIPANTS_STATUS].find({
+      participant_id: { $in: participantIds },
+      status: 'archived',
+      'data.type': 'rosComplete',
+      'data.confirmed': 'true',
+      current: true,
+    });
+
+    // Create a map of participant IDs to their ROS completion status
+    const rosCompletionMap = new Map();
+    rosCompletionStatuses.forEach((status) => {
+      rosCompletionMap.set(status.participant_id, {
+        completed: true,
+        remainingInSectorOrRoleOrAnother:
+          status.data?.remainingInSectorOrRoleOrAnother || 'Unknown',
+      });
+    });
+
+    // Enhance the entries with the ROS completion information
+    const enhancedEntries = entries.map((entry) => {
+      const rosCompletion = rosCompletionMap.get(entry.participant_id) || {
+        completed: false,
+        remainingInSectorOrRoleOrAnother: 'Unknown',
+      };
+
+      return {
+        ...entry,
+        rosCompleted: rosCompletion.completed ? 'TRUE' : 'FALSE',
+        remainingInSectorOrRoleOrAnother: rosCompletion.remainingInSectorOrRoleOrAnother,
+      };
+    });
+
+    return mapRosEntries(enhancedEntries);
+  } catch (error) {
+    logger.error(`Error generating MoH ROS milestones report: ${error.message}`);
+    throw error;
+  }
 };
 
 export const getHARosMilestonesReport = async (region: string) => {
-  const sameSiteRosEntries = await dbClient.db[collections.ROS_STATUS]
-    .join({
-      participantJoin: {
-        type: 'LEFT OUTER',
-        relation: collections.PARTICIPANTS,
-        on: {
-          id: 'participant_id',
-        },
-      },
-      siteJoin: {
-        type: 'LEFT OUTER',
-        decomposeTo: 'object',
-        relation: collections.EMPLOYER_SITES,
-        on: {
-          id: 'site_id',
-        },
-      },
-      participantStatusJoin: {
-        type: 'LEFT OUTER',
-        decomposeTo: 'object',
-        relation: collections.PARTICIPANTS_STATUS,
-        on: {
-          participant_id: 'participant_id',
-          current: true,
-          'data.site': 'siteJoin.body.siteId',
-        },
-      },
-    })
-    .find(
-      {
-        'siteJoin.body.healthAuthority': region,
-        status: 'assigned-same-site',
-      },
-      {
-        order: [
-          {
-            field: 'participant_id',
+  try {
+    const sameSiteRosEntries = await dbClient.db[collections.ROS_STATUS]
+      .join({
+        participantJoin: {
+          type: 'LEFT OUTER',
+          relation: collections.PARTICIPANTS,
+          on: {
+            id: 'participant_id',
           },
-        ],
-      }
-    );
+        },
+        siteJoin: {
+          type: 'LEFT OUTER',
+          decomposeTo: 'object',
+          relation: collections.EMPLOYER_SITES,
+          on: {
+            id: 'site_id',
+          },
+        },
+        participantStatusJoin: {
+          type: 'LEFT OUTER',
+          decomposeTo: 'object',
+          relation: collections.PARTICIPANTS_STATUS,
+          on: {
+            participant_id: 'participant_id',
+            current: true,
+            'data.site': 'siteJoin.body.siteId',
+          },
+        },
+      })
+      .find(
+        {
+          'siteJoin.body.healthAuthority': region,
+          status: 'assigned-same-site',
+        },
+        {
+          order: [
+            {
+              field: 'participant_id',
+            },
+          ],
+        }
+      );
 
-  // HAs need only see the participants in their health region + participants who changed their health region and now assigned to a site withing HAs view
-  // select participants outside HAs region for changed sites
-  const editedEntries = await dbClient.db[collections.ROS_STATUS]
-    .join({
-      participantJoin: {
-        type: 'LEFT OUTER',
-        relation: collections.PARTICIPANTS,
-        on: {
-          id: 'participant_id',
+    // If no participants found in the region, return empty array
+    if (sameSiteRosEntries.length === 0) {
+      logger.info(`No participants found for ROS milestone report in region: ${region}`);
+      return [];
+    }
+
+    // HAs need only see the participants in their health region + participants who changed their health region and now assigned to a site withing HAs view
+    // select participants outside HAs region for changed sites
+    const editedEntries = await dbClient.db[collections.ROS_STATUS]
+      .join({
+        participantJoin: {
+          type: 'LEFT OUTER',
+          relation: collections.PARTICIPANTS,
+          on: {
+            id: 'participant_id',
+          },
         },
-      },
-      siteJoin: {
-        type: 'LEFT OUTER',
-        decomposeTo: 'object',
-        relation: collections.EMPLOYER_SITES,
-        on: {
-          id: 'site_id',
+        siteJoin: {
+          type: 'LEFT OUTER',
+          decomposeTo: 'object',
+          relation: collections.EMPLOYER_SITES,
+          on: {
+            id: 'site_id',
+          },
         },
-      },
-      participantStatusJoin: {
-        type: 'LEFT OUTER',
-        decomposeTo: 'object',
-        relation: collections.PARTICIPANTS_STATUS,
-        on: {
-          participant_id: 'participant_id',
-          current: true,
-          'data.site': 'siteJoin.body.siteId',
+        participantStatusJoin: {
+          type: 'LEFT OUTER',
+          decomposeTo: 'object',
+          relation: collections.PARTICIPANTS_STATUS,
+          on: {
+            participant_id: 'participant_id',
+            current: true,
+            'data.site': 'siteJoin.body.siteId',
+          },
         },
-      },
-    })
-    .find({
-      participant_id: sameSiteRosEntries.map((entry) => entry.participant_id),
-      // data.user <> NULL - indicated that the entry was modified by another user at some point
-      'data.user <>': 'NULL',
+      })
+      .find({
+        participant_id: sameSiteRosEntries.map((entry) => entry.participant_id),
+        // data.user <> NULL - indicated that the entry was modified by another user at some point
+        'data.user <>': 'NULL',
+      });
+
+    // see if we need to display this information for HA based on what participants are included
+    // if participants are already visible to HA - include information about their previous sites
+    let rosEntries = sameSiteRosEntries;
+    if (editedEntries.length > 0) {
+      rosEntries = rosEntries.concat(editedEntries);
+      rosEntries.sort((a, b) => a.participant_id - b.participant_id);
+    }
+
+    // Get all participant IDs from the combined entries
+    const participantIds = rosEntries.map((entry) => entry.participant_id);
+
+    // Get ROS completion statuses for these participants
+    const rosCompletionStatuses = await dbClient.db[collections.PARTICIPANTS_STATUS].find({
+      participant_id: { $in: participantIds },
+      status: 'archived',
+      'data.type': 'rosComplete',
+      'data.confirmed': 'true',
+      current: true,
     });
 
-  // see if we need to display this information for HA based on what participants are included
-  // if participants are already visible to HA - include information about their previous sites
-  let rosEntries = sameSiteRosEntries;
-  if (editedEntries.length > 0) {
-    rosEntries = rosEntries.concat(editedEntries);
-    rosEntries.sort((a, b) => a.participant_id - b.participant_id);
-  }
+    // Create a map of participant IDs to their ROS completion status
+    const rosCompletionMap = new Map();
+    rosCompletionStatuses.forEach((status) => {
+      rosCompletionMap.set(status.participant_id, {
+        completed: true,
+        remainingInSectorOrRoleOrAnother:
+          status.data?.remainingInSectorOrRoleOrAnother || 'Unknown',
+      });
+    });
 
-  return mapRosEntries(rosEntries);
+    // Enhance the entries with the ROS completion information
+    const enhancedEntries = rosEntries.map((entry) => {
+      const rosCompletion = rosCompletionMap.get(entry.participant_id) || {
+        completed: false,
+        remainingInSectorOrRoleOrAnother: 'Unknown',
+      };
+
+      return {
+        ...entry,
+        rosCompleted: rosCompletion.completed ? 'TRUE' : 'FALSE',
+        remainingInSectorOrRoleOrAnother: rosCompletion.remainingInSectorOrRoleOrAnother,
+      };
+    });
+
+    return mapRosEntries(enhancedEntries);
+  } catch (error) {
+    logger.error(
+      `Error generating HA ROS milestones report for region ${region}: ${error.message}`
+    );
+    throw error;
+  }
 };


### PR DESCRIPTION
1. Fixed Infinite Loop on Cohort Update Page
   1.1. Added a reference flag to control when participant data should be fetched
   1.2. Improved dependency arrays in useEffect hooks to prevent unnecessary re-renders
   1.3. Separated loading states between cohort data and transfer actions
   1.4. Enhanced error handling for data fetching operations
2. Fixed Data Mismatch on ROS Report
   2.1. Corrected the logic for determining "Return of Service Completed" status in milestone reports
   2.2. Added support for empty result sets to prevent CSV generation errors