### PR TITLE
fix the email validation on participant info edit pop-up

### DIFF
--- a/client/src/components/modal-forms/EditParticipantForm.js
+++ b/client/src/components/modal-forms/EditParticipantForm.js
@@ -80,7 +80,7 @@ export const EditParticipantForm = ({ initialValues, onClose, submissionCallback
               type='email'
             />
             <Field
-              test-id={'editParticipantEmail'}
+              test-id={'editParticipantPostalCode'}
               name='postalCode'
               component={RenderTextField}
               label='* Postal Code'

--- a/client/src/constants/validation/schema/index.js
+++ b/client/src/constants/validation/schema/index.js
@@ -33,5 +33,11 @@ export const genericConfirm = yup.object().shape({
 });
 
 export const EmailSubmissionSchema = yup.object().shape({
-  email: yup.string().email().required('Required'),
+  email: yup
+    .string()
+    .required('Required')
+    .matches(
+      /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+      'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+    ),
 });

--- a/client/src/constants/validation/schema/schema-create-site.js
+++ b/client/src/constants/validation/schema/schema-create-site.js
@@ -21,7 +21,13 @@ export const CreateSiteSchema = yup.object().shape({
   operatorName: yup.string().required(errorMessage),
   operatorContactFirstName: yup.string().required(errorMessage),
   operatorContactLastName: yup.string().required(errorMessage),
-  operatorEmail: yup.string().required(errorMessage).email('Invalid email address'),
+  operatorEmail: yup
+    .string()
+    .required(errorMessage)
+    .matches(
+      /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+      'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+    ),
   operatorPhone: yup
     .string()
     .required(errorMessage)
@@ -32,5 +38,11 @@ export const CreateSiteSchema = yup.object().shape({
     .string()
     .required(errorMessage)
     .matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
-  siteContactEmail: yup.string().required(errorMessage).email('Invalid email address'),
+  siteContactEmail: yup
+    .string()
+    .required(errorMessage)
+    .matches(
+      /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+      'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+    ),
 });

--- a/client/src/constants/validation/schema/schema-edit-participant-form.js
+++ b/client/src/constants/validation/schema/schema-edit-participant-form.js
@@ -2,11 +2,11 @@ import * as yup from 'yup';
 import { errorMessage } from '../functions';
 
 export const EditParticipantFormSchema = yup.object().shape({
-  firstName: yup.string().required(errorMessage),
-  lastName: yup.string().required(errorMessage),
+  firstName: yup.string().required(errorMessage({ path: 'firstName' })),
+  lastName: yup.string().required(errorMessage({ path: 'lastName' })),
   phoneNumber: yup
     .string()
-    .required(errorMessage)
+    .required(errorMessage({ path: 'phoneNumber' }))
     .matches(/^\d{10}$/, 'Phone number must be provided as 10 digits'),
   postalCode: yup
     .string()
@@ -15,6 +15,13 @@ export const EditParticipantFormSchema = yup.object().shape({
       return v !== undefined && v !== '' && v !== null;
     })
     .matches(/^[A-Z]\d[A-Z]\s?\d[A-Z]\d$/, 'Invalid postal code'),
-  emailAddress: yup.string().required(errorMessage).email('Invalid email address'),
+  emailAddress: yup
+    .string()
+    .required(errorMessage({ path: 'emailAddress' }))
+    .matches(
+      /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+      'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+    ),
+  educationalRequirements: yup.string().required(errorMessage({ path: 'educationalRequirements' })),
   interested: yup.string().nullable(),
 });

--- a/client/src/constants/validation/schema/schema-edit-site.js
+++ b/client/src/constants/validation/schema/schema-edit-site.js
@@ -9,7 +9,13 @@ export const EditSiteSchema = yup.object().shape({
     .string()
     .required(errorMessage)
     .matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
-  siteContactEmail: yup.string().required(errorMessage).email('Invalid email address'),
+  siteContactEmail: yup
+    .string()
+    .required(errorMessage)
+    .matches(
+      /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+      'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+    ),
   siteName: yup
     .string()
     .required(errorMessage)
@@ -29,5 +35,11 @@ export const EditSiteSchema = yup.object().shape({
     .string()
     .required(errorMessage)
     .matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
-  operatorEmail: yup.string().required(errorMessage).email('Invalid email address'),
+  operatorEmail: yup
+    .string()
+    .required(errorMessage)
+    .matches(
+      /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+      'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+    ),
 });

--- a/client/src/constants/validation/schema/schema-edit-user-migration-user.js
+++ b/client/src/constants/validation/schema/schema-edit-user-migration-user.js
@@ -3,5 +3,11 @@ import { errorMessage } from '../functions';
 
 export const EditUserMigrationUserFormSchema = yup.object().shape({
   username: yup.string().required(errorMessage),
-  emailAddress: yup.string().required(errorMessage).email('Invalid email address'),
+  emailAddress: yup
+    .string()
+    .required(errorMessage)
+    .matches(
+      /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+      'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+    ),
 });

--- a/client/src/constants/validation/schema/schema-employer-form.js
+++ b/client/src/constants/validation/schema/schema-employer-form.js
@@ -12,7 +12,13 @@ export const EmployerFormSchema = yup
     operatorName: yup.string().nullable(errorMessage),
     operatorContactFirstName: yup.string().nullable(errorMessage),
     operatorContactLastName: yup.string().nullable(errorMessage),
-    operatorEmail: yup.string().nullable(errorMessage).email('Invalid email address'),
+    operatorEmail: yup
+      .string()
+      .nullable(errorMessage)
+      .matches(
+        /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+        'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+      ),
     operatorPhone: yup
       .string()
       .nullable(errorMessage)
@@ -39,7 +45,13 @@ export const EmployerFormSchema = yup
       .string()
       .nullable(errorMessage)
       .matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
-    emailAddress: yup.string().nullable(errorMessage).email('Invalid email address'),
+    emailAddress: yup
+      .string()
+      .nullable(errorMessage)
+      .matches(
+        /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+        'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+      ),
 
     // Site type and size info
     siteType: yup

--- a/client/src/constants/validation/schema/schema-external-hired-participant.js
+++ b/client/src/constants/validation/schema/schema-external-hired-participant.js
@@ -24,7 +24,13 @@ export const ExternalHiredParticipantSchema = yup
       .string()
       .required('Phone number is required')
       .matches(/^[0-9]{10}$/, 'Phone number must be provided as 10 digits'),
-    emailAddress: yup.string().required('Email address is required').email('Invalid email address'),
+    emailAddress: yup
+      .string()
+      .required('Email address is required')
+      .matches(
+        /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+        'Please enter a valid email address with a proper domain (e.g., user@example.com)',
+      ),
     postalCode: yup
       .string()
       .required('Postal code is required')


### PR DESCRIPTION
This PR fixes the email validation issue on the "Edit Participant" pop-up and "Add New Non-Portal Hire" pop-up, ensuring that inputs like "user@example" are correctly flagged as invalid