### PR TITLE
BCMOHAM-26040: Adding new HA ID login option into backend and frontend code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,13 @@ archive-withdrawn-participants:
 	@docker exec $(APP_NAME)-server npm run archive-withdrawn-participants
 
 # Local Development
+local-watch-server:
+	@echo "Running local app in watch mode"
+	@npm run watch --prefix server
+
+local-watch-client:
+	@echo "Running local app in watch mode"
+	@npm run start --prefix client
 
 local-build:
 	@echo "Building local app image"

--- a/client/src/pages/public/EmployerLogin.js
+++ b/client/src/pages/public/EmployerLogin.js
@@ -117,7 +117,8 @@ export default () => {
             <Typography variant='h2'>Login</Typography>
             <Box my={2}>
               <Typography variant='body1' className={classes.loginText}>
-                Log in with your IDIR or BCeID to the Health Career Access Program Employer Portal.
+                Log in with your IDIR, HA ID or BCeID to the Health Career Access Program
+                EmployerAdd commentMore actions Portal.
               </Typography>
             </Box>
             <Box>

--- a/client/src/utils/keycloak-util.js
+++ b/client/src/utils/keycloak-util.js
@@ -6,7 +6,7 @@
  * @param idpHint keycloak idp hint
  */
 export const createCustomLoginUrl = (kcInstance, route, idpHint) => {
-  const idps = ['idir', 'bceid_business', 'moh_idp'];
+  const idps = ['idir', 'bceid_business', 'moh_idp', 'phsa'];
 
   const loginUrl = kcInstance.createLoginUrl({
     idpHint,

--- a/server/keycloak.ts
+++ b/server/keycloak.ts
@@ -10,7 +10,7 @@ import { FEATURE_KEYCLOAK_MIGRATION } from './services/feature-flags';
 import { sanitize } from './utils';
 
 const MAX_RETRY = 5;
-const options = ['bceid', 'bceid_business', 'idir', 'moh_idp'];
+const options = ['bceid', 'bceid_business', 'idir', 'moh_idp', 'phsa'];
 
 const regionMap = {
   region_fraser: 'Fraser',
@@ -114,6 +114,7 @@ class Keycloak {
       ['dev', 'local'].includes(process.env.APP_ENV?.toLowerCase());
 
     if (isDevEnvironment) {
+      // eslint-disable-next-line global-require
       const https = require('https');
       this.axiosInstance = axios.create({
         baseURL: this.apiUrl,
@@ -170,7 +171,7 @@ class Keycloak {
         // if no email, user should not be in user_migration table
         const existingUser = await getUserMigration(username, email);
 
-        const type = username.split('@')[1];
+        const type = username.split('@').pop();
         const shouldSetRoles = !content?.resource_access && !existingUser && options.includes(type);
 
         if (shouldSetRoles) {


### PR DESCRIPTION
Description of changes:
- Added local watch commands, which will run the app and hot reload on changes, this is good for developing locally without having to rebuild image every time.
- Updated IDP lists and wordings to reflect HA ID.
- idp type check was done through splitting username by "@" and using the second element, in Keycloak it's possible a user can have multiple "@" in their username, so this idp type parsing code would fail. Code update to always used the last element which is confirmed by Keycloak team to always be the identifier