### PR TITLE
Openshift CLI install method update and cronjob management

### DIFF
--- a/.github/workflows/promote-dev.yml
+++ b/.github/workflows/promote-dev.yml
@@ -98,6 +98,7 @@ jobs:
           oc login --token="$SA_TOKEN" --server="$CLUSTER"
           cd "$GITHUB_WORKSPACE"
           make server-config-test
+          make cron-job-test
   confirm:
     name: Get Confirmation Dev Deployment
     runs-on: ubuntu-latest
@@ -145,6 +146,7 @@ jobs:
           oc login --token="$SA_TOKEN" --server="$CLUSTER"
           cd "$GITHUB_WORKSPACE"
           make server-config
+          make cron-job
   build:
     name: OpenShift Build & Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -29,24 +29,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Cache OpenShift CLI
-        id: cache-oc
-        uses: actions/cache@v3
-        with:
-          path: /usr/local/bin/oc
-          key: ${{ runner.os }}-oc
-
       - name: Install OpenShift CLI
-        if: steps.cache-oc.outputs.cache-hit != 'true'
-        run: |
-          OC_VERSION=3.11.0
-          sudo apt-get update
-          sudo apt-get -y install wget
-          wget --quiet -O oc.tar.gz "https://github.com/openshift/origin/releases/download/v${OC_VERSION}/openshift-origin-client-tools-v${OC_VERSION}-0cbc58b-linux-64bit.tar.gz"
-          FILE=$(tar -tf oc.tar.gz | grep '/oc$')
-          tar -zxf oc.tar.gz "$FILE"
-          sudo mv "$FILE" /usr/local/bin/oc
-          rm -rf oc.tar.gz openshift-origin-client-tools-v*
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
 
       - name: Checking Deployment Config changes
         uses: dorny/paths-filter@v2
@@ -65,7 +51,9 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           make server-config-test
+          make cron-job-test
           make server-config
+          make cron-job
 
       - name: Promote
         run: |

--- a/.github/workflows/promote-test.yml
+++ b/.github/workflows/promote-test.yml
@@ -38,27 +38,10 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
 
-      - name: Cache OpenShift CLI
-        id: cache-oc
-        uses: actions/cache@v3
-        with:
-          path: /usr/local/bin/oc
-          key: ${{ runner.os }}-oc
-
       - name: Install OpenShift CLI
-        if: steps.cache-oc.outputs.cache-hit != 'true'
-        run: |
-          OC_VERSION=3.11.0
-          sudo apt-get update
-          sudo apt-get -y install wget
-          wget --quiet -O oc.tar.gz "https://github.com/openshift/origin/releases/download/v${OC_VERSION}/openshift-origin-client-tools-v${OC_VERSION}-0cbc58b-linux-64bit.tar.gz"
-          FILE=$(tar -tf oc.tar.gz | grep '/oc$')
-          tar -zxf oc.tar.gz "$FILE"
-          sudo mv "$FILE" /usr/local/bin/oc
-          rm -rf oc.tar.gz openshift-origin-client-tools-v*
-
-      - name: Verify OpenShift CLI installation
-        run: oc version
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
 
       - name: Get previous commit
         id: get-prev-commit
@@ -80,6 +63,7 @@ jobs:
           oc login --token="$SA_TOKEN" --server="$CLUSTER"
           cd "$GITHUB_WORKSPACE"
           make server-config-test
+          make cron-job-test
   confirm:
     name: Get Confirmation For Test Deployment
     runs-on: ubuntu-latest
@@ -113,6 +97,11 @@ jobs:
               - 'openshift/**'
           base: ${{ steps.get-prev-commit.outputs.prev_commit }} #The commit right before the current commit
 
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       - name: Apply Changes
         env:
           OS_NAMESPACE_SUFFIX: test
@@ -121,6 +110,7 @@ jobs:
           oc login --token="$SA_TOKEN" --server="$CLUSTER"
           cd "$GITHUB_WORKSPACE"
           make server-config
+          make cron-job
   promoteTest:
     name: OpenShift Promotion
     runs-on: ubuntu-latest
@@ -135,24 +125,10 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
 
-      - name: Cache OpenShift CLI
-        id: cache-oc
-        uses: actions/cache@v3
-        with:
-          path: /usr/local/bin/oc
-          key: ${{ runner.os }}-oc
-
       - name: Install OpenShift CLI
-        if: steps.cache-oc.outputs.cache-hit != 'true'
-        run: |
-          OC_VERSION=3.11.0
-          sudo apt-get update
-          sudo apt-get -y install wget
-          wget --quiet -O oc.tar.gz "https://github.com/openshift/origin/releases/download/v${OC_VERSION}/openshift-origin-client-tools-v${OC_VERSION}-0cbc58b-linux-64bit.tar.gz"
-          FILE=$(tar -tf oc.tar.gz | grep '/oc$')
-          tar -zxf oc.tar.gz "$FILE"
-          sudo mv "$FILE" /usr/local/bin/oc
-          rm -rf oc.tar.gz openshift-origin-client-tools-v*
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
 
       - name: Promote
         run: |

--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,10 @@ service-pod:
 	@node .pipeline/service-config.js | xargs -I{} oc process -f openshift/service.pod.yml -p APP_NAME=$(APP_NAME) -p SERVICE_CONFIG={} -p IMAGE_TAG=$(tag) -p IMAGE_NAMESPACE=$(TOOLS_NAMESPACE) | oc apply -n $(TARGET_NAMESPACE) -f -
 
 # Cron Job
+cron-job-test:
+	@oc -n $(TARGET_NAMESPACE) process -f openshift/in-progres-stale-clean.cronjob.yml -p APP_NAME=$(APP_NAME) -p IMAGE_TAG=$(OS_NAMESPACE_SUFFIX) -p IMAGE_NAMESPACE=$(TOOLS_NAMESPACE) | oc apply -n $(TARGET_NAMESPACE) -f - --dry-run=true
+	@oc -n $(TARGET_NAMESPACE) process -f openshift/open-expired-clean.cronjob.yml -p APP_NAME=$(APP_NAME) -p IMAGE_TAG=$(OS_NAMESPACE_SUFFIX) -p IMAGE_NAMESPACE=$(TOOLS_NAMESPACE) | oc apply -n $(TARGET_NAMESPACE) -f - --dry-run=true
+
 cron-job:
 	@oc -n $(TARGET_NAMESPACE) process -f openshift/in-progres-stale-clean.cronjob.yml -p APP_NAME=$(APP_NAME) -p IMAGE_TAG=$(OS_NAMESPACE_SUFFIX) -p IMAGE_NAMESPACE=$(TOOLS_NAMESPACE) | oc apply -n $(TARGET_NAMESPACE) -f -
 	@oc -n $(TARGET_NAMESPACE) process -f openshift/open-expired-clean.cronjob.yml -p APP_NAME=$(APP_NAME) -p IMAGE_TAG=$(OS_NAMESPACE_SUFFIX) -p IMAGE_NAMESPACE=$(TOOLS_NAMESPACE) | oc apply -n $(TARGET_NAMESPACE) -f -


### PR DESCRIPTION
Summary of Changes:

1. Fixed OpenShift CLI Installation on Test&Prod deployment workflow files to match the existing dev workflow pattern
2. Added Cronjob management to all deployment workflows (promote-dev.yml, promote-test.yml, promote-prod.yml), cronjobs now automatically update when openshift/** files change