### PR TITLE
BCMOHAM-26040: Adding script for extracting Business BCeID users' HA mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,14 @@ local-kc-arm-down:
 	@echo "Stopping local app container"
 	@docker-compose -f docker-compose.arm.test.yml down --remove-orphans
 
+
+# Local Scripts
+extract-bceid-has:
+	@npx ts-node ./server/scripts/export-user-ha.ts
+
+extract-all-users-has:
+	@npx ts-node ./server/scripts/export-user-ha.ts --all
+
 # Git Tagging Aliases
 
 tag-dev:

--- a/server/scripts/export-user-ha.ts
+++ b/server/scripts/export-user-ha.ts
@@ -1,0 +1,130 @@
+/* eslint-disable no-console, no-restricted-syntax, no-await-in-loop */
+import { PromisePool } from '@supercharge/promise-pool';
+import fs from 'fs';
+import { AllRoles } from '../constants';
+import keycloak from '../keycloak';
+import { dbClient } from '../db';
+import { getUserSites } from '../services/user';
+import { EmployerSite } from '../services/employers';
+
+type UserWithHAArray = {
+  id: string;
+  username: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  roles: string[];
+  sites?: string[];
+  HA?: string[];
+};
+
+const HA_VALUES = ['Fraser', 'Interior', 'Vancouver Island', 'Northern', 'Vancouver Coastal'];
+
+export const cacheUserBCeIDRoles = async (includeAll: boolean) => {
+  if (includeAll) {
+    console.info('Extracting all users');
+  }
+
+  const users = [];
+
+  const keycloakUsers: { id: string }[] = await keycloak.getUsers(AllRoles);
+  await PromisePool.for(keycloakUsers)
+    .withConcurrency(10)
+    .process(async (user) => {
+      users.push({ ...user, roles: await keycloak.getUserRoles(user.id) });
+    });
+
+  if (users.length > 0) {
+    await dbClient.connect();
+
+    if (!('db' in dbClient) || !dbClient.db) throw new Error('Database failed to initialize!');
+
+    const usersWithSites: UserWithHAArray[] = await Promise.all(
+      users.map(async (user) => {
+        if (!user.username.includes('bceid') && !includeAll) {
+          return null;
+        }
+        const userSites = await getUserSites(user.id);
+        const HAs: string[] = userSites.map((site: EmployerSite) => site.healthAuthority);
+        if (user.roles.includes('ministry_of_health')) {
+          // If the user is a Ministry of Health user, they have access to all HAs
+          return {
+            ...user,
+            sites: userSites.map((site: EmployerSite) => site.siteId),
+            HA: HA_VALUES,
+          };
+        }
+        return {
+          ...user,
+          sites: userSites.map((site: EmployerSite) => site.siteId),
+          HA: [...new Set(HAs)],
+        };
+      })
+    ).then((results) => results.filter((user) => user !== null));
+
+    console.info(`Found ${usersWithSites.length} users with sites`);
+
+    const finalUserList: {
+      id: string;
+      username: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      roles: string[];
+      sites?: string[];
+      HA?: string;
+    }[] = [];
+
+    usersWithSites.forEach((user) => {
+      if (user.HA.length === 0) {
+        finalUserList.push({
+          id: user.id,
+          username: user.username,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          roles: user.roles,
+          sites: user.sites,
+          HA: '',
+        });
+        return;
+      }
+      user.HA.forEach((ha) => {
+        finalUserList.push({
+          id: user.id,
+          username: user.username,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          roles: user.roles,
+          sites: user.sites,
+          HA: ha,
+        });
+      });
+    });
+
+    // Write to CSV file
+    // Format: id,roles
+    const csv = finalUserList
+      .map((user) => `${user.username},${user.firstName},${user.lastName},${user.email},${user.HA}`)
+      .join('\n');
+    await fs.promises
+      .writeFile('./server/build/bceid-users.csv', csv)
+      .then(() => {
+        console.info('BCeID users cached successfully to ./server/build/bceid-users.csv');
+      })
+      .catch((err) => {
+        console.error('Error writing to ./server/build/bceid-users.csv:', err);
+      });
+  }
+
+  // find user's HA association
+};
+
+(async function main() {
+  if (require.main === module) {
+    const includeAll = process.argv.includes('--all');
+    await keycloak.buildInternalIdMap();
+    await cacheUserBCeIDRoles(includeAll);
+  }
+})();


### PR DESCRIPTION
Description of changes:
- Added a script called export-user-ha.ts under server/scripts/export-user-ha.ts

How it works:
1. Get all users from Keycloak
2. Get their roles.
3. Use `getUserSites` to get all user's associated sites and for each site get their healthAuthority property.
4. If they have `ministry_of_health` role then grant all HAs to them.
5. Generate csv in /server/build/bceid-users.csv to avoid being accidentally committed to GitHub. The CSV is in the following format:
`user@bceid_business,Firstname,Lastname,user@email.ca,Interior`
each line represents a user-HA maps. A user can have many user-HA mappings.

How to run:
- Connect to the appropriate environment, ie. if extracting from, DEV, port forward the database to local and replace the following envs with the DEV database credentials:
```
POSTGRES_HOST=
POSTGRES_PORT=
POSTGRES_DB=
POSTGRES_USER=
POSTGRES_PASSWORD=
```
Replace the following with DEV Keycloak credentials:
```
KEYCLOAK_AUTH_URL=
KEYCLOAK_API_CLIENTID=
KEYCLOAK_FE_CLIENTID=
KEYCLOAK_API_SECRET=
KEYCLOAK_SA_USERNAME=
KEYCLOAK_SA_PASSWORD=
KEYCLOAK_UMS_API_URL=
```
- Then run ```make extract-bceid-has``` to extracting only BCeID, since DEV and TEST does not have many BCeID users and mappings, I've included ```make extract-all-users-has``` which will extract all users and their associated HAs.