### PR TITLE
Add dev-env&test-env branches; update ROS report query; add KeyCloak login option

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,7 +1,7 @@
 name: Check format of code base
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
   premerge:

--- a/.github/workflows/promote-dev.yml
+++ b/.github/workflows/promote-dev.yml
@@ -77,15 +77,19 @@ jobs:
         with:
           oc: latest
 
+      - name: Get previous commit
+        id: get-prev-commit
+        run: echo "prev_commit=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
             src:
               - 'openshift/**'
-          #github.event.before is the SHA of the commit before the push event (only available during push events)
-          #HEAD~1 is the commit right before the latest commit on dev-env
-          base: ${{ github.event.before || 'HEAD~1' }}
+          # github.event.before is the SHA of the commit before the push event (only available during push events)
+          # steps.get-prev-commit.outputs.prev_commit contains the SHA of the parent commit (one before the current commit)
+          base: ${{ github.event.before || steps.get-prev-commit.outputs.prev_commit }}
       - name: Dry run - Dev
         env:
           OS_NAMESPACE_SUFFIX: dev
@@ -119,15 +123,20 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: latest
+
+      - name: Get previous commit
+        id: get-prev-commit
+        run: echo "prev_commit=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
             src:
               - 'openshift/**'
-          #github.event.before is the SHA of the commit before the push event (only available during push events)
-          #HEAD~1 is the commit right before the latest commit on dev-env
-          base: ${{ github.event.before || 'HEAD~1' }}
+          # github.event.before is the SHA of the commit before the push event (only available during push events)
+          # steps.get-prev-commit.outputs.prev_commit contains the SHA of the parent commit (one before the current commit)
+          base: ${{ github.event.before || steps.get-prev-commit.outputs.prev_commit }}
       - name: Apply Changes
         env:
           OS_NAMESPACE_SUFFIX: dev

--- a/.github/workflows/promote-dev.yml
+++ b/.github/workflows/promote-dev.yml
@@ -1,14 +1,34 @@
 # Build and Deploy to dev env.
-# Trigger with tag dev
-# Connected with repo environment 'dev'
-name: OpenShift Build and Deploy to Dev with OWSAP ZAP SCAN
+# Trigger with branch dev-env or manual dispatch
+
+# Example Scenarios
+#   Automatic Deployment:
+#     Someone pushes to dev-env
+#     Workflow triggers automatically
+#     github.event.inputs.ref is empty
+#     Code is checked out from github.ref (dev-env branch)
+#   Manual Deployment from Feature Branch:
+#     User manually triggers workflow
+#     Selects "feature/feature-name" in the ref input
+#     Code is checked out from "feature/feature-name"
+#     Deployment proceeds with that code
+
+name: OpenShift Deploy/Promotion to Dev with OWSAP ZAP SCAN
 
 on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual deployment'
+        required: true
+        default: 'Manual dev deployment'
+      ref:
+        description: 'Branch to deploy (default: dev-env)'
+        required: false
+        default: 'dev-env'
   push:
     branches:
-      - master
-    tags:
-      - dev
+      - dev-env
 
 env:
   CLUSTER: https://api.silver.devops.gov.bc.ca:6443
@@ -25,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Install OpenShift CLI
         uses: redhat-actions/openshift-tools-installer@v1
@@ -46,6 +68,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          fetch-depth: 0
 
       - name: Install OpenShift CLI
         uses: redhat-actions/openshift-tools-installer@v1
@@ -58,7 +83,9 @@ jobs:
           filters: |
             src:
               - 'openshift/**'
-          base: ${{ github.ref }}
+          #github.event.before is the SHA of the commit before the push event (only available during push events)
+          #HEAD~1 is the commit right before the latest commit on dev-env
+          base: ${{ github.event.before || 'HEAD~1' }}
       - name: Dry run - Dev
         env:
           OS_NAMESPACE_SUFFIX: dev
@@ -85,6 +112,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+          fetch-depth: 0
       - name: Install OpenShift CLI
         uses: redhat-actions/openshift-tools-installer@v1
         with:
@@ -95,7 +125,9 @@ jobs:
           filters: |
             src:
               - 'openshift/**'
-          base: ${{ github.ref}}
+          #github.event.before is the SHA of the commit before the push event (only available during push events)
+          #HEAD~1 is the commit right before the latest commit on dev-env
+          base: ${{ github.event.before || 'HEAD~1' }}
       - name: Apply Changes
         env:
           OS_NAMESPACE_SUFFIX: dev
@@ -115,6 +147,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
       - name: Install OpenShift CLI
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -60,13 +60,17 @@ jobs:
       - name: Verify OpenShift CLI installation
         run: oc version
 
+      - name: Get previous commit
+        id: get-prev-commit
+        run: echo "prev_commit=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
             src:
               - 'openshift/**'
-          base: 'HEAD~1' #The commit right before the latest commit on test-env
+          base: ${{ steps.get-prev-commit.outputs.prev_commit }} #The commit right before the current commit
 
       - name: Dry run - Test
         env:
@@ -96,13 +100,18 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
+
+      - name: Get previous commit
+        id: get-prev-commit
+        run: echo "prev_commit=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
             src:
               - 'openshift/**'
-          base: 'HEAD~1' #The commit right before the latest commit on test-env
+          base: ${{ steps.get-prev-commit.outputs.prev_commit }} #The commit right before the current commit
 
       - name: Apply Changes
         env:

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -1,12 +1,25 @@
 # Promotion to test env.
-# Trigger with tag push
-# Connected with repo environment 'test'
+# Trigger with manual dispatch only
+#
+# Deployment Process:
+#   User manually triggers workflow
+#   Provides ticket number in the reason field
+#   Workflow checks for OpenShift config changes
+#   Requires approval from environment protection rules
+#   Deploys the selected branch to test environment
 name: OpenShift Deploy/Promotion to Test
 
 on:
-  push:
-    tags:
-      - test
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for deployment to test (include ticket number)'
+        required: true
+        default: 'BCMOHAM-XXXXX: Test deployment'
+      ref:
+        description: 'Branch to deploy (default: test-env)'
+        required: false
+        default: 'test-env'
 
 env:
   CLUSTER: https://api.silver.devops.gov.bc.ca:6443
@@ -21,6 +34,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0
 
       - name: Cache OpenShift CLI
         id: cache-oc
@@ -50,7 +66,7 @@ jobs:
           filters: |
             src:
               - 'openshift/**'
-          base: 'refs/tags/test'
+          base: 'HEAD~1' #The commit right before the latest commit on test-env
 
       - name: Dry run - Test
         env:
@@ -77,13 +93,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0
       - uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
             src:
               - 'openshift/**'
-          base: 'refs/tags/test'
+          base: 'HEAD~1' #The commit right before the latest commit on test-env
+
       - name: Apply Changes
         env:
           OS_NAMESPACE_SUFFIX: test
@@ -103,6 +123,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Cache OpenShift CLI
         id: cache-oc

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+      - dev-env
+      - test-env
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
 
   pull_request:
     branches:
+      - dev-env
+      - test-env
       - master
 env:
   KEYCLOAK_LOCAL_USERNAME: 'test-admin'

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ server/*.pdf
 server/pdfs/*
 server/db/.migrate
 server/build
+server/scripts/output
 
 # Misc.
 Dockerrun.aws.json

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,13 @@ local-kc-arm-down:
 	@echo "Stopping local app container"
 	@docker-compose -f docker-compose.arm.test.yml down --remove-orphans
 
+# Local Scripts
+local-export-business-bceid-has:
+	@npx ts-node ./server/scripts/export-user-ha.ts
+
+local-export-all-users-has:
+	@npx ts-node ./server/scripts/export-user-ha.ts --all
+
 # Branch-based deployment commands
 deploy-to-dev: #deploy the code on current branch to DEV env via dev-env branch
 ifdef ticket

--- a/Makefile
+++ b/Makefile
@@ -162,27 +162,15 @@ local-kc-arm-down:
 	@echo "Stopping local app container"
 	@docker-compose -f docker-compose.arm.test.yml down --remove-orphans
 
-# Git Tagging Aliases
-
-tag-dev:
+# Branch-based deployment commands
+deploy-to-dev: #deploy the code on current branch to DEV env via dev-env branch
 ifdef ticket
-	@git tag -fa dev -m "Deploy $(ticket) to DEV env"
+	@echo "Deploying current branch to DEV with ticket $(ticket)"
+	@CURRENT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) && \
+	git push origin $$CURRENT_BRANCH:dev-env -f
 else
-	@echo -e '\nTicket name missing - Example :: make tag-dev ticket=HCAP-ABC \n'
-	@echo -e 'Falling Back to using branch name \n'
-	@git tag -fa dev -m "Deploy $(git rev-parse --abbrev-ref HEAD) to DEV env"
+	@echo -e '\nTicket name missing - Example :: make deploy-to-dev ticket=BCMOHAM-12345 \n'
 endif
-	@git push --force origin refs/tags/dev:refs/tags/dev
-
-tag-test:
-ifdef ticket
-	@git tag -fa test -m "Deploy $(ticket) to TEST env"
-else
-	@echo -e '\nTicket name missing - Example :: make tag-test ticket=HCAP-ABC \n'
-	@echo -e 'Falling Back to using branch name\n'
-	@git tag -fa test -m "Deploy $(git rev-parse --abbrev-ref HEAD) to TEST env"
-endif
-	@git push --force origin refs/tags/test:refs/tags/test
 
 tag-prod:
 ifdef ticket

--- a/client/src/utils/keycloak-util.js
+++ b/client/src/utils/keycloak-util.js
@@ -6,7 +6,7 @@
  * @param idpHint keycloak idp hint
  */
 export const createCustomLoginUrl = (kcInstance, route, idpHint) => {
-  const idps = ['idir', 'bceid_business'];
+  const idps = ['idir', 'bceid_business', 'moh_idp'];
 
   const loginUrl = kcInstance.createLoginUrl({
     idpHint,

--- a/server/keycloak.ts
+++ b/server/keycloak.ts
@@ -10,7 +10,7 @@ import { FEATURE_KEYCLOAK_MIGRATION } from './services/feature-flags';
 import { sanitize } from './utils';
 
 const MAX_RETRY = 5;
-const options = ['bceid', 'bceid_business', 'idir'];
+const options = ['bceid', 'bceid_business', 'idir', 'moh_idp'];
 
 const regionMap = {
   region_fraser: 'Fraser',

--- a/server/scripts/export-user-ha.ts
+++ b/server/scripts/export-user-ha.ts
@@ -1,0 +1,143 @@
+/* eslint-disable no-console, no-restricted-syntax, no-await-in-loop */
+import { PromisePool } from '@supercharge/promise-pool';
+import fs from 'fs';
+import path from 'path';
+import { AllRoles } from '../constants';
+import keycloak from '../keycloak';
+import { dbClient } from '../db';
+import { getUserSites } from '../services/user';
+import { EmployerSite } from '../services/employers';
+
+type UserWithHAArray = {
+  id: string;
+  username: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  roles: string[];
+  sites?: string[];
+  HA?: string[];
+};
+
+const HA_VALUES = ['Fraser', 'Interior', 'Vancouver Island', 'Northern', 'Vancouver Coastal'];
+
+// Function to cache BCeID user roles and sites
+export const exportUserHAs = async (includeAll: boolean) => {
+  if (includeAll) {
+    console.info('Extracting all users');
+  }
+
+  const users = [];
+
+  const keycloakUsers: { id: string }[] = await keycloak.getUsers(AllRoles);
+  await PromisePool.for(keycloakUsers)
+    .withConcurrency(10)
+    .process(async (user) => {
+      users.push({ ...user, roles: await keycloak.getUserRoles(user.id) });
+    });
+
+  if (users.length > 0) {
+    await dbClient.connect();
+
+    // Check if the database client is initialized correctly
+    if (!('db' in dbClient) || !dbClient.db) throw new Error('Database failed to initialize!');
+
+    // For all users with BCeID roles, get their sites and health authorities
+    const usersWithSites: UserWithHAArray[] = await Promise.all(
+      users.map(async (user) => {
+        // Check if the user has a business BCeID or if we are including all users
+        if (!user.username.includes('@bceid_business') && !includeAll) {
+          return null;
+        }
+        // Get all sites for the user
+        const userSites = await getUserSites(user.id);
+        // Get the HAs for those sites
+        const HAs: string[] = userSites.map((site: EmployerSite) => site.healthAuthority);
+        if (user.roles.includes('ministry_of_health')) {
+          // If the user is a Ministry of Health user, they have access to all HAs
+          return {
+            ...user,
+            sites: userSites.map((site: EmployerSite) => site.siteId),
+            HA: HA_VALUES,
+          };
+        }
+        return {
+          ...user,
+          sites: userSites.map((site: EmployerSite) => site.siteId),
+          HA: [...new Set(HAs)],
+        };
+      })
+    ).then((results) => results.filter((user) => user !== null));
+
+    console.info(`Found ${usersWithSites.length} users with sites`);
+
+    const finalUserList: {
+      id: string;
+      username: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      roles: string[];
+      sites?: string[];
+      HA?: string;
+    }[] = [];
+
+    usersWithSites.forEach((user) => {
+      if (user.HA.length === 0) {
+        finalUserList.push({
+          id: user.id,
+          username: user.username,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          roles: user.roles,
+          sites: user.sites,
+          HA: '',
+        });
+        return;
+      }
+      // Generate a row for each health authority the user has access to
+      // This allows users with access to multiple HAs to have multiple rows in the CSV
+      user.HA.forEach((ha) => {
+        finalUserList.push({
+          id: user.id,
+          username: user.username,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          roles: user.roles,
+          sites: user.sites,
+          HA: ha,
+        });
+      });
+    });
+
+    // Create output directory if it doesn't exist
+    if (!fs.existsSync(path.join(__dirname, 'output'))) {
+      fs.mkdirSync(path.join(__dirname, 'output'), { recursive: true });
+    }
+    // Write to CSV file
+    // Format: username,firstName,lastName,email,HA
+    const csv = finalUserList
+      .map((user) => `${user.username},${user.firstName},${user.lastName},${user.email},${user.HA}`)
+      .join('\n');
+    await fs.promises
+      .writeFile(path.join(__dirname, 'output/business-bceid-users.csv'), csv)
+      .then(() => {
+        console.info(
+          'Business BCeID users cached successfully to ./server/scripts/output/business-bceid-users.csv'
+        );
+      })
+      .catch((err) => {
+        console.error('Error writing to ./server/scripts/output/business-bceid-users.csv:', err);
+      });
+  }
+};
+
+(async function main() {
+  if (require.main === module) {
+    const includeAll = process.argv.includes('--all');
+    await keycloak.buildInternalIdMap();
+    await exportUserHAs(includeAll);
+  }
+})();

--- a/server/services/reporting/ros-entries.ts
+++ b/server/services/reporting/ros-entries.ts
@@ -18,21 +18,14 @@ interface RosEntry {
       healthAuthority: string;
     };
   };
-  participantStatusJoin: {
-    status: string;
-    current: boolean;
-    data: {
-      type: string;
-      confirmed: boolean;
-      remainingInSectorOrRoleOrAnother: string;
-    };
-  };
   data: {
     date: Date | string;
     startDate: Date | string;
     positionType?: string;
     employmentType?: string;
   };
+  rosCompleted: string;
+  remainingInSectorOrRoleOrAnother: string;
 }
 
 export const mapRosEntries = (rosEntries: RosEntry[]) =>
@@ -48,11 +41,37 @@ export const mapRosEntries = (rosEntries: RosEntry[]) =>
     positionType: entry.data?.positionType || 'Unknown',
     healthRegion: entry.siteJoin?.body?.healthAuthority,
     employmentType: entry.data?.employmentType || 'Unknown',
-    rosCompleted:
-      entry.participantStatusJoin?.status === 'archived' &&
-      entry.participantStatusJoin?.data?.type === 'rosComplete' &&
-      entry.participantStatusJoin?.current &&
-      entry.participantStatusJoin?.data?.confirmed,
-    remainingInSectorOrRoleOrAnother:
-      entry.participantStatusJoin?.data?.remainingInSectorOrRoleOrAnother ?? 'Unknown',
+    rosCompleted: entry.rosCompleted,
+    remainingInSectorOrRoleOrAnother: entry.remainingInSectorOrRoleOrAnother,
   }));
+
+//A helper for the DISTINCT logic
+export const applyDistinct = (entries) => {
+  const uniqueEntries = [];
+  const seenRecords = new Set();
+
+  entries.forEach((entry) => {
+    const distinctKey = JSON.stringify({
+      participantId: entry.participantId,
+      firstName: entry.firstName,
+      lastName: entry.lastName,
+      program: entry.program,
+      startDate: entry.startDate,
+      endDate: entry.endDate,
+      siteStartDate: entry.siteStartDate,
+      positionType: entry.positionType,
+      employmentType: entry.employmentType,
+      site: entry.site,
+      healthRegion: entry.healthRegion,
+      rosCompleted: entry.rosCompleted,
+      remainingInSectorOrRoleOrAnother: entry.remainingInSectorOrRoleOrAnother,
+    });
+
+    if (!seenRecords.has(distinctKey)) {
+      seenRecords.add(distinctKey);
+      uniqueEntries.push(entry);
+    }
+  });
+
+  return uniqueEntries;
+};


### PR DESCRIPTION
This PR includes the following updates:


1. New Branches Added:
    dev-env and test-env branches have been introduced.

2. Updated GitHub Actions Behavior:
Format Check
    Trigger: Runs on PRs that are opened, synchronized, or reopened to any branch.
    Analysis: Evaluates the current feature branch without comparing against any other branch.

Sonar Check
    PR Check: Runs on PRs opened, synchronized, or reopened to any branch. Compares the current feature branch against the target branch (e.g., dev-env).
    Push Check: Runs on direct pushes to master, dev-env, and test-env branches. Analyzes the target branch directly.

Cypress/Jest Tests
    Tag Trigger: Runs when a Git tag named cypress is pushed, analyzing the current feature branch.
    PR Trigger: Also runs on PRs opened, synchronized, or reopened to master, dev-env, or test-env only, analyzing the current feature branch.

3. Deployment Process:
Development Environment Deployment can be triggered in the following ways:
    By creating and merging a PR into the dev-env branch.
    Manually triggering the “OpenShift Deploy/Promotion to Dev” workflow from GitHub Actions.
    Using the Makefile command for quick, PR-free deployment.

Test Environment Deployment can only be triggered manually from the GitHub Actions tab by clicking the “Run workflow” button. This is required as test deployments depend on RFCs/approvals.

4. ROS Report:
Updated to reflect changes based on the revised query.
```
SELECT DISTINCT
    ross.participant_id AS "Participant ID",
    p.body->>'firstName' AS "First Name",
    p.body->>'lastName' AS "Last Name",
    p.body->>'program' AS "Pathway",
    TO_DATE(ross.data->>'date', 'YYYY-MM-DD') AS "ROS Start Date",
    CASE 
        WHEN EXTRACT(month FROM TO_DATE(ross.data->>'date', 'YYYY-MM-DD')) = 2 
         AND EXTRACT(day FROM TO_DATE(ross.data->>'date', 'YYYY-MM-DD')) = 29
        THEN TO_DATE(ross.data->>'date', 'YYYY-MM-DD') + INTERVAL '1 year' + INTERVAL '1 day'
        ELSE TO_DATE(ross.data->>'date', 'YYYY-MM-DD') + INTERVAL '1 year'
    END AS "ROS End Date",
    TO_DATE(COALESCE(ross.data->>'startDate', ross.data->>'date'), 'YYYY-MM-DD') AS "Start Date at a Site",
    COALESCE(ross.data->>'positionType', 'Unknown') AS "Position Type",
    COALESCE(ross.data->>'employmentType', 'Unknown') AS "Specific Position Type",
    es.body->>'siteName' AS "Site of ROS",
    es.body->>'healthAuthority' AS "Health Region",
    CASE 
        WHEN EXISTS (
            SELECT 1 
            FROM participants_status ps_sub
            WHERE ps_sub.participant_id = ross.participant_id
              AND ps_sub.status = 'archived'
              AND ps_sub.data->>'type' = 'rosComplete'
              AND ps_sub.data->>'confirmed' = 'true'
              AND ps_sub.current = true
        ) THEN 'TRUE'
        ELSE 'FALSE'
    END AS "Return of Service Completed",
    COALESCE(
        (
            SELECT ps_sub.data->>'remainingInSectorOrRoleOrAnother'
            FROM participants_status ps_sub
            WHERE ps_sub.participant_id = ross.participant_id
              AND ps_sub.status = 'archived'
              AND ps_sub.data->>'type' = 'rosComplete'
              AND ps_sub.data->>'confirmed' = 'true'
              AND ps_sub.current = true
            LIMIT 1
        ),
        'Unknown'
    ) AS "Intends to Continue as HCA/MHAW Following ROS Completion"
FROM
    return_of_service_status ross
LEFT JOIN participants p ON
    ross.participant_id = p.id
LEFT JOIN employer_sites es ON
    ross.site_id = es.id;
```

5. Enabled KeyCloak login options on both dev and test environments to support internal and UAT testing with new test accounts