### PR TITLE
Replace Bitnami Mongodb to official MongoDB image

### DIFF
--- a/openshift/mongo.helm.yml
+++ b/openshift/mongo.helm.yml
@@ -14,7 +14,9 @@ arbiter:
 
 architecture: replicaset
 image:
-  registry: 'public.ecr.aws'
+  registry: docker.io
+  repository: mongo
+  tag: '4.4.29'
 
 auth:
   username: hcap

--- a/openshift/mongo.yml
+++ b/openshift/mongo.yml
@@ -56,7 +56,7 @@ parameters:
     required: true
   - name: MONGODB_IMAGE
     description: A reference to a supported MongoDB Docker image
-    value: registry.hub.docker.com/centos/mongodb-36-centos7
+    value: docker.io/mongo:4.4.29
     required: true
   - name: VOLUME_CAPACITY
     description: Volume space available for data, e.g. 512Mi, 2Gi


### PR DESCRIPTION
Replace Bitnami Mongodb to official MongoDB image to address this issue:

> Good morning Everyone,
 
> The Private Cloud team has noticed that multiple applications have been impacted by a change in Bitnami, a commonly used developer tool. This change impacts only teams who are using Bitnami images pulled from DockerHub. Due to the strike action, we are wanting to ensure that you are aware and that appropriate action at the application level can be taken, if necessary.
 
> This change may cause impacted applications to crash in OpenShift and need intervention from someone with application access to resolve it. Unfortunately, we cannot do anything at the platform level.
 
>Required Action:
>If any of your teams have applications on the OpenShift Private Cloud, they should immediately:
Check if the application is operating as normal. If not,
Identify if the application  relies on Bitnami images pulled from Docker Hub. If they do,
> Migrate those images to your organization’s private registry (e.g., Artifactory or OpenShift image registry).
> Additional Information:
[Message in DevOps Alerts](https://urldefense.com/v3/__https:/chat.developer.gov.bc.ca/channel/devops-alerts?msg=J8NW8RQs6PRRpQoJo__;!!AaIhyw!tp_lglFPcrsx_8f4ue9rXVGucJdZnLYKHTVkIWs-2PDHXWRc0YYiBe9Pm4dPycJMqZ7V_RmlLVQgrJfAclDecm_Nl2zoa50$)
[Broadcom Announcement](https://urldefense.com/v3/__https:/community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon__;!!AaIhyw!tp_lglFPcrsx_8f4ue9rXVGucJdZnLYKHTVkIWs-2PDHXWRc0YYiBe9Pm4dPycJMqZ7V_RmlLVQgrJfAclDecm_NiWboH9s$)
[Industry Analysis](https://urldefense.com/v3/__https:/medium.com/@talkimhi/bitnamis-august-28th-bombshell-the-end-of-free-container-images-as-we-know-them-74fe5cdfb882__;!!AaIhyw!tp_lglFPcrsx_8f4ue9rXVGucJdZnLYKHTVkIWs-2PDHXWRc0YYiBe9Pm4dPycJMqZ7V_RmlLVQgrJfAclDecm_NpLiSIIU$)
> BCDevXHQ