### PR TITLE
fix keycloak session timeout errors 

### DIFF
--- a/client/src/providers/KeycloakProvider.js
+++ b/client/src/providers/KeycloakProvider.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
 import Keycloak from 'keycloak-js';
 import LinearProgress from '@mui/material/LinearProgress';
 import { API_URL } from '../constants';
@@ -21,8 +21,16 @@ export const KeycloakProvider = ({ children, onTokens }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const { dispatch } = useAuth();
+  const initialized = useRef(false);
+  const refreshTimerRef = useRef(null);
 
   const initKeycloak = useCallback(async () => {
+    // Prevent re-initialization
+    if (initialized.current) {
+      return;
+    }
+    initialized.current = true;
+
     try {
       setLoading(true);
       setError(null);
@@ -54,29 +62,43 @@ export const KeycloakProvider = ({ children, onTokens }) => {
       });
 
       // Initialize Keycloak
+      // Disable iframe check on localhost to avoid CORS/iframe issues
+      const isLocalhost =
+        window.location.hostname.includes('localhost') ||
+        window.location.hostname.includes('127.0.0.1');
+
       let authenticated;
-      try {
-        authenticated = await keycloakInstance.init({
-          pkceMethod: 'S256',
-          checkLoginIframe: true,
-          checkLoginIframeInterval: 30, // Check every 30 seconds
-          messageReceiveTimeout: 10000, // Wait up to 10 seconds for iframe
-        });
-      } catch (initError) {
-        console.warn(
-          'Keycloak iframe initialization failed, falling back to token-only mode:',
-          initError,
-        );
-        // Create a new instance for fallback since Keycloak can only be initialized once
-        keycloakInstance = new Keycloak({
-          realm: result.realm,
-          url: result.url,
-          clientId: result.clientId,
-        });
+
+      if (isLocalhost) {
+        console.log('Running on localhost - disabling iframe check');
         authenticated = await keycloakInstance.init({
           pkceMethod: 'S256',
           checkLoginIframe: false,
         });
+      } else {
+        try {
+          authenticated = await keycloakInstance.init({
+            pkceMethod: 'S256',
+            checkLoginIframe: true,
+            checkLoginIframeInterval: 30, // Check every 30 seconds
+            messageReceiveTimeout: 10000, // Wait up to 10 seconds for iframe
+          });
+        } catch (initError) {
+          console.warn(
+            'Keycloak iframe initialization failed, falling back to token-only mode:',
+            initError,
+          );
+          // Create a new instance for fallback since Keycloak can only be initialized once
+          keycloakInstance = new Keycloak({
+            realm: result.realm,
+            url: result.url,
+            clientId: result.clientId,
+          });
+          authenticated = await keycloakInstance.init({
+            pkceMethod: 'S256',
+            checkLoginIframe: false,
+          });
+        }
       }
 
       if (authenticated) {
@@ -175,7 +197,9 @@ export const KeycloakProvider = ({ children, onTokens }) => {
               storage.remove('TOKEN');
               setAuthenticated(false);
               alert('Your session has expired. Please login again.');
-              keycloakInstance.login();
+              keycloakInstance.login({
+                redirectUri: window.location.href,
+              });
               return response;
             }
 
@@ -191,7 +215,9 @@ export const KeycloakProvider = ({ children, onTokens }) => {
               storage.remove('TOKEN');
               setAuthenticated(false);
               alert('Your session has expired. Please login again.');
-              keycloakInstance.login();
+              keycloakInstance.login({
+                redirectUri: window.location.href,
+              });
             }
             throw error; // Re-throw for other types of errors
           }
@@ -210,15 +236,13 @@ export const KeycloakProvider = ({ children, onTokens }) => {
           onTokens(tokens);
         }
 
-        // Also call user info loading here if needed
-        // You can pass a getUserInfo callback through props
-
-        // Set up automatic token refresh
-        keycloakInstance.onTokenExpired = () => {
+        // Helper function to handle token refresh
+        const refreshToken = () => {
           keycloakInstance
-            .updateToken(30)
+            .updateToken(60) // Refresh if token expires in less than 60 seconds
             .then((refreshed) => {
               if (refreshed) {
+                console.log('Token refreshed successfully');
                 const newTokens = {
                   token: keycloakInstance.token,
                   refreshToken: keycloakInstance.refreshToken,
@@ -228,21 +252,71 @@ export const KeycloakProvider = ({ children, onTokens }) => {
                   onTokens(newTokens);
                 }
                 storage.set('TOKEN', keycloakInstance.token);
+
+                // Schedule next refresh after successful refresh
+                scheduleTokenRefresh();
+              } else {
+                console.log('Token not refreshed, still valid');
+                // Token still valid, check again in 10 seconds
+                // This prevents tight loops when token is close to but not within refresh threshold
+                refreshTimerRef.current = setTimeout(() => {
+                  refreshToken();
+                }, 10000);
               }
             })
-            .catch(() => {
-              console.error('Failed to refresh token - session expired');
+            .catch((error) => {
+              console.error('Failed to refresh token - session expired', error);
               // Clear stored token to prevent further API calls with expired token
               storage.remove('TOKEN');
               // Alert user and redirect to login
               alert('Your session has expired. You will be redirected to login.');
-              keycloakInstance.login();
+              keycloakInstance.login({
+                redirectUri: window.location.href,
+              });
             });
+        };
+
+        // Schedule token refresh before expiration
+        const scheduleTokenRefresh = () => {
+          // Clear any existing timer
+          if (refreshTimerRef.current) {
+            clearTimeout(refreshTimerRef.current);
+          }
+
+          // Calculate when to refresh (e.g., 1 minute before expiration)
+          const tokenParsed = keycloakInstance.tokenParsed;
+          if (tokenParsed && tokenParsed.exp) {
+            const now = Math.floor(Date.now() / 1000);
+            const tokenExp = tokenParsed.exp;
+            const timeUntilExpiry = tokenExp - now;
+
+            // Refresh 60 seconds before expiration
+            // Add minimum delay of 10 seconds to prevent tight loops
+            const refreshTime = Math.max(10000, (timeUntilExpiry - 60) * 1000);
+
+            console.log(`Next token refresh check in ${Math.floor(refreshTime / 1000)} seconds`);
+
+            refreshTimerRef.current = setTimeout(() => {
+              refreshToken();
+            }, refreshTime);
+          }
+        };
+
+        // Start the refresh schedule
+        scheduleTokenRefresh();
+
+        // Set up automatic token refresh as fallback (in case timer misses)
+        keycloakInstance.onTokenExpired = () => {
+          console.warn('Token expired - refreshing immediately (fallback handler)');
+          refreshToken();
         };
 
         // Monitor SSO session state when checkLoginIframe is enabled
         keycloakInstance.onAuthLogout = () => {
           console.log('SSO logout detected');
+          if (refreshTimerRef.current) {
+            clearTimeout(refreshTimerRef.current);
+          }
           storage.remove('TOKEN');
           setAuthenticated(false);
           alert('You have been logged out. Please login again.');
@@ -269,11 +343,20 @@ export const KeycloakProvider = ({ children, onTokens }) => {
 
   useEffect(() => {
     initKeycloak();
+
+    // Cleanup function to clear refresh timer
+    return () => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
+    };
   }, [initKeycloak]);
 
   const login = useCallback(() => {
     if (keycloak) {
-      keycloak.login();
+      keycloak.login({
+        redirectUri: window.location.href,
+      });
     }
   }, [keycloak]);
 

--- a/client/src/providers/KeycloakProvider.js
+++ b/client/src/providers/KeycloakProvider.js
@@ -47,23 +47,54 @@ export const KeycloakProvider = ({ children, onTokens }) => {
       }
 
       // Create Keycloak instance
-      const keycloakInstance = new Keycloak({
+      let keycloakInstance = new Keycloak({
         realm: result.realm,
         url: result.url,
         clientId: result.clientId,
       });
 
       // Initialize Keycloak
-      const authenticated = await keycloakInstance.init({
-        pkceMethod: 'S256',
-        checkLoginIframe: false,
-      });
+      let authenticated;
+      try {
+        authenticated = await keycloakInstance.init({
+          pkceMethod: 'S256',
+          checkLoginIframe: true,
+          checkLoginIframeInterval: 30, // Check every 30 seconds
+          messageReceiveTimeout: 10000, // Wait up to 10 seconds for iframe
+        });
+      } catch (initError) {
+        console.warn(
+          'Keycloak iframe initialization failed, falling back to token-only mode:',
+          initError,
+        );
+        // Create a new instance for fallback since Keycloak can only be initialized once
+        keycloakInstance = new Keycloak({
+          realm: result.realm,
+          url: result.url,
+          clientId: result.clientId,
+        });
+        authenticated = await keycloakInstance.init({
+          pkceMethod: 'S256',
+          checkLoginIframe: false,
+        });
+      }
 
       if (authenticated) {
         // Extract user data from Keycloak token
         const tokenParsed = keycloakInstance.tokenParsed;
 
         if (tokenParsed) {
+          // Debug token expiration times
+          const now = Math.floor(Date.now() / 1000);
+          const tokenExp = tokenParsed.exp;
+          const tokenMinutesLeft = Math.floor((tokenExp - now) / 60);
+          console.log('=== TOKEN DEBUG INFO ===');
+          console.log('Current time:', new Date(now * 1000).toLocaleTimeString());
+          console.log('Token expires at:', new Date(tokenExp * 1000).toLocaleTimeString());
+          console.log('Token valid for:', tokenMinutesLeft, 'minutes');
+          console.log('checkLoginIframe enabled:', !keycloakInstance.checkLoginIframe === false);
+          console.log('========================');
+
           // Check different possible locations for roles
           const realmRoles = tokenParsed.realm_access?.roles || [];
           const clientRoles = tokenParsed.resource_access?.[tokenParsed.aud]?.roles || [];
@@ -131,6 +162,42 @@ export const KeycloakProvider = ({ children, onTokens }) => {
       setKeycloak(keycloakInstance);
       setAuthenticated(authenticated);
 
+      // Set up global fetch interceptor for 401 errors
+      if (authenticated) {
+        const originalFetch = window.fetch;
+        window.fetch = async (...args) => {
+          try {
+            const response = await originalFetch(...args);
+
+            // If we get 401 Unauthorized, session has expired
+            if (response.status === 401 && storage.get('TOKEN')) {
+              console.error('401 Unauthorized - clearing session');
+              storage.remove('TOKEN');
+              setAuthenticated(false);
+              alert('Your session has expired. Please login again.');
+              keycloakInstance.login();
+              return response;
+            }
+
+            return response;
+          } catch (error) {
+            // Handle network errors (CORS, network failure, etc.)
+            // These often happen when token is expired and server rejects the request
+            if (
+              storage.get('TOKEN') &&
+              (error.message.includes('Failed to fetch') || error.message.includes('CORS'))
+            ) {
+              console.error('Network error with expired token - clearing session');
+              storage.remove('TOKEN');
+              setAuthenticated(false);
+              alert('Your session has expired. Please login again.');
+              keycloakInstance.login();
+            }
+            throw error; // Re-throw for other types of errors
+          }
+        };
+      }
+
       // Set up token refresh
       if (authenticated) {
         const tokens = {
@@ -160,12 +227,26 @@ export const KeycloakProvider = ({ children, onTokens }) => {
                 if (onTokens) {
                   onTokens(newTokens);
                 }
+                storage.set('TOKEN', keycloakInstance.token);
               }
             })
             .catch(() => {
-              console.error('Failed to refresh token');
+              console.error('Failed to refresh token - session expired');
+              // Clear stored token to prevent further API calls with expired token
+              storage.remove('TOKEN');
+              // Alert user and redirect to login
+              alert('Your session has expired. You will be redirected to login.');
               keycloakInstance.login();
             });
+        };
+
+        // Monitor SSO session state when checkLoginIframe is enabled
+        keycloakInstance.onAuthLogout = () => {
+          console.log('SSO logout detected');
+          storage.remove('TOKEN');
+          setAuthenticated(false);
+          alert('You have been logged out. Please login again.');
+          window.location.reload();
         };
       }
 
@@ -178,6 +259,9 @@ export const KeycloakProvider = ({ children, onTokens }) => {
     } catch (err) {
       console.error('Failed to initialize Keycloak:', err);
       setError(err.message);
+      // Set a fallback null keycloak to prevent crashes
+      setKeycloak(null);
+      setAuthenticated(false);
     } finally {
       setLoading(false);
     }

--- a/openshift/server.dc.yml
+++ b/openshift/server.dc.yml
@@ -30,7 +30,7 @@ objects:
     metadata:
       name: ${APP_NAME}-server
       annotations:
-        haproxy.router.openshift.io/timeout: 90s
+        haproxy.router.openshift.io/timeout: 300s
         haproxy.router.openshift.io/disable_cookies: true
     spec:
       host: ''

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -119,6 +119,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -719,6 +720,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -741,6 +743,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2319,6 +2322,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
       "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2488,6 +2492,7 @@
       "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.1",
         "@typescript-eslint/types": "8.44.1",
@@ -2705,6 +2710,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3156,6 +3162,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -4130,6 +4137,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5622,6 +5630,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7546,6 +7555,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -7646,6 +7656,7 @@
       "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.10.3.tgz",
       "integrity": "sha512-h2utrzpOIzeT9JfaqfvBbVuvCfBjH86jNfVrGGTbyepKAIOyTfDew0lAt8bbJjs9n/I5bGDl7S2sx6h5hPyJxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-cursor": "^2.15.3"
       },
@@ -9216,6 +9227,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9314,6 +9326,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9554,6 +9567,7 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
       "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",

--- a/server/server.ts
+++ b/server/server.ts
@@ -49,12 +49,6 @@ app.use(
         'base-uri': ["'self'"],
         'block-all-mixed-content': [],
         'font-src': ["'self'"],
-        'frame-src': [
-          "'self'",
-          'https://common-logon-dev.hlth.gov.bc.ca',
-          'https://common-logon-test.hlth.gov.bc.ca',
-          'https://common-logon.hlth.gov.bc.ca',
-        ],
         'frame-ancestors': ["'self'"],
         'img-src': ["'self'", 'data:'],
         'object-src': ["'none'"],

--- a/server/server.ts
+++ b/server/server.ts
@@ -49,6 +49,12 @@ app.use(
         'base-uri': ["'self'"],
         'block-all-mixed-content': [],
         'font-src': ["'self'"],
+        'frame-src': [
+          "'self'",
+          'https://common-logon-dev.hlth.gov.bc.ca',
+          'https://common-logon-test.hlth.gov.bc.ca',
+          'https://common-logon.hlth.gov.bc.ca',
+        ],
         'frame-ancestors': ["'self'"],
         'img-src': ["'self'", 'data:'],
         'object-src': ["'none'"],


### PR DESCRIPTION
1. Replace generic “Failed to fetch” errors with clear session-expiration messages to prevent the screen from appearing frozen.
2. Implement periodic Keycloak token refresh (every 240 seconds) to avoid token expiry and extend the effective session duration from 5 minutes to 30 minutes.