### PR TITLE
BCMOHAM-26040: Domain migration for DEV and TEST

### DIFF
--- a/.github/workflows/promote-dev.yml
+++ b/.github/workflows/promote-dev.yml
@@ -36,7 +36,7 @@ env:
   SA_TOKEN: ${{ secrets.SA_TOKEN_CONFIG }}
   PROJECT: hcap
   HEALTH_CHECK_URL: https://hcap-server-f047a2-dev.apps.silver.devops.gov.bc.ca/api/v1/version
-  DEV_URL: https://hcapemployers.dev.freshworks.club
+  DEV_URL: https://dev.hcapemployers.gov.bc.ca
 
 jobs:
   audit:

--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -1,7 +1,7 @@
 export default Object.freeze({
   // Hostname
-  ParticipantHostname: RegExp('^(www\\.)?hcapparticipants\\..*'),
-  EmployerHostname: RegExp('^(www\\.)?hcapemployers\\..*'),
+  ParticipantHostname: RegExp('^(www\\.)?((?:dev|test)\\.)?hcapparticipants\\..*'),
+  EmployerHostname: RegExp('^(www\\.)?((?:dev|test)\\.)?hcapemployers\\..*'),
 
   // Public routes
   Login: '/login',

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -110,30 +110,6 @@ This command will:
 
 ## Dev/Test Certificate Creation
 
-Currently, the domains use a manually created lets encrypt certificate which is only valid for 90 days, this can easily be switched to a longer lived certificate from your favorite provider. Note: the foundrybc.ca certificate is valid for 1 year.
+Currently, the domain is a custom domain ordered from IMS. Please follow the renewal process outlined in [Request a domain renewal or transfer](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/digital-delivery/web-property-process) to renew the cert.
 
-### Install Certbot
-
-```
-brew install certbot
-```
-
-### Certificate Generation
-
-```
-sudo certbot certonly --manual
-```
-
-Will prompt you for domain you want to secure. You can use a wildcard to cover participants and employers:
-
-`*.<env>.freshworks.club`
-
-Once provided, certbot will ask you to perform DNS verification for the domains above. The domain is managed by Azure DNS. Follow the instructions provided by certbot.
-
-This will generate a couple of pem files (your new certificate)
-
-### Adding certificates to Openshift Routes
-
-Add the contents of `dev.freshworks.club/fullchain.pem` to the routes `hcap-participants` and `hcap-employers` at `spec.tls.certificate` and do the same for the contents of `dev.freshworks.club/privkey.pem` at `spec.tls.key`.
-
-Click save and the certificates should be updated.
+Dev and Test domains are bundled under the same cert, as in all dev.-prefixed URLs are ordered under the same CSR as Common Name (CN) and Subject Alternative Names (SANs). You only need to renew 1 cert for DEV and 1 cert for TEST.

--- a/load/employerStaticFiles.js
+++ b/load/employerStaticFiles.js
@@ -25,7 +25,7 @@ export let options = {
 
 export default function () {
   let failed = false;
-  const indexRes = http.get(`https://hcapemployers.${__ENV.OS_NAMESPACE_SUFFIX}.freshworks.club/`);
+  const indexRes = http.get(`https://${__ENV.OS_NAMESPACE_SUFFIX}.hcapemployers.gov.bc.ca/`);
 
   if (indexRes.status != 200) {
     failed = true;
@@ -36,7 +36,7 @@ export default function () {
   for (const script of js) {
     const scriptPath = script.attr('src');
     const jsRes = http.get(
-      `https://hcapemployers.${__ENV.OS_NAMESPACE_SUFFIX}.freshworks.club${scriptPath}`
+      `https://${__ENV.OS_NAMESPACE_SUFFIX}.hcapemployers.gov.bc.ca${scriptPath}`,
     );
     if (jsRes.status != 200) {
       failed = true;

--- a/load/participantLogin.js
+++ b/load/participantLogin.js
@@ -12,8 +12,8 @@ const KC_USER = {
 };
 
 const GET_ROUTES = [
-  `https://hcapparticipants.${__ENV.OS_NAMESPACE_SUFFIX}.freshworks.club/api/v1/user`,
-  `https://hcapparticipants.${__ENV.OS_NAMESPACE_SUFFIX}.freshworks.club/api/v1/participant-user/participants`,
+  `https://${__ENV.OS_NAMESPACE_SUFFIX}.hcapparticipants.gov.bc.ca/api/v1/user`,
+  `https://${__ENV.OS_NAMESPACE_SUFFIX}.hcapparticipants.gov.bc.ca/api/v1/participant-user/participants`,
 ];
 
 const authUrl = `https://${__ENV.OS_NAMESPACE_SUFFIX}.oidc.gov.bc.ca/auth/realms/${__ENV.KEYCLOAK_REALM}/protocol/openid-connect/token`;

--- a/openshift/ches.prep.yml
+++ b/openshift/ches.prep.yml
@@ -20,7 +20,7 @@ parameters:
     value: https://dev.oidc.gov.bc.ca/auth/realms/jbd6rnxw/protocol/openid-connect/token
   - name: CLIENT_URL
     required: true
-    value: https://hcapparticipants.dev.freshworks.club
+    value: https://dev.hcapparticipants.gov.bc.ca
 objects:
   - kind: Secret
     apiVersion: v1


### PR DESCRIPTION
Description of changes:
- updating Regex to support the following domains while not breaking current domains:
  - https://dev.hcapparticipants.gov.bc.ca
  - https://dev.hcapemployers.gov.bc.ca
  - https://test.hcapparticipants.gov.bc.ca
  - https://test.hcapemployers.gov.bc.ca